### PR TITLE
Printer power plugin

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -174,8 +174,9 @@ batch subscription updates together.
 
 ## Plugin Configuration
 The core plugins are configured via the primary configuration above.  Optional
-plugins each need their own configuration.  Currently the only optional plugin
-available is the `paneldue` plugin, which can be configured as follows:
+plugins each need their own configuration as outlined below.
+
+### PanelDue Plugin
 
 ```
 [moonraker_plugin paneldue]
@@ -207,3 +208,30 @@ gcode:
 		"paneldue_beep", frequency=FREQUENCY|int,
 		duration=DURATION|float) }
 ```
+
+### Power Control Plugin
+```
+[moonraker_plugin power]
+devices: printer, led           
+#  A comma separated list of devices you wish to control. Do not use spaces in
+#  the device's name here
+#{dev}_name: Friendly Name
+#  This is the friendly name for the device. {dev} must be swapped for the name
+#  of the device used under devices, as an example:
+#  printer_name: My Printer
+{dev}_pin: 23
+#  This option is required.
+#  The GPIO Pin number you wish to control
+#{dev}_activehigh: True
+#  If you have a device that needs a low or 0 signal to be turned on, set this
+#  option to False.
+```
+
+Define the devices you wish to control under _devices_ with a comma separated
+list. For device specific configrations, swap {dev} for the name of the device
+that you listed under devices.
+
+Each device can have a Friendly Name, pin, and activehigh set. Pin is the only
+required option. For devices that should be active when the signal is 0 or low,
+set {dev}_activehigh to False, otherwise don't put the option in the
+configuration.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -222,9 +222,9 @@ devices: printer, led
 {dev}_pin: 23
 #  This option is required.
 #  The GPIO Pin number you wish to control
-#{dev}_activehigh: True
+#{dev}_active_low: False
 #  If you have a device that needs a low or 0 signal to be turned on, set this
