### PR TITLE
fix: make installer not fail if klipper is installed as systemd service

### DIFF
--- a/scripts/install-moonraker.sh
+++ b/scripts/install-moonraker.sh
@@ -69,13 +69,13 @@ MOONRAKER_ARGS="${SRCDIR}/moonraker/moonraker.py"
 EOF
 }
 
-# Step 4: Start server
+# Step 6: Start server
 start_software()
 {
     report_status "Launching Moonraker API Server..."
-    sudo /etc/init.d/klipper stop
+    sudo systemctl stop klipper
     sudo /etc/init.d/moonraker restart
-    sudo /etc/init.d/klipper start
+    sudo systemctl start klipper
 }
 
 # Helper functions


### PR DESCRIPTION
If Klipper is installed as systemd service, the script would fail and exit at step 6 (corrected that typo) when trying to stop Klipper via init.d. Changing the used command to systemctl will be compatible with both init.d and systemd services.