### PR TITLE
file_manager:  Add support for serving configuration files

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -165,6 +165,12 @@ Below is a detailed explanation of all options currently available:
 #  This is the base interval used for status tier 1.  All other status tiers
 #  are calculated using the value defined by tick_time (See below for more
 #  information).  Default is 250ms.
+#config_include_path: ~/klipper_config
+#  The path of a directory in which "included" configuration files reside.
+#  If specified, moonraker will serve this path allowing file and directory
+#  manipuation within it.  Note that this should not be the same directory
+#  in which printer.cfg is located (the home directory for most installations).
+#  The default is None, in which no included config files will be served.
 ```
 
 The "status tiers" are used to determine how fast each klippy object is allowed

--- a/moonraker/app.py
+++ b/moonraker/app.py
@@ -338,8 +338,10 @@ class FileRequestHandler(AuthorizedFileHandler):
                         403, "File is loaded, DELETE not permitted")
 
         os.remove(self.absolute_path)
-        filename = os.path.basename(self.absolute_path)
-        self.server.notify_filelist_changed(filename, 'removed')
+        base = self.request.path.lstrip("/").split("/")[2]
+        filename = self.path.lstrip("/")
+        file_manager = self.server.lookup_plugin('file_manager')
+        file_manager.notify_filelist_changed(filename, 'removed', base)
         self.finish({'result': filename})
 
 class FileUploadHandler(AuthorizedRequestHandler):

--- a/moonraker/app.py
+++ b/moonraker/app.py
@@ -103,6 +103,7 @@ class MoonrakerApp:
 
         mimetypes.add_type('text/plain', '.log')
         mimetypes.add_type('text/plain', '.gcode')
+        mimetypes.add_type('text/plain', '.cfg')
 
         # Set up HTTP only requests
         self.mutable_router = MutableRouter(self)

--- a/moonraker/moonraker.py
+++ b/moonraker/moonraker.py
@@ -336,16 +336,6 @@ class Server:
                 ServerError("Klippy Host not connected", 503))
         return base_request
 
-    def notify_filelist_changed(self, filename, action):
-        file_manager = self.lookup_plugin('file_manager')
-        try:
-            filelist = file_manager.get_file_list(format_list=True)
-        except ServerError:
-            filelist = []
-        result = {'filename': filename, 'action': action,
-                  'filelist': filelist}
-        self.send_event("server:filelist_changed", result)
-
     async def _kill_server(self):
         # XXX - Currently this function is not used.
         # Should I expose functionality to shutdown

--- a/moonraker/moonraker.py
+++ b/moonraker/moonraker.py
@@ -241,6 +241,11 @@ class Server:
         if not isinstance(result, ServerError):
             self._load_config(result)
             self.server_configured = True
+        else:
+            logging.info(
+                "\nError receiving configuration.  This indicates a potential\n"
+                "configuration issue in printer.cfg.  Please check klippy.log\n"
+                "for more information")
 
     async def _request_ready(self):
         request = self.make_request(
@@ -250,6 +255,11 @@ class Server:
             is_ready = result.get("is_ready", False)
             if is_ready:
                 self._set_klippy_ready()
+        if not self.is_klippy_ready:
+            logging.info(
+                "\nKlippy not ready.  This indicates a that Klippy may have\n"
+                "experienced an error during startup.  Please check\n"
+                "klippy.log for more information")
 
     def _load_config(self, config):
         self.request_timeout = config.get(

--- a/moonraker/websockets.py
+++ b/moonraker/websockets.py
@@ -110,7 +110,7 @@ class WebsocketManager:
         self.server.register_event_handler(
             "server:status_update", self._handle_status_update)
         self.server.register_event_handler(
-            "server:filelist_changed", self._handle_filelist_changed)
+            "file_manager:filelist_changed", self._handle_filelist_changed)
 
     async def _handle_klippy_state_changed(self, state):
         await self.notify_websockets("klippy_state_changed", state)

--- a/test/client/index.html
+++ b/test/client/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-<script src="/js/main.js?v=0.1.16" type="module"></script>
+<script src="/js/main.js?v=0.1.17" type="module"></script>
 </head>
 <body>
 <h3>Klippy Web API Test</h3>
@@ -22,9 +22,12 @@
 </form>
 <br/>
 <form id="apiform">
-    <input type="text" style="width: 30em" value="/printer/objects/list"
+    <input type="text" style="width: 30em" id="apirequest" name="apirequest" value="/printer/objects/list"
     title="Should be a url for a http request, ie: /printer/objects/list, or a json-rpc registered
     method name."/>
+    <input type="text" style="width: 20em" id="apiargs" name="apiargs"
+    title="Arguments for a websocket request.  Arguments should be specified in as a JSON object, without
+    brackets." hidden/>
     <input type="submit" value="Send API Command"/>
     <span id="apimethod">
     <input type="radio" name="api_cmd_type" value="get" checked="true">GET

--- a/test/client/index.html
+++ b/test/client/index.html
@@ -39,24 +39,31 @@
 <div style="display: flex">
 <input type="file" style="display:none" id="upload-file" />
 <div style="width: 10em">
-<button id="btnupload" class="toggleable" style="width: 9em">Upload GCode</button><br/><br/>
-<button id="btndownload" class="toggleable" style="width: 9em">Download Gcode</button><br/><br/>
-<button id="btndelete" class="toggleable" style="width: 9em">Delete Gcode</button><br/><br/>
-<button id="btngetmetadata" style="width: 9em">Get Metadata</button>
+  <button id="btnupload" class="toggleable" style="width: 9em">Upload File</button><br/><br/>
+  <button id="btndownload" class="toggleable" style="width: 9em">Download File</button><br/><br/>
+  <button id="btndelete" class="toggleable" style="width: 9em">Delete File</button><br/><br/>
+  <button id="btngetfiles" style="width: 9em">Refresh List</button>
 <a id="hidden_link" href="#" hidden>hidden</a>
 </div>
 <div style="width: 10em">
   <button id="btnstartprint"  style="width: 9em">Start Print</button><br/><br/>
   <button id="btnpauseresume" style="width: 9em">Pause Print</button><br/><br/>
-  <button id="btncancelprint" style="width: 9em">Cancel Print</button>
+  <button id="btncancelprint" style="width: 9em">Cancel Print</button><br/><br/>
+  <button id="btngetmetadata" style="width: 9em">Get Metadata</button>
 </div>
 <div>
 <select id="filelist" size="8"></select>
+</div>
+<div id=filetype>
+  <input type="radio" name="file_type" value="gcodes" checked="true">GCodes<br/>
+  <input type="radio" name="file_type" value="config">Config Files
 </div>
 </div>
 <br/>
 Progress: <progress id="progressbar" value="0" max="100"></progress>
 <span id="upload_progress">0%</span><br/><br/>
+<button id="btnwritecfg" class="toggleable" style="width: 12em">Upload printer.cfg</button>
+<button id="btngetcfg" class="toggleable" style="width: 12em">Download printer.cfg</button><br/><br/>
 <button id="btnqueryendstops" style="width: 9em">Query Endstops</button>
 <button id="btnsubscribe" style="width: 9em">Post Subscription</button>
 <button id="btngetsub" style="width: 9em">Get Subscription</button>

--- a/test/client/js/main.js
+++ b/test/client/js/main.js
@@ -610,8 +610,10 @@ json_rpc.register_method("notify_klippy_state_changed", handle_klippy_state);
 function handle_file_list_changed(file_info) {
     // This event fires when a client has either added or removed
     // a gcode file.
-    if (file_list_type == "gcodes")
-        update_filelist(file_info.filelist);
+    if (file_list_type == file_info.root)
+        get_file_list(file_info.root);
+    console.log("Filelist Changed:");
+    console.log(file_info);
 }
 json_rpc.register_method("notify_filelist_changed", handle_file_list_changed);
 

--- a/test/client/js/main.js
+++ b/test/client/js/main.js
@@ -804,6 +804,7 @@ window.onload = () => {
             'disabled', (api_type == 'websocket' || disable_transfer));
         $('.reqws').prop('disabled', (api_type == 'http'));
         $('#apimethod').prop('hidden', (api_type == "websocket"));
+        $('#apiargs').prop('hidden', (api_type == "http"));
     });
 
     $('#cbxFileTransfer').on('change', function () {
@@ -845,7 +846,7 @@ window.onload = () => {
         // Send to a user defined endpoint and log the response
         if (api_type == 'http') {
             let sendtype = $("input[type=radio][name=api_cmd_type]:checked").val();
-            let url = $('#apiform [type=text]').val();
+            let url = $('#apirequest').val();
             let settings = {url: url}
             if (apikey != null)
                 settings.headers = {"X-Api-Key": apikey};
@@ -868,12 +869,14 @@ window.onload = () => {
                 $.ajax(settings);
             }
         } else {
-            let cmd = $('#apiform [type=text]').val().split(',', 2);
-            let method = cmd[0].trim();
-            if (cmd.length > 1) {
-                let args = cmd[1].trim();
-                if (args.startsWith("{")) {
-                    args = JSON.parse(args);
+            let method = $('#apirequest').val().trim();
+            let args = $('#apiargs').val();
+            if (args != "") {
+                try {
+                    args = JSON.parse("{" + args + "}");
+                } catch (error) {
+                    console.log("Unable to parse arguments");
+                    return
                 }
                 json_rpc.call_method_with_kwargs(method, args)
                 .then((result) => {


### PR DESCRIPTION
This pull request extends the file manager so config files can be downloaded, modified, and uploaded.  Included files must be in a directory specified by the [moonraker] configuration option `config_include_path`.  

Client developers should be aware that the behavior of "notify_filelist_changed" has been altered.  It no longer sends a filelist with the event, clients can decide if the need to retrieve an updated list or not.  Clients will receive an  object with"action", "filename", and "root" attributes.  For file move/or copy, they will receive a "prev_file" attribute in addition to the others.  Changes to the existing API as well as the configuration endpoints have been added to web_api.md.

Signed-off-by:  Eric Callahan <arksine.code@gmail.com>