### PR TITLE
file_manager:  rework config file management

### DIFF
--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -308,14 +308,9 @@ as the "gcodes" root.  The following roots are available:
 - config_examples (read-only)
 
 Write operations (upload, delete, make directory, remove directory) are
-only available on the gcodes and config roots.  Note that the config root
-is only available if user has specified a folder in which "included" config
-files reside.  If the user is not using "include" functionality, or if they
-have not specified the folder in moonraker's configuration, then the "config"
-root will not exist.  Also note that while `printer.cfg` is part of the
-"config" root for the purposes of uploading, it should not reside in the
-same folder as included files, thus it will not show up for file list or
-directory queries.
+only available on the `gcodes` and config roots.  Note that the `config` root
+is only available if the "config_path" option has been set in Moonraker's
+configuration.
 
 ### List Available Files
 Walks through a directory and fetches all files.  All file names include a
@@ -537,10 +532,6 @@ below.
   - print: If set to "true", Klippy will attempt to start the print after
     uploading.  Note that this value should be a string type, not boolean. This
     provides compatibility with Octoprint's legacy upload API.
-  Arguments available only for "config" root:
-  - primary_config:  If set to "true", this indications that the attached file
-    should overwrite printer.cfg.  As with the "print" argument above, this
-    should be a string type.
 
 - Websocket command:\
   Not Available
@@ -568,19 +559,9 @@ to delete a file in a subdirectory.
 - Returns:\
   The HTTP request returns the name of the deleted file.
 
-### Download printer.cfg
-- HTTP command:\
-  `GET /server/files/config/printer.cfg`
-
-- Websocket command:\
-  Not Available
-
-- Returns:\
-  printer.cfg
-
 ### Download included config file
 - HTTP command:\
-  `GET /server/files/config/include/<file_name>`
+  `GET /server/files/config/<file_name>`
 
 - Websocket command:\
   Not Available
@@ -592,7 +573,7 @@ to delete a file in a subdirectory.
 Delete a file in the "config" root.  A relative path may be added to the file
 to delete a file in a subdirectory.
 - HTTP command:\
-  `DELETE /server/files/config/include/<file_name>`
+  `DELETE /server/files/config/<file_name>`
 
 - Websocket command:\
   Not Available
@@ -602,7 +583,7 @@ to delete a file in a subdirectory.
 
 ### Download a config example
 - HTTP command:\
-  `GET /server/files/config/examples/<file_name>`
+  `GET /server/files/config_examples/<file_name>`
 
 - Websocket command:\
   Not Available
@@ -720,17 +701,19 @@ When a client makes a change to the virtual sdcard file list
 (via upload or delete) a notification is broadcast to alert all connected
 clients of the change:
 
-`{jsonrpc: "2.0", method: "notify_filelist_changed", params: [<file changed info>]}`
+`{jsonrpc: "2.0", method: "notify_filelist_changed",
+ params: [<file changed info>]}`
 
 The <file changed info> param is an object in the following format:
 
 ```json
 {action: "<action>", filename: "<file_name>", root: "<root_name>"}
 ```
-Note that file move/copy actions also include the name of the previous file:
+Note that file move/copy actions also include the name and root of the
+previous/source file:
 ```json
 {action: "<action>", filename: "<file_name>", root: "<root_name>",
- prev_file: "<previous file name>"}
+ prev_file: "<previous file name>", prev_root: "<previous_root_name>"}
 ```
 
 The `action` is the operation that resulted in a file list change, the `filename`

--- a/test/client/index.html
+++ b/test/client/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-<script src="/js/main.js?v=0.1.17" type="module"></script>
+<script src="/js/main.js?v=0.1.18" type="module"></script>
 </head>
 <body>
 <h3>Klippy Web API Test</h3>
@@ -56,14 +56,13 @@
 </div>
 <div id=filetype>
   <input type="radio" name="file_type" value="gcodes" checked="true">GCodes<br/>
-  <input type="radio" name="file_type" value="config">Config Files
+  <input type="radio" name="file_type" value="config">Config Files<br/>
+  <input type="radio" name="file_type" value="config_examples">Config Examples
 </div>
 </div>
 <br/>
 Progress: <progress id="progressbar" value="0" max="100"></progress>
 <span id="upload_progress">0%</span><br/><br/>
-<button id="btnwritecfg" class="toggleable" style="width: 12em">Upload printer.cfg</button>
-<button id="btngetcfg" class="toggleable" style="width: 12em">Download printer.cfg</button><br/><br/>
 <button id="btnqueryendstops" style="width: 9em">Query Endstops</button>
 <button id="btnsubscribe" style="width: 9em">Post Subscription</button>
 <button id="btngetsub" style="width: 9em">Get Subscription</button>

