### PR TITLE
moonraker:  report subscription updates on a per client basis

### DIFF
--- a/docs/api_changes.md
+++ b/docs/api_changes.md
@@ -1,6 +1,24 @@
 This document keeps a record of all changes to Moonraker's remote
 facing APIs.
 
+### November 11th 2020
+- The `server.websocket.id` API has been added.  This returns a
+  unique ID that Moonraker uses to track each client connection.
+  As such, this API is only available over the websocket, there
+  is no complementary HTTP request.
+- All HTTP API request may now include arguments in either the
+  query string or in the request's body.
+- Subscriptions are now managed on a per connection basis.  Each
+  connection will only recieve updates for objects in which they
+  are currently subscribed.  If an "empty" request is sent, the
+  subscription will be cancelled.
+- The `POST /printer/object/subscribe` now requires a
+  `connection_id` argument.  This is used to identify which
+  connection's associated subscription should be updated.
+  Currenlty subscriptions are only supported over the a
+  websocket connection, one may use the id received from
+  `server.websocket.id`.
+
 ### November 2nd 2020
 - The `GET /server/files/directory` endpoint now accepts a new
   optional argument, `extended`.  If `extended=true`, then

--- a/docs/api_changes.md
+++ b/docs/api_changes.md
@@ -18,6 +18,8 @@ facing APIs.
   Currenlty subscriptions are only supported over the a
   websocket connection, one may use the id received from
   `server.websocket.id`.
+- The `notify_klippy_ready` websocket notification has been
+  added.
 
 ### November 2nd 2020
 - The `GET /server/files/directory` endpoint now accepts a new

--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -11,8 +11,9 @@ of:
 
 `{result: <response data>}`
 
-The command matches the original command request, the result is the return
-value generated from the request.
+Arguments sent via the HTTP APIs may either be included in the query string
+or as part of the request's body.  All of the examples in this document
+use the query string for arguments.
 
 Websocket requests are returned in JSON-RPC format:
 `{jsonrpc: "2.0", "result": <response data>, id: <request id>}`
@@ -143,15 +144,25 @@ available for query.
 
 ### Subscribe to printer object status:
 - HTTP command:\
