### PR TITLE
Resolve list modification while iterating in websockets.py

### DIFF
--- a/moonraker/websockets.py
+++ b/moonraker/websockets.py
@@ -178,15 +178,18 @@ class WebsocketManager:
             'method': "notify_" + name,
             'params': [data]})
         async with self.ws_lock:
+            to_remove = []
             for ws in self.websockets.values():
                 try:
                     ws.write_message(notification)
                 except WebSocketClosedError:
-                    self.websockets.pop(ws.uid, None)
-                    logging.info("Websocket Removed: %d" % ws.uid)
+                    to_remove.append(ws.uid)
                 except Exception:
                     logging.exception(
                         "Error sending data over websocket: %d" % (ws.uid))
+            for ws_uid in to_remove:
+                self.websockets.pop(ws_uid, None)
+                logging.info("Websocket Removed: %d" % ws_uid)
 
     async def close(self):
         async with self.ws_lock:


### PR DESCRIPTION
This avoids problems with throwing errors while in the websocket notification loop. Seems to happen more often with nginx in front of moonraker.

2020-08-04 02:25:11,986 [ioloop.py:_run_callback()] - Exception in callback functools.partial(<bound method IOLoop._discard_future_result of <tornado.platform.asyncio.AsyncIOMainLoop object at 0x75c878f0>>, <Task finished coro=<WebsocketManager._handle_status_update() done, defined at /home/pi/moonraker/moonraker/websockets.py:121> exception=RuntimeError('dictionary changed size during iteration')>)
Traceback (most recent call last):
  File "/home/pi/moonraker-env/lib/python3.7/site-packages/tornado/ioloop.py", line 743, in _run_callback
    ret = callback()
  File "/home/pi/moonraker-env/lib/python3.7/site-packages/tornado/ioloop.py", line 767, in _discard_future_result
    future.result()
  File "/home/pi/moonraker/moonraker/websockets.py", line 122, in _handle_status_update
    await self.notify_websockets("status_update", status)
  File "/home/pi/moonraker/moonraker/websockets.py", line 181, in notify_websockets
    for ws in self.websockets.values():
RuntimeError: dictionary changed size during iteration