### PR TITLE
Tasmota power plugin

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -292,6 +292,9 @@ output_id:
 #   Provide a password if configured in Tasmota (default is empty). 
 #   Provided an output_id (relay id) if the Tasmota device supports
 #   more than one (default is 1).
+#   If your single-relay Tasmota device switches on/off successfully,
+#   but fails to report its state, ensure that 'SetOption26' is set in 
+#   Tasmota.
 
 ```
 Below are some potential examples:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -265,10 +265,10 @@ a printer on/off regardless of Klippy's state.  GPIOs are toggled
 using libgpiod.  A configuration section should be added for each
 device as shown below:
 ```
-[power device name]
+[power device_name]
 type: gpio
-#   The type of device.  Can be either gpio or tplink_smartplug.  This
-#   parameter must be provided.
+#   The type of device.  Can be either gpio, tplink_smartplug or tasmota.
+#   This parameter must be provided.
 pin: gpiochip0/gpio26
 #   The pin to use for GPIO devices.  The chip is optional, if left out
 #   then the module will default to gpiochip0.  If one wishes to invert
@@ -283,7 +283,15 @@ port:
 #   The above options are used for "tplink_smartplug" devices.  The
 #   address should be a valid ip or hostname for the tplink device.
 #   The port should be the port the device is configured to use.  The
-#   address must be provided.  The port defaults to 9999.
+#   address must be provided. The port defaults to 9999.
+address:
+password:
+output_id:
+#   The above options are used for "tasmota" devices.  The
+#   address should be a valid ip or hostname for the tasmota device.
+#   Provide a password if configured in Tasmota (default is empty). 
+#   Provided an output_id (relay id) if the Tasmota device supports
+#   more than one (default is 1).
 
 ```
 Below are some potential examples:
@@ -299,6 +307,11 @@ pin: !gpiochip0/gpio16
 [power wifi_switch]
 type: tplink_smartplug
 address: 192.168.1.123
+
+[power tasmota_plug]
+type: tasmota
+address: 192.168.1.124
+password: password1
 ```
 
 It is possible to toggle device power from the Klippy host, this can be done

--- a/moonraker/plugins/power.py
+++ b/moonraker/plugins/power.py
@@ -383,7 +383,7 @@ class Tasmota:
     async def refresh_status(self):
         try:
             res = await self._send_tasmota_command("info")
-            state = res[f"Power{self.output_id}"].lower()
+            state = res[f"POWER{self.output_id}"].lower()
         except Exception:
             self.state = "error"
             msg = f"Error Refeshing Device Status: {self.name}"
@@ -394,7 +394,7 @@ class Tasmota:
     async def set_power(self, state):
         try:
             res = await self._send_tasmota_command(state)
-            state = res[f"Power{self.output_id}"].lower()
+            state = res[f"POWER{self.output_id}"].lower()
         except Exception:
             self.state = "error"
             msg = f"Error Setting Device Status: {self.name} to {state}"


### PR DESCRIPTION
Based on the TPLinkSmartPlug, I added a power plugin for Tasmota switches. Switching the plug from fluidd works with the power macros from the documentation and it works in fluidd's Power menu to toggle the device.

Since this is the first time I'm working with Tornado/async, I'm happy to get feedback. Also, there is a bit of code duplication, this could probably be improved if additional power plugins are added in the future as well.

Signed-off-by:  Matthias Neumayr matt.neumayr@gmail.com