-  `POST /printer/objects/subscribe?gcode=gcode_position,bus&extruder=target`
+  `POST /printer/objects/subscribe?connection_id=123456789&
+   gcode=gcode_position,bus&extruder=target`
+
+   Note:  The HTTP API requires that a `connection_id` is passed via the query
+   string or as part of the form.   This should be the
+   [ID reported](#get-websocket-id) from a currently connected websocket. A
+   request that includes only the `connection_id` argument will cancel the
+   subscription on the specified websocket.
 
 - Websocket command:\
   `{jsonrpc: "2.0", method: "printer.objects.subscribe", params:
     {objects: {gcode: null, toolhead: ["position", "status"]}},
     id: <request id>}`
 
+    Note that if `objects` is an empty object then the subscription will
+    be cancelled.
+
 - Returns:\
-  Status data for all currently subscribed objects, with the format matching that of
+  Status data for objects in the request, with the format matching that of
   the `/printer/objects/query`:
 
   ```json
@@ -172,12 +183,7 @@ available for query.
 See [printer_objects.md](printer_objects.md) for details on the printer objects
 available for subscription.
 
-Note that Moonraker's current behavior is to maintain a superset of all
-subscriptions, thus you may receive updates for objects that you did not
-request.  This behavior is subject to change in the future (where each
-client receives only the subscriptions it requested).
-
-Future updates for subscribed objects are sent asynchronously over the
+Status updates for subscribed objects are sent asynchronously over the
 websocket.  See the `notify_status_update` notification for details.
 
 ### Query Endstops
@@ -289,6 +295,23 @@ for (let resp of result.gcode_store) {
   is returns, the server will restart.  Any existing connection
   will be disconnected.  A restart will result in the creation
   of a new server instance where the configuration is reloaded.
+
+## Get Websocket ID
+- HTTP command:\
+  Not Available
+
+- Websocket command:
+  `{jsonrpc: "2.0", method: "server.websocket.id", id: <request id>}`
+
+- Returns:\
+  This connected websocket's unique identifer in the format shown below.
+  Note that this API call is only available over the websocket.
+
+```json
+  {
+    websocket_id: <int>
+  }
+```
 
 ## Gcode Controls
 

--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -816,6 +816,11 @@ Status Subscriptions arrive as a "notify_status_update" notification:
 The structure of the status data is identical to the structure that is
 returned from an object query's "status" attribute.
 
+### Klippy Ready:
+Notify clients when Klippy has reported a ready state
+
+`{jsonrpc: "2.0", method: "notify_klippy_ready"}`
+
 ### Klippy Disconnected:
 Notify clients when Moonraker's connection to Klippy has terminated
 

--- a/moonraker/app.py
+++ b/moonraker/app.py
@@ -12,7 +12,7 @@ from inspect import isclass
 from tornado.escape import url_unescape
 from tornado.routing import Rule, PathMatches, AnyMatches
 from utils import ServerError
-from websockets import WebsocketManager, WebSocket
+from websockets import WebRequest, WebsocketManager, WebSocket
 from authorization import AuthorizedRequestHandler, AuthorizedFileHandler
 from authorization import Authorization
 
@@ -270,7 +270,7 @@ class RemoteRequestHandler(AuthorizedRequestHandler):
             args = self.query_parser(self.request)
         try:
             result = await self.server.make_request(
-                self.remote_callback, args)
+                WebRequest(self.remote_callback, args))
         except ServerError as e:
             raise tornado.web.HTTPError(
                 e.status_code, str(e)) from e
@@ -307,7 +307,8 @@ class LocalRequestHandler(AuthorizedRequestHandler):
         if self.request.query:
             args = self.query_parser(self.request)
         try:
-            result = await self.callback(self.request.path, method, args)
+            result = await self.callback(
+                WebRequest(self.request.path, args, method))
         except ServerError as e:
             raise tornado.web.HTTPError(
                 e.status_code, str(e)) from e

--- a/moonraker/app.py
+++ b/moonraker/app.py
@@ -270,12 +270,13 @@ class RemoteRequestHandler(AuthorizedRequestHandler):
         await self._process_http_request()
 
     async def _process_http_request(self):
+        conn = self.get_associated_websocket()
         args = {}
         if self.request.query:
             args = self.query_parser(self.request)
         try:
             result = await self.server.make_request(
-                WebRequest(self.remote_callback, args))
+                WebRequest(self.remote_callback, args, conn=conn))
         except ServerError as e:
             raise tornado.web.HTTPError(
                 e.status_code, str(e)) from e
@@ -307,12 +308,13 @@ class LocalRequestHandler(AuthorizedRequestHandler):
             raise tornado.web.HTTPError(405)
 
     async def _process_http_request(self, method):
+        conn = self.get_associated_websocket()
         args = {}
         if self.request.query:
             args = self.query_parser(self.request)
         try:
             result = await self.callback(
-                WebRequest(self.request.path, args, method))
+                WebRequest(self.request.path, args, method, conn=conn))
         except ServerError as e:
             raise tornado.web.HTTPError(
                 e.status_code, str(e)) from e

--- a/moonraker/authorization.py
+++ b/moonraker/authorization.py
@@ -71,12 +71,13 @@ class Authorization:
             "/access/oneshot_token", ['GET'],
             self._handle_token_request, protocol=['http'])
 
-    async def _handle_apikey_request(self, path, method, args):
-        if method.upper() == 'POST':
+    async def _handle_apikey_request(self, web_request):
+        action = web_request.get_action()
+        if action.upper() == 'POST':
             self.api_key = self._create_api_key()
         return self.api_key
 
-    async def _handle_token_request(self, path, method, args):
+    async def _handle_token_request(self, web_request):
         return self.get_access_token()
 
     def _read_api_key(self):

--- a/moonraker/authorization.py
+++ b/moonraker/authorization.py
@@ -180,9 +180,10 @@ class Authorization:
         self.prune_handler.stop()
 
 class AuthorizedRequestHandler(tornado.web.RequestHandler):
-    def initialize(self, server, auth):
-        self.server = server
-        self.auth = auth
+    def initialize(self, main_app):
+        self.server = main_app.get_server()
+        self.auth = main_app.get_auth()
+        self.wsm = main_app.get_websocket_manager()
 
     def prepare(self):
         if not self.auth.check_authorized(self.request):
@@ -210,10 +211,10 @@ class AuthorizedRequestHandler(tornado.web.RequestHandler):
 # Due to the way Python treats multiple inheritance its best
 # to create a separate authorized handler for serving files
 class AuthorizedFileHandler(tornado.web.StaticFileHandler):
-    def initialize(self, server, auth, path, default_filename=None):
+    def initialize(self, main_app, path, default_filename=None):
         super(AuthorizedFileHandler, self).initialize(path, default_filename)
-        self.server = server
-        self.auth = auth
+        self.server = main_app.get_server()
+        self.auth = main_app.get_auth()
 
     def prepare(self):
         if not self.auth.check_authorized(self.request):

--- a/moonraker/authorization.py
+++ b/moonraker/authorization.py
@@ -208,6 +208,20 @@ class AuthorizedRequestHandler(tornado.web.RequestHandler):
         else:
             super(AuthorizedRequestHandler, self).options()
 
+    def get_associated_websocket(self):
+        # Return associated websocket connection if an id
+        # was provided by the request
+        conn = None
+        conn_id = self.get_argument('connection_id', None)
+        if conn_id is not None:
+            try:
+                conn_id = int(conn_id)
+            except Exception:
+                pass
+            else:
+                conn = self.wsm.get_websocket(conn_id)
+        return conn
+
 # Due to the way Python treats multiple inheritance its best
 # to create a separate authorized handler for serving files
 class AuthorizedFileHandler(tornado.web.StaticFileHandler):

--- a/moonraker/plugins/data_store.py
+++ b/moonraker/plugins/data_store.py
@@ -98,7 +98,7 @@ class DataStore:
             self.temperature_store[sensor]['temperatures'].append(temp)
             self.temperature_store[sensor]['targets'].append(target)
 
-    async def _handle_temp_store_request(self, path, method, args):
+    async def _handle_temp_store_request(self, web_request):
         store = {}
         for name, sensor in self.temperature_store.items():
             store[name] = {k: list(v) for k, v in sensor.items()}
@@ -111,15 +111,9 @@ class DataStore:
         curtime = time.time()
         self.gcode_queue.append({'message': response, 'time': curtime})
 
-    async def _handle_gcode_store_request(self, path, method, args):
-        count = args.get("count", None)
+    async def _handle_gcode_store_request(self, web_request):
+        count = web_request.get_int("count", None)
         if count is not None:
-            try:
-                count = int(count)
-            except Exception:
-                raise self.server.error(
-                    "Parameter <count> must be an integer value, "
-                    f"received: {count}")
             res = list(self.gcode_queue)[-count:]
         else:
             res = list(self.gcode_queue)

--- a/moonraker/plugins/klippy_apis.py
+++ b/moonraker/plugins/klippy_apis.py
@@ -4,6 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import utils
+from websockets import WebRequest
 
 INFO_ENDPOINT = "info"
 ESTOP_ENDPOINT = "emergency_stop"
@@ -36,28 +37,29 @@ class KlippyAPI:
         self.server.register_endpoint(
             "/printer/firmware_restart", ['POST'], self._gcode_firmware_restart)
 
-    async def _gcode_pause(self, path, method, args):
+    async def _gcode_pause(self, web_request):
         return await self.run_gcode("PAUSE")
 
-    async def _gcode_resume(self, path, method, args):
+    async def _gcode_resume(self, web_request):
         return await self.run_gcode("RESUME")
 
-    async def _gcode_cancel(self, path, method, args):
+    async def _gcode_cancel(self, web_request):
         return await self.run_gcode("CANCEL_PRINT")
 
-    async def _gcode_start_print(self, path, method, args):
-        filename = args.get('filename')
+    async def _gcode_start_print(self, web_request):
+        filename = web_request.get_str('filename')
         return await self.start_print(filename)
 
-    async def _gcode_restart(self, path, method, args):
+    async def _gcode_restart(self, web_request):
         return await self.do_restart("RESTART")
 
-    async def _gcode_firmware_restart(self, path, method, args):
+    async def _gcode_firmware_restart(self, web_request):
         return await self.do_restart("FIRMWARE_RESTART")
 
     async def _send_klippy_request(self, method, params, default=Sentinel):
         try:
-            result = await self.server.make_request(method, params)
+            result = await self.server.make_request(
+                WebRequest(method, params))
         except self.server.error as e:
             if default == Sentinel:
                 raise

--- a/moonraker/plugins/machine.py
+++ b/moonraker/plugins/machine.py
@@ -13,10 +13,11 @@ class Machine:
         self.server.register_endpoint(
             "/machine/shutdown", ['POST'], self._handle_machine_request)
 
-    async def _handle_machine_request(self, path, method, args):
-        if path == "/machine/shutdown":
+    async def _handle_machine_request(self, web_request):
+        ep = web_request.get_endpoint()
+        if ep == "/machine/shutdown":
             cmd = "sudo shutdown now"
-        elif path == "/machine/reboot":
+        elif ep == "/machine/reboot":
             cmd = "sudo shutdown -r now"
         else:
             raise self.server.error("Unsupported machine request")

--- a/moonraker/plugins/power.py
+++ b/moonraker/plugins/power.py
@@ -38,7 +38,7 @@ class PrinterPower:
         ioloop = IOLoop.current()
         ioloop.spawn_callback(self.initialize_devices, devices)
 
-    async def _handle_list_devices(self, path, method, args):
+    async def _handle_list_devices(self, web_request):
         output = {"devices": []}
         for dev in self.devices:
             output['devices'].append({
@@ -47,15 +47,17 @@ class PrinterPower:
             })
         return output
 
-    async def _handle_power_request(self, path, method, args):
+    async def _handle_power_request(self, web_request):
+        args = web_request.get_args()
+        ep = web_request.get_endpoint()
         if len(args) == 0:
-            if path == "/machine/gpio_power/status":
+            if ep == "/machine/gpio_power/status":
                 args = self.devices
             else:
                 return "no_devices"
 
         result = {}
-        req = path.split("/")[-1]
+        req = ep.split("/")[-1]
         for dev in args:
             if req not in ("on", "off", "status"):
                 raise self.server.error("Unsupported power request")

--- a/moonraker/websockets.py
+++ b/moonraker/websockets.py
@@ -268,9 +268,9 @@ class WebsocketManager:
             self.websockets = {}
 
 class WebSocket(WebSocketHandler):
-    def initialize(self, wsm, auth):
-        self.wsm = wsm
-        self.auth = auth
+    def initialize(self, main_app):
+        self.auth = main_app.get_auth()
+        self.wsm = main_app.get_websocket_manager()
         self.rpc = self.wsm.rpc
         self.uid = id(self)
 

--- a/moonraker/websockets.py
+++ b/moonraker/websockets.py
@@ -167,6 +167,8 @@ class WebsocketManager:
         self.ws_lock = tornado.locks.Lock()
         self.rpc = JsonRPC()
 
+        self.rpc.register_method("server.websocket.id", self._handle_id_request)
+
         # Register events
         self.server.register_event_handler(
             "server:klippy_disconnect", self._handle_klippy_disconnect)
@@ -223,8 +225,14 @@ class WebsocketManager:
             return result
         return func
 
+    async def _handle_id_request(self, ws, **kwargs):
+        return {'websocket_id': ws.uid}
+
     def has_websocket(self, ws_id):
         return ws_id in self.websockets
+
+    def get_websocket(self, ws_id):
+        return self.websockets.get(ws_id, None)
 
     async def add_websocket(self, ws):
         async with self.ws_lock:

--- a/moonraker/websockets.py
+++ b/moonraker/websockets.py
@@ -171,6 +171,8 @@ class WebsocketManager:
 
         # Register events
         self.server.register_event_handler(
+            "server:klippy_ready", self._handle_klippy_ready)
+        self.server.register_event_handler(
             "server:klippy_disconnect", self._handle_klippy_disconnect)
         self.server.register_event_handler(
             "server:gcode_response", self._handle_gcode_response)
@@ -180,6 +182,9 @@ class WebsocketManager:
             "file_manager:metadata_update", self._handle_metadata_update)
         self.server.register_event_handler(
             "gpio_power:power_changed", self._handle_power_changed)
+
+    async def _handle_klippy_ready(self):
+        await self.notify_websockets("klippy_ready")
 
     async def _handle_klippy_disconnect(self):
         await self.notify_websockets("klippy_disconnected")

--- a/test/client/js/main.js
+++ b/test/client/js/main.js
@@ -721,11 +721,20 @@ function handle_klippy_disconnected() {
     // be a good place.
     klippy_ready = false;
     update_term("Klippy Disconnected");
-    setTimeout(() => {
-        get_klippy_info();
-    }, 2000);
 }
 json_rpc.register_method("notify_klippy_disconnected", handle_klippy_disconnected);
+
+function handle_klippy_ready() {
+    update_term("Klippy Is READY");
+    console.log("Klippy Ready Recieved");
+    get_klippy_info();
+}
+json_rpc.register_method("notify_klippy_ready", handle_klippy_ready);
+
+function handle_power_changed(power_status) {
+    console.log(`Power Changed: ${power_status}`);
+}
+json_rpc.register_method("notify_power_changed", handle_power_changed);
 
 function handle_file_list_changed(file_info) {
     // This event fires when a client has either added or removed


### PR DESCRIPTION
This makes several changes to the code with the goal of making client subscriptions independent.  The changes here will affect both client developers and plugin developers, which is why this was not pushed directly to master.  I plan to wait a few days until this is merged.

For client developers:
- A new `server.websocket.id` API has been added.  This returns a unique ID that moonraker uses to identify different client connections.  It is unlikely that most of you will need this, currently it is only necessary when using the HTTP `POST /printer/objects/subscribe` API.  If you are using that, see the updated documentation for how to include it.
- As mentioned in the intro, the behavior of subscriptions has changed.  Clients will no longer receive a "superset" of all subscribed objects, they will only receive updates for the specific objects specified in their most recent subscription request.   It is possible to "cancel" a subscription by passing an empty object via the `objects` argument.
-  A side effect of this change is that subscriptions are cleared if Klippy or Moonraker disconnects.  When Klippy reconnects clients must always resubscribe.

For Moonraker developers:
- Request handlers now accept a WebRequest object.  For example, previously a handler would look something like this:
  ```python
  async def _handle_my_request(self, path, method, args):
     # do stuff
  ```
  They now look like this:
  ```python
  async def _handle_my_request(self, web_request):
    path = web_request.get_endpoint()
    request_method = web_request.get_action()   # should be "GET", "POST", or "DELETE"
    my_integer_arg = web_request.get_int("count", 0)
    # do stuff 
  ```
  If you have developed an "extras" module in Klipper this will look familiar.  The WebRequest  object has "get", "get_str", "get_int", "get_float", and "get_boolean" methods.  These methods will search the request arguments for the supplied key and do the conversion for you.  If the Key doesn't exist the default is returned, or if no default is provided an exception is raised.  The bare "get" method can be used to fetch items that cannot be converted, for example if the argument is a list or a dict.  It is also possible to call "get_args()" to get a direct reference to the arguments dict, where you can iterate through it or modify it if necessary.
- Plugins that subscribe to objects will receive a superset of all subscriptions made by the host.  For example, `data_store.py` subscribes to all available temperature sensors.  Your plugin will receive updates for that data as well as anything it may subscribe to.  All host subscriptions must be done through the `klippy_apis` module via the `subscribe_objects()` method.  As with clients, plugins must re-subscribe if Klippy disconnects.  As such, it is recommended to request the subscription in a "sever:klippy_ready" event handler.