-#  option to False.
+#  option to True.
 ```
 
 Define the devices you wish to control under _devices_ with a comma separated

--- a/moonraker/plugins/power.py
+++ b/moonraker/plugins/power.py
@@ -1,57 +1,14 @@
-# Printer power manipulations
+# Raspberry Pi Power Control
 #
-#   GET  /printer/power/devices             # List devices
-#   GET  /printer/power/status?dev=devname  # Get device status
-#   POST /printer/power/on?dev=devname      # Turn device on
-#   POST /printer/power/off?dev=devname     # Turn device off
-#
-# Add to printer.cfg:
-#   [moonraker_plugin power]
-#   devices: printer, led           (comma separated list of devices)
-#   {dev}_status: /script/to/power/status   Swap {dev} for name of device under devices
-#   printer_status: /script/to/printer/status
-#   led_status: /script/to/led/status
-#   {dev}_off: /script/to/power/off
-#   {dev}_on: /script/to/power/on
+# Copyright (C) 2020 Jordan Ruthe <jordanruthe@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-#
-#   Sample on script for pi:
-#     #!/bin/bash
-#     gpio export 23 out
-#     gpio -g write 23 1
-#
-#   Sample off script:
-#     #!/bin/bash
-#     gpio export 23 out
-#     gpio -g write 23 0
-#
-#
-#   Sample status script:
-#     #!/bin/bash
-#     status=$(cat /sys/class/gpio/gpiochip0/subsystem/gpio23/value)
-#     if [ $status -eq 0 ]
-#     then
-#             echo "Printer is on"
-#             exit 0
-#     fi
-#     echo "Printer is off"
-#     exit 1
-#
-#
-#
 
 
 import logging
+import RPi.GPIO as GPIO
 
 class PrinterPower:
-    paths = {
-        "status":   "/printer/power/status",
-        "on":       "/printer/power/on",
-        "off":      "/printer/power/off"
-    }
-
-
     def __init__(self, server):
         self.server = server
         self.server.register_endpoint(
@@ -59,17 +16,17 @@ class PrinterPower:
             self._handle_list_devices)
         self.server.register_endpoint(
             "/printer/power/status", "power_status", ['GET'],
-            self._handle_machine_request)
+            self._handle_power_request)
         self.server.register_endpoint(
             "/printer/power/on", "power_on", ['POST'],
-            self._handle_machine_request)
+            self._handle_power_request)
         self.server.register_endpoint(
             "/printer/power/off", "power_off", ['POST'],
-            self._handle_machine_request)
-        
+            self._handle_power_request)
+
         self.current_dev = None
         self.devices = {}
-    
+
     async def _handle_list_devices(self, path, method, args):
         output = {"devices": []}
         for dev in self.devices:
@@ -79,77 +36,74 @@ class PrinterPower:
             })
         return output
 
-    async def _handle_machine_request(self, path, method, args):
+    async def _handle_power_request(self, path, method, args):
         if len(args) == 0:
-            if path == self.paths['status']:
+            if path == "/printer/power/status":
                 args = self.devices
             else:
                 return "no_devices"
-         
+
         result = {}
         for dev in args:
             if dev not in self.devices:
                 result[dev] = "device_not_found"
                 continue
-            
-            if path == self.paths['status']:
-                cmd = self.devices[dev]["cmds"]["status"]
-            elif path == self.paths['on']:
-                cmd = self.devices[dev]["cmds"]["on"]
-                action = "on"
-            elif path == self.paths['off']:
-                cmd = self.devices[dev]["cmds"]["off"]
-                action = "off"
+
+            if path == "/printer/power/status":
+                # Update device status
+                self.devices[dev]["status"] = self.is_pin_on(dev)
+            elif path == "/printer/power/on":
+                self.set_pin_level(dev, True)
+            elif path == "/printer/power/off":
+                self.set_pin_level(dev, False)
             else:
                 raise self.server.error("Unsupported power request")
-            
-            if cmd == None:
-                raise self.server.error("Command not configured in printer.cfg under [moonraker_plugins power] for device " + dev)
-            
-            self.current_dev = dev
-            shell_command = self.server.lookup_plugin('shell_command')
-            scmd = shell_command.build_shell_command(cmd, self.get_cmd_output)
-            try:
-                await scmd.run()
-            except Exception:
-                logging.exception("Error running cmd '%s'" % (cmd))
-        
-            if path == self.paths['status']:
-                result[dev] = self.devices[dev]["status"]
-            else:
-                result[dev] = action
+
+            result[dev] = self.devices[dev]["status"]
         return result
-    
-    def get_cmd_output(self, partial_output):
-        if "on" in str(partial_output):
-            self.devices[self.current_dev]["status"] = "on"
-        elif "off" in str(partial_output):
-            self.devices[self.current_dev]["status"] = "off"
-        else:
-            self.devices[self.current_dev]["status"] = "unknown"
-     
+
+    def is_pin_on(self, dev):
+        value = GPIO.input(self.devices[dev]["pin"])
+        if (value == 1 and self.devices[dev]["active_high"] == True) or (value == 0 and self.devices[dev]["active_high"] == False):
+            return "on"
+        return "off"
+
+    def set_pin_level(self, dev, active):
+        value = 1 if (active == True and self.devices[dev]["active_high"] == True) or (active == False and self.devices[dev]["active_high"] == False) else 0
+        GPIO.output(self.devices[dev]["pin"], value)
+        self.devices[dev]["status"] = self.is_pin_on(dev)
+
     def load_config(self, config):
         if "devices" not in config.keys():
             return
-        
+
+        GPIO.setmode(GPIO.BCM)
+        GPIO.setwarnings(False) #Ignore if other things are controlling GPIO pins
+
         devices = config["devices"].split(',')
-        keys = [ "status", "off", "on"]
-        
         logging.info("Power plugin loading devices: " + str(devices))
-        
+
         for dev in devices:
             dev = dev.strip()
-            name = config[dev + "_name"] if dev + "_name" in config.keys() else dev
+            if dev + "_pin" not in config.keys():
+                logging.info("Power plugin: ERR " + dev + " does not have a pin defined")
+                continue
+
             self.devices[dev] = {
-                "name": name,
-                "cmds": {}
+                "name": config[dev + "_name"] if dev + "_name" in config.keys() else dev,
+                "pin": int(config[dev + "_pin"]),
+                "active_high": False if dev+"_activehigh" in config.keys() and config[dev+"_activehigh"] == "False" else True,
+                "status": None
             }
 
-            for key in keys:
-                logging.info(dev + "_" + key)
-                id = dev + "_" + key
-                self.devices[dev]["cmds"][key] = config[id] if id in config.keys() else None
-        
+            try:
+                GPIO.setup(self.devices[dev]["pin"], GPIO.OUT)
+                self.devices[dev]["status"] = self.is_pin_on(dev)
+            except:
+                logging.info("Power plugin: ERR Problem configuring the output pin for device " + dev + ". Removing device")
+                self.devices.pop(dev, None)
+                continue
+
 
 def load_plugin(server):
     return PrinterPower(server)

--- a/moonraker/plugins/power.py
+++ b/moonraker/plugins/power.py
@@ -26,7 +26,6 @@
 #     fi
 #     echo "Printer is off"
 #     exit 1
-
 #
 #
 #
@@ -50,14 +49,20 @@ class PrinterPower:
             self._handle_machine_request)
         
         self.printer_status = "unknown"
+        
+        self.cmds = {
+            "status":   "/usr/local/bin/printer_status",
+            "on":       "/usr/local/bin/printer_on",
+            "off":      "/usr/local/bin/printer_off"
+        }
 
     async def _handle_machine_request(self, path, method, args):
         if path == "/printer/power/status":
-            cmd = "/usr/local/bin/printer_status"
+            cmd = self.cmds["status"]
         elif path == "/printer/power/on":
-            cmd = "/usr/local/bin/printer_on"
+            cmd = self.cmds["on"]
         elif path == "/printer/power/off":
-            cmd = "/usr/local/bin/printer_off"
+            cmd = self.cmds["off"]
         else:
             raise self.server.error("Unsupported machine request")
         shell_command = self.server.lookup_plugin('shell_command')

--- a/moonraker/plugins/power.py
+++ b/moonraker/plugins/power.py
@@ -1,5 +1,10 @@
 # Printer power manipulations
 #
+#   GET  /printer/power/devices             # List devices
+#   GET  /printer/power/status?dev=devname  # Get device status
+#   POST /printer/power/on?dev=devname      # Turn device on
+#   POST /printer/power/off?dev=devname     # Turn device off
+#
 # Add to printer.cfg:
 #   [moonraker_plugin power]
 #   devices: printer, led           (comma separated list of devices)
@@ -11,19 +16,18 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 #
-#   Sample printer_on script for pi:
-#     #!/bin/bash
-#     gpio export 23 out
-#     gpio -g write 23 0
-#     sleep 1
-#     sudo service klipper restart
-#
-#   Sample printer_on script:
+#   Sample on script for pi:
 #     #!/bin/bash
 #     gpio export 23 out
 #     gpio -g write 23 1
 #
+#   Sample off script:
+#     #!/bin/bash
+#     gpio export 23 out
+#     gpio -g write 23 0
 #
+#
+#   Sample status script:
 #     #!/bin/bash
 #     status=$(cat /sys/class/gpio/gpiochip0/subsystem/gpio23/value)
 #     if [ $status -eq 0 ]
@@ -41,10 +45,17 @@
 import logging
 
 class PrinterPower:
+    paths = {
+        "status":   "/printer/power/status",
+        "on":       "/printer/power/on",
+        "off":      "/printer/power/off"
+    }
+
+
     def __init__(self, server):
         self.server = server
         self.server.register_endpoint(
-            "/printer/power/devices", "power_status", ['GET'],
+            "/printer/power/devices", "power_devices", ['GET'],
             self._handle_list_devices)
         self.server.register_endpoint(
             "/printer/power/status", "power_status", ['GET'],
@@ -56,51 +67,66 @@ class PrinterPower:
             "/printer/power/off", "power_off", ['POST'],
             self._handle_machine_request)
         
-        self.printer_status = "unknown"
-        self.cmds = {}
+        self.current_dev = None
+        self.devices = {}
     
     async def _handle_list_devices(self, path, method, args):
         output = {"devices": []}
-        for dev in self.cmds:
-            output['devices'].append(dev)
+        for dev in self.devices:
+            output['devices'].append({
+                "name": self.devices[dev]["name"],
+                "id": dev
+            })
         return output
 
     async def _handle_machine_request(self, path, method, args):
-        dev = args.get('dev')
-        if dev not in self.cmds:
-            return "device_not_found"
+        if len(args) == 0:
+            if path == self.paths['status']:
+                args = self.devices
+            else:
+                return "no_devices"
+         
+        result = {}
+        for dev in args:
+            if dev not in self.devices:
+                result[dev] = "device_not_found"
+                continue
+            
+            if path == self.paths['status']:
+                cmd = self.devices[dev]["cmds"]["status"]
+            elif path == self.paths['on']:
+                cmd = self.devices[dev]["cmds"]["on"]
+                action = "on"
+            elif path == self.paths['off']:
+                cmd = self.devices[dev]["cmds"]["off"]
+                action = "off"
+            else:
+                raise self.server.error("Unsupported power request")
+            
+            if cmd == None:
+                raise self.server.error("Command not configured in printer.cfg under [moonraker_plugins power] for device " + dev)
+            
+            self.current_dev = dev
+            shell_command = self.server.lookup_plugin('shell_command')
+            scmd = shell_command.build_shell_command(cmd, self.get_cmd_output)
+            try:
+                await scmd.run()
+            except Exception:
+                logging.exception("Error running cmd '%s'" % (cmd))
         
-        if path == "/printer/power/status":
-            cmd = self.cmds[dev]["status"]
-        elif path == "/printer/power/on":
-            cmd = self.cmds[dev]["on"]
-        elif path == "/printer/power/off":
-            cmd = self.cmds[dev]["off"]
-        else:
-            raise self.server.error("Unsupported power request")
-        
-        if cmd == None:
-            raise self.server.error("Command not configured in printer.cfg under [moonraker_plugins power] for device " + dev)
-        
-        shell_command = self.server.lookup_plugin('shell_command')
-        scmd = shell_command.build_shell_command(cmd, self.get_cmd_output)
-        try:
-            await scmd.run()
-        except Exception:
-            logging.exception("Error running cmd '%s'" % (cmd))
-        
-        if path == "/printer/power/status":
-            return {"power": self.printer_status}
-        else:
-            return "ok"
+            if path == self.paths['status']:
+                result[dev] = self.devices[dev]["status"]
+            else:
+                result[dev] = action
+        return result
     
     def get_cmd_output(self, partial_output):
         if "on" in str(partial_output):
-            self.printer_status = "on"
+            self.devices[self.current_dev]["status"] = "on"
         elif "off" in str(partial_output):
-            self.printer_status = "off"
+            self.devices[self.current_dev]["status"] = "off"
         else:
-            self.printer_status = "unknown"
+            self.devices[self.current_dev]["status"] = "unknown"
      
     def load_config(self, config):
         if "devices" not in config.keys():
@@ -113,12 +139,16 @@ class PrinterPower:
         
         for dev in devices:
             dev = dev.strip()
-            self.cmds[dev] = {}
-            
+            name = config[dev + "_name"] if dev + "_name" in config.keys() else dev
+            self.devices[dev] = {
+                "name": name,
+                "cmds": {}
+            }
+
             for key in keys:
                 logging.info(dev + "_" + key)
                 id = dev + "_" + key
-                self.cmds[dev][key] = config[id] if id in config.keys() else None
+                self.devices[dev]["cmds"][key] = config[id] if id in config.keys() else None
         
 
 def load_plugin(server):

--- a/moonraker/plugins/power.py
+++ b/moonraker/plugins/power.py
@@ -4,9 +4,9 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
-
 import logging
-import RPi.GPIO as GPIO
+import os
+import time
 
 class PrinterPower:
     def __init__(self, server):
@@ -49,36 +49,22 @@ class PrinterPower:
                 result[dev] = "device_not_found"
                 continue
 
-            if path == "/printer/power/status":
-                # Update device status
-                self.devices[dev]["status"] = self.is_pin_on(dev)
-            elif path == "/printer/power/on":
-                self.set_pin_level(dev, True)
+            GPIO.verify_pin(self.devices[dev]["pin"], self.devices[dev]["active_low"])
+            if path == "/printer/power/on":
+                GPIO.set_pin_value(self.devices[dev]["pin"], 1)
             elif path == "/printer/power/off":
-                self.set_pin_level(dev, False)
-            else:
+                GPIO.set_pin_value(self.devices[dev]["pin"], 0)
+            elif path != "/printer/power/status":
                 raise self.server.error("Unsupported power request")
+
+            self.devices[dev]["status"] = GPIO.is_pin_on(self.devices[dev]["pin"])
 
             result[dev] = self.devices[dev]["status"]
         return result
 
-    def is_pin_on(self, dev):
-        value = GPIO.input(self.devices[dev]["pin"])
-        if (value == 1 and self.devices[dev]["active_high"] == True) or (value == 0 and self.devices[dev]["active_high"] == False):
-            return "on"
-        return "off"
-
-    def set_pin_level(self, dev, active):
-        value = 1 if (active == True and self.devices[dev]["active_high"] == True) or (active == False and self.devices[dev]["active_high"] == False) else 0
-        GPIO.output(self.devices[dev]["pin"], value)
-        self.devices[dev]["status"] = self.is_pin_on(dev)
-
     def load_config(self, config):
         if "devices" not in config.keys():
             return
-
-        GPIO.setmode(GPIO.BCM)
-        GPIO.setwarnings(False) #Ignore if other things are controlling GPIO pins
 
         devices = config["devices"].split(',')
         logging.info("Power plugin loading devices: " + str(devices))
@@ -92,17 +78,89 @@ class PrinterPower:
             self.devices[dev] = {
                 "name": config[dev + "_name"] if dev + "_name" in config.keys() else dev,
                 "pin": int(config[dev + "_pin"]),
-                "active_high": False if dev+"_activehigh" in config.keys() and config[dev+"_activehigh"] == "False" else True,
+                "active_low": 1 if dev+"_active_low" in config.keys() and config[dev+"_active_low"] == "True" else 0,
                 "status": None
             }
 
             try:
-                GPIO.setup(self.devices[dev]["pin"], GPIO.OUT)
-                self.devices[dev]["status"] = self.is_pin_on(dev)
+                logging.debug("Attempting to configure pin GPIO" + str(self.devices[dev]["pin"]))
+                GPIO.setup_pin(self.devices[dev]["pin"], self.devices[dev]["active_low"])
+                self.devices[dev]["status"] = GPIO.is_pin_on(self.devices[dev]["pin"])
             except:
                 logging.info("Power plugin: ERR Problem configuring the output pin for device " + dev + ". Removing device")
                 self.devices.pop(dev, None)
                 continue
+
+class GPIO:
+    gpio_root = "/sys/class/gpio"
+
+    @staticmethod
+    def _set_gpio_option(gpio, option, value):
+        GPIO._write(
+            os.path.join(GPIO.gpio_root, "gpio"+str(gpio), option),
+            value
+        )
+
+    def _get_gpio_option(pin, option):
+        return GPIO._read(
+            os.path.join(GPIO.gpio_root, "gpio"+str(pin), option)
+        )
+
+    @staticmethod
+    def _write(file, data):
+        with open(file, 'w') as f:
+            f.write(str(data))
+            f.flush()
+
+    @staticmethod
+    def _read(file):
+        with open(file, 'r') as f:
+            f.seek(0)
+            return f.read().strip()
+
+    @staticmethod
+    def verify_pin(pin, active_low=1):
+        gpiopath = os.path.join(GPIO.gpio_root, "gpio"+str(pin))
+        if not os.path.exists(gpiopath):
+            logging.info("Re-intializing GPIO"+str(pin))
+            GPIO.setup_pin(pin, active_low)
+            return
+
+        if GPIO._get_gpio_option(pin, "active_low").strip() != str(active_low):
+            GPIO._set_gpio_option(pin, "active_low", active_low)
+
+        if GPIO._get_gpio_option(pin, "direction").strip() != "out":
+            GPIO._set_gpio_option(pin, "direction", "out")
+
+    @staticmethod
+    def setup_pin(pin, active_low=1):
+        pin = int(pin)
+        active_low = 1 if active_low == 1 else 0
+
+        gpiopath = os.path.join(GPIO.gpio_root, "gpio"+str(pin))
+        if not os.path.exists(gpiopath):
+            GPIO._write(
+                os.path.join(GPIO.gpio_root, "export"),
+                pin)
+            logging.info("Waiting for GPIO"+str(pin)+" to initialize")
+            while os.stat(os.path.join(GPIO.gpio_root, "gpio"+str(pin),"active_low")).st_gid == 0:
+                time.sleep(.1)
+
+        if GPIO._get_gpio_option(pin, "active_low").strip() != str(active_low):
+            GPIO._set_gpio_option(pin, "active_low", active_low)
+            
+        if GPIO._get_gpio_option(pin, "direction").strip() != "out":
+            GPIO._set_gpio_option(pin, "direction", "out")
+
+
+    @staticmethod
+    def is_pin_on(pin):
+        return "on" if int(GPIO._get_gpio_option(pin, "value")) else "off"
+
+    @staticmethod
+    def set_pin_value(pin, active):
+        value = 1 if (active == 1) else 0
+        GPIO._set_gpio_option(pin, "value", value)
 
 
 def load_plugin(server):

--- a/scripts/moonraker-requirements.txt
+++ b/scripts/moonraker-requirements.txt
@@ -1,3 +1,4 @@
 # Python dependencies for Moonraker
 tornado==6.0.4
 pyserial==3.4
+RPi.GPIO==0.7.0

--- a/scripts/moonraker-requirements.txt
+++ b/scripts/moonraker-requirements.txt
@@ -1,4 +1,3 @@
 # Python dependencies for Moonraker
 tornado==6.0.4
 pyserial==3.4
-RPi.GPIO==0.7.0


### PR DESCRIPTION
Adding plugin to control printer power via shell scripts. This would allow moonraker to turn on/off the printer rather than manually doing it through the cli. Implementing this into moonraker rather than klipper since if a MCU is powered down, due to a power off, klipper will refuse to issues any commands such as M80/M81 which would allow the MCU to turn back on if controlled by hardware.