### PR TITLE
power:  use libgpiod, add support for tplink-smartplug

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,15 @@ Note that Moonraker does not come bundled with a client, you will need to
 install one.  The following web clients are currently available:
 - [Mainsail](https://github.com/meteyou/mainsail) by Meteyou
 - [Fluidd](https://github.com/cadriel/fluidd) by Cadriel
+
+### Changes
+
+This section contains changelogs that users and developers may reference
+to see if any action is necessary on their part.  The date of the most
+recent change is included.
+
+Users:\
+[user_changes.md](/docs/user_changes.md) - November 19th 2020
+
+Developers:\
+[api_changes.md](/docs/api_changes.md) - November 19th 2020

--- a/docs/api_changes.md
+++ b/docs/api_changes.md
@@ -1,6 +1,37 @@
 This document keeps a record of all changes to Moonraker's remote
 facing APIs.
 
+### November 19th 2020
+- The path for the power APIs has changed from `gpio_power` to `device_power`:
+  - `GET /machine/device_power/devices`\
+    `{"jsonrpc":"2.0","method":"machine.device_power.devices","id":"1"}`\
+    Returns an array of objects listing all detected devices.
+    Each object in the array is guaranteed to have the following
+    fields:
+    - `device`:  The device name
+    - `status`:  May be "init", "on", "off", or "error"
+    - `type`: May be "gpio" or "tplink_smartplug"
+  - `GET /machine/device_power/status?dev_name`\
+    `{"jsonrpc":"2.0","method":"machine.device_power.status","id":"1",
+    "params":{"dev_name":null}}`\
+    It is no longer possible to call this method with no arguments.
+    Status will only be returned for the requested device, to get
+    status of all devices use `/machine/device_power/devices`.  As
+    before, this returns an object in the format of
+    `{device_name: status}`, where device_name is the name of the device
+    and `status` is the devices current status.
+  - `POST /machine/device_power/on?dev_name`\
+    `{"jsonrpc":"2.0","method":"machine.device_power.on","id":"1",
+    "params":{"dev_name":null}}`\
+    Toggles device on.  Returns the current status of the device.
+  - `POST /machine/device_power/off?dev_name`\
+    `{"jsonrpc":"2.0","method":"machine.device_power.off","id":"1",
+    "params":{"dev_name":null}}`\
+    Toggles device off.  Returns the current status of the device.
+  - The `notify_power_changed` notification now includes an object
+    containing device info, matching that which would be recieved
+    from a single item in `/machine/power/devices`.
+
 ### November 12th 2020
 - Two new fields have been added to the gcode metadata:
   - `gcode_start_byte`:  Indicates the byte position in the

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -47,18 +47,24 @@ cd ~
 git clone https://github.com/Arksine/moonraker.git
 ```
 
-If you have an experimental verison of moonraker that pre-dates this repo,
-it must be uninstalled:
-```
-cd ~/moonraker/scripts
-./uninstall-moonraker.sh
-```
-
 Finally, run moonraker's install script:
 ```
 cd ~/moonraker/scripts
 ./install-moonraker.sh
 ```
+
+The install script has a few command line options that may be useful,
+particularly for those upgrading:
+- -r\
+  This will rebuild the virtual environment for existing installations.
+  Sometimes this is necessary when a dependency has been added.
+- -f\
+  This will tell the script to overwrite Moonraker's "defaults" file.
+  By default the script will not modify the "defaults" file if it is
+  detected as present.
+- -c /path/to/moonraker.conf\
+  This allows the user to specify the path to Moonraker's config file.
+  The default location is "/home/<user>/moonraker.conf".
 
 When the script completes it should start both Moonraker and Klipper. In
 `klippy.log` you should find the following entry:\

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -262,33 +262,44 @@ gcode:
 Power Plugin Configuration.  One may use this module to toggle the
 state of a relay using a linux GPIO, enabling the ability to power
 a printer on/off regardless of Klippy's state.  GPIOs are toggled
-using linux sysfs.
+using libgpiod.  A configuration section should be added for each
+device as shown below:
 ```
-[power]
-devices: printer, led
-#   A comma separated list of devices you wish to control. Device names may not
-#   contain whitespace.  This parameter must be provided.
-#
-# Each device specified in "devices" should define its own set of the below
-# options:
-{dev}_name: Friendly Name
-#   An optional alias for the device. The default is the name specifed in
-#   "devices".
-{dev}_pin: 23
-#   The sysfs GPIO pin number you wish to control.  This parameter must be
-#   provided.
-{dev}_active_low: False
-#   When set to true the pin signal is inverted.  Default is False.
+[power device name]
+type: gpio
+#   The type of device.  Can be either gpio or tplink_smartplug.  This
+#   parameter must be provided.
+pin: gpiochip0/gpio26
+#   The pin to use for GPIO devices.  The chip is optional, if left out
+#   then the module will default to gpiochip0.  If one wishes to invert
+#   the signal, a "!" may be prefixed to the pin.  Valid examples:
+#      gpiochip0/gpio26
+#      gpio26
+#      !gpiochip0/gpio26
+#      !gpio26
+#    This parameter must be provided for "gpio" type devices
+address:
+port:
+#   The above options are used for "tplink_smartplug" devices.  The
+#   address should be a valid ip or hostname for the tplink device.
+#   The port should be the port the device is configured to use.  The
+#   address must be provided.  The port defaults to 9999.
+
 ```
+Below are some potential examples:
+```
+[power printer]
+type: gpio
+pin: gpio26
 
-Define the devices you wish to control under _devices_ with a comma separated
-list. For device specific configrations, swap {dev} for the name of the device
-that you listed under devices.
+[power printer_led]
+type: gpio
+pin: !gpiochip0/gpio16
 
-Each device can have a Friendly Name, pin, and activehigh set. Pin is the only
-required option. For devices that should be active when the signal is 0 or low,
-set {dev}_active_low to False, otherwise don't put the option in the
-configuration.
+[power wifi_switch]
+type: tplink_smartplug
+address: 192.168.1.123
+```
 
 It is possible to toggle device power from the Klippy host, this can be done
 with a gcode_macro, such as:

--- a/docs/user_changes.md
+++ b/docs/user_changes.md
@@ -1,0 +1,34 @@
+This file will track changes that require user intervention,
+such as a configuration change or a reinstallation.
+
+### November 19th 2020
+- The install script (`install_moonraker.sh`) now has command-line
+  options:\
+  `-r`   Rebuild the python virtual env\
+  `-f`   Force an overwrite of `/etc/default/moonraker` during installation\
+  `-c /path/to/moonraker.conf`    Allows user to specify the path to
+  moonraker.conf during configuration.  Using this in conjunction with `-f`
+  will update the defaults file wih the new path.
+- New dependencies have been added to Moonraker which require reinstallation.
+  Run the following command to reinstall and rebuild the virtualenv:
+  ```
+  ~/moonraker/scripts/install_moonraker.sh -r
+  ```
+- The power plugin configuration has changed.  See the
+  [install guide](installation.md#power-control-plugin) for
+  details on the new configuration.
+- Users transitioning from the previous version of the power plugin will need
+  to unexport any curently used pins.  For example, the following command
+  may be used to unexport pin 19:
+  ```
+  echo 19 > /sys/class/gpio/unexport
+  ```
+  Alternatively one may reboot the machine after upgrading:
+  ```
+  cd ~/moonraker/
+  git pull
+  ~/moonraker/scripts/install_moonraker.sh -r
+  sudo reboot
+  ```
+  Make sure that the power plugin configuration has been updated prior
+  to rebooting the machine.

--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -788,6 +788,84 @@ only be used once, making them relatively for inclusion in the query string.
   to any API endpoint.  The query string should be added in the form of:
   `?token=randomly_generated_token`
 
+## Power APIs
+The APIs below are available when the "power" plugin has been enabled.
+
+### Get Devices
+- HTTP command:\
+  `GET /machine/device_power/devices`
+
+- Websocket command:\
+  `{"jsonrpc":"2.0","method":"machine.device_power.devices","id":"1"}`
+
+- Returns:\
+  An array of objects containing info for each configured device.
+  ```json
+  {
+    devices: [
+      {
+        device: <device_name>,
+        status: <device_status>,
+        type: <device_type>
+      }, ...
+    ]
+  }
+  ```
+
+### Get Device Status
+- HTTP command:\
+  `GET /machine/device_power/status?dev_one&dev_two`
+
+- Websocket command:\
+  `{"jsonrpc":"2.0","method":"machine.device_power.status","id":"1",
+    "params":{"dev_one":null, "dev_two": null}}`
+
+- Returns:\
+  An object containing status for each requested device
+  ```json
+  {
+    dev_one: <device_status>,
+    dev_two: <device_status>,
+    ...
+  }
+  ```
+
+### Power On Device(s)
+- HTTP command:\
+  `POST /machine/device_power/on?dev_one&dev_two`
+
+- Websocket command:\
+  `{"jsonrpc":"2.0","method":"machine.device_power.on","id":"1",
+    "params":{"dev_one":null, "dev_two": null}}`
+
+- Returns:\
+  An object containing status for each requested device
+  ```json
+  {
+    dev_one: <device_status>,
+    dev_two: <device_status>,
+    ...
+  }
+  ```
+
+### Power Off Device(s)
+- HTTP command:\
+  `POST /machine/device_power/off?dev_one&dev_two`
+
+- Websocket command:\
+  `{"jsonrpc":"2.0","method":"machine.device_power.off","id":"1",
+    "params":{"dev_one":null, "dev_two": null}}`
+
+- Returns:\
+  An object containing status for each requested device
+  ```json
+  {
+    dev_one: <device_status>,
+    dev_two: <device_status>,
+    ...
+  }
+  ```
+
 ## Websocket notifications
 Printer generated events are sent over the websocket as JSON-RPC 2.0
 notifications.  These notifications are sent to all connected clients

--- a/moonraker/confighelper.py
+++ b/moonraker/confighelper.py
@@ -31,6 +31,12 @@ class ConfigHelper:
     def __contains__(self, key):
         return key in self.config
 
+    def get_name(self):
+        return self.section
+
+    def get_prefix_sections(self, prefix):
+        return [s for s in self.sections() if s.startswith(prefix)]
+
     def getsection(self, section):
         if section not in self.config:
             raise ConfigError(f"No section [{section}] in config")

--- a/moonraker/moonraker.py
+++ b/moonraker/moonraker.py
@@ -100,7 +100,7 @@ class Server:
             self.load_plugin(config, plugin)
 
         # check for optional plugins
-        opt_sections = set(config.sections()) - \
+        opt_sections = set([s.split()[0] for s in config.sections()]) - \
             set(['server', 'authorization', 'cmd_args'])
         for section in opt_sections:
             self.load_plugin(config, section, None)
@@ -119,9 +119,12 @@ class Server:
             return default
         module = importlib.import_module("plugins." + plugin_name)
         try:
-            if plugin_name not in CORE_PLUGINS:
+            func_name = "load_plugin"
+            if hasattr(module, "load_plugin_multi"):
+                func_name = "load_plugin_multi"
+            if plugin_name not in CORE_PLUGINS and func_name == "load_plugin":
                 config = config[plugin_name]
-            load_func = getattr(module, "load_plugin")
+            load_func = getattr(module, func_name)
             plugin = load_func(config)
         except Exception:
             msg = f"Unable to load plugin ({plugin_name})"

--- a/moonraker/plugins/power.py
+++ b/moonraker/plugins/power.py
@@ -15,16 +15,16 @@ class PrinterPower:
     def __init__(self, config):
         self.server = config.get_server()
         self.server.register_endpoint(
-            "/machine/gpio_power/devices", ['GET'],
+            "/machine/device_power/devices", ['GET'],
             self._handle_list_devices)
         self.server.register_endpoint(
-            "/machine/gpio_power/status", ['GET'],
+            "/machine/device_power/status", ['GET'],
             self._handle_power_request)
         self.server.register_endpoint(
-            "/machine/gpio_power/on", ['POST'],
+            "/machine/device_power/on", ['POST'],
             self._handle_power_request)
         self.server.register_endpoint(
-            "/machine/gpio_power/off", ['POST'],
+            "/machine/device_power/off", ['POST'],
             self._handle_power_request)
         self.server.register_remote_method(
             "set_device_power", self.set_device_power)
@@ -35,7 +35,12 @@ class PrinterPower:
         prefix_sections = config.get_prefix_sections("power")
         logging.info(f"Power plugin loading devices: {prefix_sections}")
         for section in prefix_sections:
-            dev = GpioDevice(config[section], self.chip_factory)
+            cfg = config[section]
+            dev_type = cfg.get("type")
+            if dev_type == "gpio":
+                dev = GpioDevice(cfg, self.chip_factory)
+            else:
+                raise config.error(f"Unsupported Device Type: {dev_type}")
             self.devices[dev.get_name()] = dev
 
     async def _handle_list_devices(self, web_request):

--- a/scripts/moonraker-requirements.txt
+++ b/scripts/moonraker-requirements.txt
@@ -1,4 +1,4 @@
 # Python dependencies for Moonraker
-tornado==6.0.4
+tornado==6.1.0
 pyserial==3.4
 pillow==8.0.1

--- a/test/client/js/main.js
+++ b/test/client/js/main.js
@@ -732,7 +732,8 @@ function handle_klippy_ready() {
 json_rpc.register_method("notify_klippy_ready", handle_klippy_ready);
 
 function handle_power_changed(power_status) {
-    console.log(`Power Changed: ${power_status}`);
+    console.log(`Power Changed:`);
+    console.log(power_status)
 }
 json_rpc.register_method("notify_power_changed", handle_power_changed);
 


### PR DESCRIPTION
This is a significant refactor of the power plugin two accomplish two goals:
- Switch from sysfs to libgpiod gpio management
- Implement native support for tplink smartplug devices

The first solves several potential issues that lingered with sysfs managment.  Using libgpoid gives moonraker exclusive access to a gpio and it automatically releases the line if moonraker restarts or stops.  When a gpio is set using libgpoid it is no additional query is necessary to determine if the operation was successful.  This makes behavior consistent, however users should be aware that restarting moonraker will likely result in connected devices powering off.

This change has introduced additional dependencies that require Moonraker be reinstalled and the virtualenv be rebuilt.  As such, new options have been added to `install-moonraker.sh`. This may be of interest to you @th33xitus:
- `-r`   Rebuild the python virtual env\
- `-f`   Force an overwrite of `/etc/default/moonraker` during installation\
- `-c /path/to/moonraker.conf`    Allows user to specify the path to moonraker.conf during configuration.  Using this in conjunction with `-f` will update the defaults file wih the new path.

Client developers should be aware that the path for the APIs has changed from `gpio_power` to `device_power`.  The behavior of the APIs has changed slightly, as documented in [api_changes.md](https://github.com/Arksine/moonraker/blob/7adedf64597311e45f8554d0dd2498fd68ce3502/docs/api_changes.md).

@jordanruthe @Aulos If you have any custom functionality you may want to take a look at this as well.  Some specific things to keep an eye on:
- Custom Device Implementations should be modeled after the GpioDevice class, the should specifically with the following methods.
  -  `get_name()` - must return the device name.  Cannot be async.
  -  `get_device_info()`  - must return a dict with `device`, `status`, and `type` fields.  Cannot be async
  - `initialize()` - If not necessary pass off the function. If this call fails the device status should be set to "error".
  - `refresh_status()` - If not necessary pass off the function. If this call fails the device status should be set to "error".
  - `set_power()` - must toggle device power.  If this call fails the device status should be set to "error".
- The `initialize()`, `refesh_status()` , and `set_power()` methods may be defined as async, but it is not required.
- The  `refresh_status()` method is not called if `set_power()` has been called.  The implementation of `set_power()` must update the device state after toggling power.

I plan to merge this rather soon, however I tagged interested parties so they could see this and be aware of it.  If anyone finds an issue after merging please feel free to create a PR or let me know about it.  Thanks.

Signed-off-by: Eric Callahan <arksine.code@gmail.com>