### PR TITLE
api:  clean up websocket API

### DIFF
--- a/docs/api_changes.md
+++ b/docs/api_changes.md
@@ -1,6 +1,46 @@
 This document keeps a record of all changes to Moonraker's remote
 facing APIs.
 
+### September 3rd 2020
+- The Websocket APIs have changed for clarity.  The APIs methods now
+  use namespaces similar to those found in common programming languages.
+  This change affects all websocket APIs, however websocket events have
+  not changed.  Below is a chart mapping the Previous API to the New API:
+  | Previous Websocket Method | New Websocket Method |
+  |---------------------------|----------------------|
+  | get_printer_info | printer.info |
+  | post_printer_emergency_stop | printer.emergency_stop |
+  | post_printer_restart | printer.restart |
+  | post_printer_firmware_restart | printer.firmware_restart |
+  | get_printer_objects_list | printer.objects.list |
+  | get_printer_objects_query | printer.objects.query |
+  | post_printer_objects_subscribe | printer.objects.subscribe |
+  | get_printer_query_endstops_status | printer.query_endstops.status |
+  | post_printer_gcode_script | printer.gcode.script |
+  | get_printer_gcode_help | printer.gcode.help |
+  | post_printer_print_start | printer.print.start |
+  | post_printer_print_pause | printer.print.pause |
+  | post_printer_print_resume | printer.print.resume |
+  | post_printer_print_cancel | printer.print.cancel |
+  | post_machine_reboot | machine.reboot |
+  | post_machine_shutdown | machine.shutdown |
+  | get_server_temperature_store | server.temperature_store |
+  | get_file_list | server.files.list |
+  | get_file_metadata | server.files.metadata |
+  | get_directory | server.files.get_directory |
+  | post_directory | server.files.post_directory |
+  | delete_directory | server.files.delete_directory |
+  | post_file_move | server.files.move |
+  | post_file_copy | server.files.copy |
+- The "power" plugin APIs have changed.  This affects both HTTP and
+  Websocket APIs.  They were originally added to the "/printer" path,
+  however this adds the possibility of a naming conflict.  The new
+  APIs are as follows:
+  - `GET /machine/gpio_power/devices` : `machine.gpio_power.devices`
+  - `GET /machine/gpio_power/status` : `machine.gpio_power.status`
+  - `POST /machine/gpio_power/on` : `machine.gpio_power.on`
+  - `POST /machine/gpio_power/off` : `machine.gpio_power.off`
+
 ### September 1st 2020
 - A new notification has been added: `notify_metdata_update`.  This
   notification is sent when Moonraker parses metdata from a new upload.

--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -37,7 +37,7 @@ that uses promises to return responses and errors (see json-rcp.js).
   `GET /printer/info`
 
 - Websocket command:\
-  `{jsonrpc: "2.0", method: "get_printer_info", id: <request id>}`
+  `{jsonrpc: "2.0", method: "printer.info", id: <request id>}`
 
 - Returns:\
   An object containing the build version, cpu info, Klippy's current state.
@@ -61,7 +61,7 @@ that uses promises to return responses and errors (see json-rcp.js).
   `POST /printer/emergency_stop`
 
 - Websocket command:\
-  `{jsonrpc: "2.0", method: "post_printer_emergency_stop", id: <request id>}`
+  `{jsonrpc: "2.0", method: "printer.emergency_stop", id: <request id>}`
 
 - Returns:\
   `ok`
@@ -71,7 +71,7 @@ that uses promises to return responses and errors (see json-rcp.js).
   `POST /printer/restart`
 
 - Websocket command:\
-  `{jsonrpc: "2.0", method: "post_printer_restart", id: <request id>}`
+  `{jsonrpc: "2.0", method: "printer.restart", id: <request id>}`
 
 - Returns:\
   `ok`
@@ -81,7 +81,7 @@ that uses promises to return responses and errors (see json-rcp.js).
   `POST /printer/firmware_restart`
 
 - Websocket command:\
-  `{jsonrpc: "2.0", method: "post_printer_firmware_restart", id: <request id>}`
+  `{jsonrpc: "2.0", method: "printer.firmware_restart", id: <request id>}`
 
 - Returns:\
   `ok`