--- a/test/client/js/main.js
+++ b/test/client/js/main.js
@@ -96,11 +96,11 @@ var api = {
     moonraker_log: {
         url: "/server/files/moonraker.log"
     },
-    printer_cfg: {
-        url: "/server/files/config/printer.cfg"
+    cfg_files: {
+        url: "/server/files/config/"
     },
-    included_cfg_files: {
-        url: "/server/files/config/include/"
+    cfg_examples: {
+        url: "/server/files/config_examples/"
     },
 
     // Machine APIs
@@ -128,7 +128,6 @@ var paused = false;
 var klippy_ready = false;
 var api_type = 'http';
 var is_printing = false;
-var upload_location = "gcodes"
 var file_list_type = "gcodes";
 var json_rpc = new JsonRPC();
 
@@ -196,19 +195,6 @@ function update_filelist(filelist) {
     }
 }
 
-function update_configlist(cfglist) {
-    $("#filelist").empty();
-    // Add base printer.cfg
-    $("#filelist").append(
-        "<option value='printer.cfg'>printer.cfg</option>");
-    for (let file of cfglist) {
-        let fname = "include/" + file.filename;
-        $("#filelist").append(
-            "<option value='" + fname + "'>" +
-            fname + "</option>");
-    }
-}
-
 var last_progress = 0;
 function update_progress(loaded, total) {
     let progress = parseInt(loaded / total * 100);
@@ -241,10 +227,7 @@ function get_file_list() {
     .then((result) => {
         // result is an "ok" acknowledgment that the gcode has
         // been successfully processed
-        if (file_list_type == "config")
-            update_configlist(result);
-        else
-            update_filelist(result);
+        update_filelist(result);
     })
     .catch((error) => {
         update_error(api.file_list.method, error);
@@ -934,7 +917,6 @@ window.onload = () => {
     //  Hidden file element's click is forwarded to the button
     $('#btnupload').click(() => {
         if (api_type == "http") {
-            upload_location = file_list_type;
             $('#upload-file').click();
         } else {
             console.log("File Upload not supported over websocket")
@@ -956,13 +938,7 @@ window.onload = () => {
             if (api_type == 'http') {
                 let fdata = new FormData();
                 fdata.append("file", file);
-                if (upload_location.startsWith("config")) {
-                    fdata.append("root", "config");
-                    if (upload_location == "config_main")
-                        fdata.append("primary_config", "true");
-                } else {
-                    fdata.append("root", upload_location);
-                }
+                fdata.append("root", file_list_type);
                 let settings = {
                     url: api.upload.url,
                     data: fdata,
@@ -1003,16 +979,9 @@ window.onload = () => {
             if (api_type == 'http') {
                 let url = api.gcode_files.url + filename;
                 if (file_list_type == "config") {
-                    url = api.included_cfg_files.url + filename;
-                    if (filename.startsWith("include/")) {
-                        url = api.included_cfg_files.url + filename.slice(8);
-                    } else if (filename == "printer.cfg") {
-                        url = api.printer_cfg.url;
-                    }
-                    else {
-                        console.log("Cannot download file: " + filename);
-                        return false;
-                    }
+                    url = api.cfg_files.url + filename;
+                } else if (file_list_type == "config_examples") {
+                    url = api.cfg_examples.url + filename;
                 }
                 let dl_url = "http://" + location.host + url;
                 if (apikey != null) {
@@ -1043,13 +1012,10 @@ window.onload = () => {
             if (api_type == 'http') {
                 let url = api.gcode_files.url + filename;
                 if (file_list_type == "config") {
-                    url = api.included_cfg_files.url + filename;
-                    if (filename.startsWith("include/")) {
-                        url = api.included_cfg_files.url + filename.slice(8);
-                    } else {
-                        console.log("Cannot Delete printer.cfg");
-                        return false;
-                    }
+                    url = api.cfg_files.url + filename;
+                } else if (file_list_type != "gcodes") {
+                    console.log("Cannot delete file");
+                    return false;
                 }
                 let settings = {
                     url: url,
@@ -1155,37 +1121,6 @@ window.onload = () => {
             });
         } else {
             get_file_list();
-        }
-    });
-
-    $('#btnwritecfg').click(() => {
-        if (api_type == "http") {
-            upload_location = "config_main";
-            $('#upload-file').click();
-        } else {
-            console.log("File Upload not supported over websocket")
-        }
-    });
-
-    $('#btngetcfg').click(() => {
-        if (api_type == 'http') {
-            let dl_url = "http://" + location.host + api.printer_cfg.url;
-            if (apikey != null) {
-                let settings = {
-                    url: api.oneshot_token.url,
-                    headers: {"X-Api-Key": apikey}
-                };
-                $.get(settings, (resp, status) => {
-                    let token = resp.result;
-                    dl_url += "?token=" + token;
-                    do_download(dl_url);
-                    return false;
-                });
-            } else {
-                do_download(dl_url);
-            }
-        } else {
-            console.log("Get Log not supported over websocket")
         }
     });
 


### PR DESCRIPTION
This PR looks to resolve an overly complex system for managing printer configuration files.  It is no longer possible to access printer.cfg if it is located outside of the "config_path" specified in Moonraker's configuration.  

Given these changes, the endpoints for accessing config files have changed:
- Files in the configured file path can be accessed at `/server/files/config/<filename>` (vs the previous `/server/files/config/include/<filename>`).   This applies both to config file downloads and config file deletions.
- Config examples can be accessed at `/server/files/config_examples/<filename>`.  The "config_examples" root is read-only, it is not possible to delete, upload, or copy to, or move from this path.  It is however possible to copy a file from the "config_examples" root to another root.
- The `primary_config` argument of `/server/files/upload` has been removed.

Also it is now possible to move/copy files between different roots. for example, one may copy a file from `config_examples` to `config`, ie:
```
POST /server/files/copy?source=config_examples/example.cfg&dest=config/example.cfg
```
As such, the file_list_changed notification now adds `prev_root` item if the notification is a move or copy.