@@ -93,7 +93,7 @@ that uses promises to return responses and errors (see json-rcp.js).
   `GET /printer/objects/list`
 
 - Websocket command:\
-  `{jsonrpc: "2.0", method: "get_printer_objects_list", id: <request id>}`
+  `{jsonrpc: "2.0", method: "printer.objects.list", id: <request id>}`
 
 - Returns:\
   An a list of "printer objects" that are currently available for query
@@ -113,7 +113,7 @@ that uses promises to return responses and errors (see json-rcp.js).
   `?gcode=gcode_position,busy&toolhead&extruder=target`
 
 - Websocket command:\
-  `{jsonrpc: "2.0", method: "get_printer_objects_query", params:
+  `{jsonrpc: "2.0", method: "printer.objects.query", params:
     {objects: {gcode: [], toolhead: ["position", "status"]}},
      id: <request id>}`
 
@@ -143,7 +143,7 @@ that uses promises to return responses and errors (see json-rcp.js).
   `POST /printer/objects/subscribe?gcode=gcode_position,bus&extruder=target`
 
 - Websocket command:\
-  `{jsonrpc: "2.0", method: "post_printer_objects_subscribe", params:
+  `{jsonrpc: "2.0", method: "printer.objects.subscribe", params:
     {objects: {gcode: [], toolhead: ["position", "status"]}},
     id: <request id>}`
 
@@ -179,7 +179,7 @@ that uses promises to return responses and errors (see json-rcp.js).
   `GET /printer/query_endstops/status`
 
 - Websocket command:\
-  `{jsonrpc: "2.0", method: "get_printer_query_endstops_status", id: <request id>}`
+  `{jsonrpc: "2.0", method: "printer.query_endstops.status", id: <request id>}`
 
 - Returns:\
   An object containing the current endstop state, with each attribute in the
@@ -197,7 +197,7 @@ that uses promises to return responses and errors (see json-rcp.js).
   `GET /server/temperature_store`
 
 - Websocket command:
-  `{jsonrpc: "2.0", method: "get_temperature_store", id: <request id>}`
+  `{jsonrpc: "2.0", method: "server.temperature_store", id: <request id>}`
 
 - Returns:\
   An object where the keys are the available temperature sensor names, and with
@@ -217,7 +217,7 @@ that uses promises to return responses and errors (see json-rcp.js).
   Will echo "Hello" to the terminal.
 
 - Websocket command:\
-  `{jsonrpc: "2.0", method: "post_printer_gcode_script",
+  `{jsonrpc: "2.0", method: "printer.gcode.script",
     params: {script: <gc>}, id: <request id>}`
 
 - Returns:\
@@ -230,7 +230,7 @@ that uses promises to return responses and errors (see json-rcp.js).
   `GET /printer/gcode/help`
 
 - Websocket command:\
-  `{jsonrpc: "2.0", method: "get_printer_gcode_help",
+  `{jsonrpc: "2.0", method: "printer.gcode.help",
     params: {script: <gc>}, id: <request id>}`
 
 - Returns:\
@@ -245,7 +245,7 @@ that uses promises to return responses and errors (see json-rcp.js).
   `POST /printer/print/start?filename=<file name>`
 
 - Websocket command:\
-  `{jsonrpc: "2.0", method: "post_printer_print_start",
+  `{jsonrpc: "2.0", method: "printer.print.start",
     params: {filename: <file name>, id:<request id>}`
 
 - Returns:\
@@ -256,7 +256,7 @@ that uses promises to return responses and errors (see json-rcp.js).
   `POST /printer/print/pause`
 
 - Websocket command:\
-  `{jsonrpc: "2.0", method: "post_printer_print_pause", id: <request id>}`
+  `{jsonrpc: "2.0", method: "printer.print.pause", id: <request id>}`
 
 - Returns:\
   `ok`
@@ -266,7 +266,7 @@ that uses promises to return responses and errors (see json-rcp.js).
   `POST /printer/print/resume`
 
 - Websocket command:\
-  `{jsonrpc: "2.0", method: "post_printer_print_resume", id: <request id>}`
+  `{jsonrpc: "2.0", method: "printer.print.resume", id: <request id>}`
 
 - Returns:\
   `ok`
@@ -276,7 +276,7 @@ that uses promises to return responses and errors (see json-rcp.js).
   `POST /printer/print/cancel`
 
 - Websocket command:\
-  `{jsonrpc: "2.0", method: "post_printer_print_cancel", id: <request id>}`
+  `{jsonrpc: "2.0", method: "printer.print.cancel", id: <request id>}`
 
 - Returns:\
   `ok`
@@ -288,7 +288,7 @@ that uses promises to return responses and errors (see json-rcp.js).
   `POST /machine/shutdown`
 
 - Websocket command:\
-  `{jsonrpc: "2.0", method: "post_machine_shutdown", id: <request id>}`
+  `{jsonrpc: "2.0", method: "machine.shutdown", id: <request id>}`
 
 - Returns:\
   No return value as the server will shut down upon execution
@@ -298,7 +298,7 @@ that uses promises to return responses and errors (see json-rcp.js).
   `POST /machine/reboot`
 
 - Websocket command:\
-  `{jsonrpc: "2.0", method: "post_machine_reboot", id: <request id>}`
+  `{jsonrpc: "2.0", method: "machine.reboot", id: <request id>}`
 
 - Returns:\
   No return value as the server will shut down upon execution
@@ -332,7 +332,7 @@ path relative to the specified "root".  Note that if the query st
   the "gcodes" file list by default.
 
 - Websocket command:\
-  `{jsonrpc: "2.0", method: "get_file_list", params: {root: "gcodes"}
+  `{jsonrpc: "2.0", method: "server.files.list", params: {root: "gcodes"}
   , id: <request id>}`
 
   If `params` are are omitted then the command will return the "gcodes"
@@ -360,7 +360,7 @@ path relative to the specified "root".  Note that if the query st
   `GET /server/files/metadata?filename=<filename>`
 
 - Websocket command:\
-  `{jsonrpc: "2.0", method: "get_file_metadata", params: {filename: "filename"}
+  `{jsonrpc: "2.0", method: "server.files.metadata", params: {filename: "filename"}
   , id: <request id>}`
 
 - Returns:\
@@ -402,8 +402,8 @@ subdirectories.
   the "gcodes" file list by default.
 
 - Websocket command:\
-  `{jsonrpc: "2.0", method: "get_directory", params: {path: "gcodes/my_subdir"}
-  , id: <request id>}`
+  `{jsonrpc: "2.0", method: "server.files.get_directory",
+   params: {path: "gcodes/my_subdir"} , id: <request id>}`
 
   If the "params" are omitted then the command will return
   the "gcodes" file list by default.
@@ -437,7 +437,7 @@ Creates a new directory at the specified path.
   `POST /server/files/directory?path=gcodes/my_new_dir`
 
 - Websocket command:\
-  `{jsonrpc: "2.0", method: "post_directory", params:
+  `{jsonrpc: "2.0", method: "server.files.post_directory", params:
    {path: "gcodes/my_new_dir"}, id: <request id>}`
 
 Returns:\
@@ -450,7 +450,7 @@ Deletes a directory at the specified path.
   `DELETE /server/files/directory?path=gcodes/my_subdir`
 
 - Websocket command:\
-  `{jsonrpc: "2.0", method: "delete_directory", params:
+  `{jsonrpc: "2.0", method: "server.files.delete_directory", params:
    {path: "gcodes/my_subdir"} , id: <request id>}`
 
   If the specified directory contains files then the delete request
@@ -490,7 +490,7 @@ in *moving* the source directory to the destination directory.
   &dest=gcodes/subdir/my_file.gcode`
 
 - Websocket command:\
-  `{jsonrpc: "2.0", method: "post_file_move", params:
+  `{jsonrpc: "2.0", method: "server.files.move", params:
    {source: "gcodes/my_file.gcode",
    dest: "gcodes/subdir/my_file.gcode"}, id: <request id>}`
 
@@ -505,7 +505,7 @@ the source and destination should have the root prefixed.
    &dest=gcodes/subdir/my_file.gcode`
 
 - Websocket command:\
-  `{jsonrpc: "2.0", method: "post_file_copy", params:
+  `{jsonrpc: "2.0", method: "server.files.copy", params:
    {source: "gcodes/my_file.gcode", dest: "gcodes/subdir/my_file.gcode"},
    id: <request id>}`
 
@@ -806,7 +806,7 @@ The following startup sequence is recommened for clients which make use of
 the websocket:
 1) Attempt to connect to `/websocket` until successful using a timer-like
    mechanism
-2) Once connected, query `/printer/info` (or `get_printer_info`) for the ready
+2) Once connected, query `/printer/info` (or `printer.info`) for the ready
    status.
    - If the response returns an error (such as 404), set a timeout for
      2 seconds and try again.
@@ -819,7 +819,7 @@ the websocket:
      - If `state == "shutdown"` then Klippy is in a shutdown state.
      - If `state == "startup"` then re-request printer info in 2s.
 - Repeat step 2s until Klipper reports ready.  T
-- Client's should watch for the `notify_klippy_state_changed` event.  If it reports
+- Client's should watch for the `notify_klippy_disconnected` event.  If it reports
   disconnected then Klippy has either been stopped or restarted.  In this
   instance the client should repeat the steps above to determine when
   klippy is ready.

--- a/moonraker/authorization.py
+++ b/moonraker/authorization.py
@@ -65,10 +65,10 @@ class Authorization:
     def register_handlers(self, app):
         # Register Authorization Endpoints
         app.register_local_handler(
-            "/access/api_key", None, ['GET', 'POST'],
+            "/access/api_key", ['GET', 'POST'],
             self._handle_apikey_request, http_only=True)
         app.register_local_handler(
-            "/access/oneshot_token", None, ['GET'],
+            "/access/oneshot_token", ['GET'],
             self._handle_token_request, http_only=True)
 
     async def _handle_apikey_request(self, path, method, args):

--- a/moonraker/plugins/file_manager.py
+++ b/moonraker/plugins/file_manager.py
@@ -27,20 +27,16 @@ class FileManager:
 
         # Register file management endpoints
         self.server.register_endpoint(
-            "/server/files/list", "file_list", ['GET'],
-            self._handle_filelist_request)
+            "/server/files/list", ['GET'], self._handle_filelist_request)
         self.server.register_endpoint(
-            "/server/files/metadata", "file_metadata", ['GET'],
-            self._handle_metadata_request)
+            "/server/files/metadata", ['GET'], self._handle_metadata_request)
         self.server.register_endpoint(
-            "/server/files/directory", "directory", ['GET', 'POST', 'DELETE'],
+            "/server/files/directory", ['GET', 'POST', 'DELETE'],
             self._handle_directory_request)
         self.server.register_endpoint(
-            "/server/files/move", "file_move", ['POST'],
-            self._handle_file_move_copy)
+            "/server/files/move", ['POST'], self._handle_file_move_copy)
         self.server.register_endpoint(
-            "/server/files/copy", "file_copy", ['POST'],
-            self._handle_file_move_copy)
+            "/server/files/copy", ['POST'], self._handle_file_move_copy)
         # Register APIs to handle file uploads
         self.server.register_upload_handler("/server/files/upload")
         self.server.register_upload_handler("/api/files/local")

--- a/moonraker/plugins/klippy_apis.py
+++ b/moonraker/plugins/klippy_apis.py
@@ -23,23 +23,17 @@ class KlippyAPI:
 
         # Register GCode Aliases
         self.server.register_endpoint(
-            "/printer/print/pause", "printer_print_pause", ['POST'],
-            self._gcode_pause)
+            "/printer/print/pause", ['POST'], self._gcode_pause)
         self.server.register_endpoint(
-            "/printer/print/resume", "printer_print_resume", ['POST'],
-            self._gcode_resume)
+            "/printer/print/resume", ['POST'], self._gcode_resume)
         self.server.register_endpoint(
-            "/printer/print/cancel", "printer_print_cancel", ['POST'],
-            self._gcode_cancel)
+            "/printer/print/cancel", ['POST'], self._gcode_cancel)
         self.server.register_endpoint(
-            "/printer/print/start", "printer_print_start", ['POST'],
-            self._gcode_start_print)
+            "/printer/print/start", ['POST'], self._gcode_start_print)
         self.server.register_endpoint(
-            "/printer/restart", "printer_restart", ['POST'],
-            self._gcode_restart)
+            "/printer/restart", ['POST'], self._gcode_restart)
         self.server.register_endpoint(
-            "/printer/firmware_restart", "printer_firmware_restart", ['POST'],
-            self._gcode_firmware_restart)
+            "/printer/firmware_restart", ['POST'], self._gcode_firmware_restart)
 
     async def _gcode_pause(self, path, method, args):
         return await self.run_gcode("PAUSE")

--- a/moonraker/plugins/machine.py
+++ b/moonraker/plugins/machine.py
@@ -9,11 +9,9 @@ class Machine:
     def __init__(self, config):
         self.server = config.get_server()
         self.server.register_endpoint(
-            "/machine/reboot", "machine_reboot", ['POST'],
-            self._handle_machine_request)
+            "/machine/reboot", ['POST'], self._handle_machine_request)
         self.server.register_endpoint(
-            "/machine/shutdown", "machine_shutdown", ['POST'],
-            self._handle_machine_request)
+            "/machine/shutdown", ['POST'], self._handle_machine_request)
 
     async def _handle_machine_request(self, path, method, args):
         if path == "/machine/shutdown":

--- a/moonraker/plugins/power.py
+++ b/moonraker/plugins/power.py
@@ -13,16 +13,16 @@ class PrinterPower:
     def __init__(self, config):
         self.server = config.get_server()
         self.server.register_endpoint(
-            "/printer/power/devices", "power_devices", ['GET'],
+            "/machine/gpio_power/devices", ['GET'],
             self._handle_list_devices)
         self.server.register_endpoint(
-            "/printer/power/status", "power_status", ['GET'],
+            "/machine/gpio_power/status", ['GET'],
             self._handle_power_request)
         self.server.register_endpoint(
-            "/printer/power/on", "power_on", ['POST'],
+            "/machine/gpio_power/on", ['POST'],
             self._handle_power_request)
         self.server.register_endpoint(
-            "/printer/power/off", "power_off", ['POST'],
+            "/machine/gpio_power/off", ['POST'],
             self._handle_power_request)
 
         self.current_dev = None

--- a/moonraker/plugins/temperature_store.py
+++ b/moonraker/plugins/temperature_store.py
@@ -28,7 +28,7 @@ class TemperatureStore:
 
         # Register endpoint
         self.server.register_endpoint(
-            "/server/temperature_store", "server_temperature_store", ['GET'],
+            "/server/temperature_store", ['GET'],
             self._handle_temp_store_request)
 
     async def _init_sensors(self):

--- a/test/client/js/main.js
+++ b/test/client/js/main.js
@@ -10,79 +10,81 @@ import JsonRPC from "./json-rpc.js?v=0.1.2";
 var api = {
     printer_info: {
         url: "/printer/info",
-        method: "get_printer_info"
+        method: "printer.info"
     },
     gcode_script: {
         url: "/printer/gcode/script",
-        method: "post_printer_gcode_script"
+        method: "printer.gcode.script"
     },
     gcode_help: {
         url: "/printer/gcode/help",
-        method: "get_printer_gcode_help"
+        method: "printer.gcode.help"
     },
     start_print: {
         url: "/printer/print/start",
-        method: "post_printer_print_start"
+        method: "printer.print.start"
     },
     cancel_print: {
         url: "/printer/print/cancel",
-        method: "post_printer_print_cancel"
+        method: "printer.print.cancel"
     },
     pause_print: {
         url: "/printer/print/pause",
-        method: "post_printer_print_pause"
+        method: "printer.print.pause"
     },
     resume_print: {
         url: "/printer/print/resume",
-        method: "post_printer_print_resume"
+        method: "printer.print.resume"
     },
     query_endstops: {
         url: "/printer/query_endstops/status",
-        method: "get_printer_query_endstops_status"
+        method: "printer.query_endstops.status"
     },
     object_list: {
         url: "/printer/objects/list",
-        method: "get_printer_objects_list"
+        method: "printer.objects.list"
     },
     object_status: {
         url: "/printer/objects/query",
-        method: "get_printer_objects_query"
+        method: "printer.objects.query"
     },
     object_subscription: {
         url: "/printer/objects/subscribe",
-        method: {
-            post: "post_printer_objects_subscribe",
-            get: "get_printer_objects_subscribe"
-        },
+        method: "printer.objects.subscribe"
     },
     temperature_store: {
         url: "/server/temperature_store",
-        method: "get_server_temperature_store"
+        method: "server.temperature_store"
     },
     estop: {
         url: "/printer/emergency_stop",
-        method: "post_printer_emergency_stop"
+        method: "printer.emergency_stop"
     },
     restart: {
         url: "/printer/restart",
-        method: "post_printer_restart"
+        method: "printer.restart"
     },
     firmware_restart: {
         url: "/printer/firmware_restart",
-        method: "post_printer_firmware_restart"
+        method: "printer.firmware_restart"
     },
 
     // File Management Apis
     file_list:{
         url: "/server/files/list",
-        method: "get_file_list"
+        method: "server.files.list"
     },
     metadata: {
         url: "/server/files/metadata",
-        method: "get_file_metadata"
+        method: "server.files.metadata"
     },
     directory: {
-        url: "/server/files/directory"
+        url: "/server/files/directory",
+        method: {
+            get: "server.files.get_directory",
+            post: "server.files.post_directory",
+            delete: "server.files.delete_directory"
+        }
     },
     upload: {
         url: "/server/files/upload"
@@ -106,11 +108,11 @@ var api = {
     // Machine APIs
     reboot: {
         url: "/machine/reboot",
-        method: "post_machine_reboot"
+        method: "machine.reboot"
     },
     shutdown: {
         url: "/machine/shutdown",
-        method: "post_machine_shutdown"
+        method: "machine.shutdown"
     },
 
     // Access APIs
@@ -379,26 +381,26 @@ function get_object_list() {
 
 function add_subscription(printer_objects) {
     json_rpc.call_method_with_kwargs(
-        api.object_subscription.method.post, printer_objects)
+        api.object_subscription.method, printer_objects)
     .then((result) => {
         // result is the the state from all fetched data
         handle_status_update(result.status)
         console.log(result);
     })
     .catch((error) => {
-        update_error(api.object_subscription.method.post, error);
+        update_error(api.object_subscription.method, error);
     });
 }
 
 function get_subscribed() {
-    json_rpc.call_method(api.object_subscription.method.get)
+    json_rpc.call_method(api.object_subscription.method)
     .then((result) => {
         // result is a dictionary containing all currently subscribed
         // printer objects/attributes
         console.log(result);
     })
     .catch((error) => {
-        update_error(api.object_subscription.method.get, error);
+        update_error(api.object_subscription.method, error);
     });
 }
 
@@ -634,7 +636,7 @@ function send_gcode_batch(gcodes) {
     for (let gc of gcodes) {
         batch.push(
             {
-                method: 'post_printer_gcode_script',
+                method: api.gcode_script.method,
                 type: 'request',
                 params: {script: gc}
             });
@@ -675,7 +677,7 @@ async function send_gcode_macro(gcodes) {
     for (let gc of gcodes) {
         try {
             let result = await json_rpc.call_method_with_kwargs(
-                'post_printer_gcode_script', {script: gc});
+                api.gcode_script.method, {script: gc});
         } catch (err) {
             console.log("Error executing gcode macro: " + err.message);
             break;


### PR DESCRIPTION
This pull request changes how websocket APIs are generated.  The goal is to eliminate ridiculous API calls such as `get_printer_query_endstops_status`.  That example would now resolve to `printer.query_endstops.status`.  This also ensures that  APIs registered by Moonraker are contained within a namespace, eliminating the chance that an endpoint added from Klipper can cause a conflict.

@jordanruthe This also changes the APIs for the power plugin.  Specifically, rather than put it in the `/printer` path, the APIs are now located at `/machine/gpio_power`, so for example `GET /machine/gpio_power/devices` or `machine.gpio_power.devices`.  I did this for the reason above, it is possible that Klipper could one day have its own "power" extra.  I don't see that happening, but if it does this eliminates the chance of a naming conflict.