### PR TITLE
Add Klippers heater PWM value to /server/temperature_store

### DIFF
--- a/moonraker/plugins/data_store.py
+++ b/moonraker/plugins/data_store.py
@@ -66,9 +66,10 @@ class DataStore:
                 else:
                     new_store[sensor] = {
                         'temperatures': deque(maxlen=TEMPERATURE_STORE_SIZE),
-                        'targets': deque(maxlen=TEMPERATURE_STORE_SIZE)}
+                        'targets': deque(maxlen=TEMPERATURE_STORE_SIZE),
+                        'powers': deque(maxlen=TEMPERATURE_STORE_SIZE)}
                 if sensor not in self.last_temps:
-                    self.last_temps[sensor] = (0., 0.)
+                    self.last_temps[sensor] = (0., 0., 0.)
             self.temperature_store = new_store
             # Prune unconfigured sensors in self.last_temps
             for sensor in list(self.last_temps.keys()):
@@ -86,17 +87,19 @@ class DataStore:
     def _set_current_temps(self, data):
         for sensor in self.temperature_store:
             if sensor in data:
-                last_temp, last_target = self.last_temps[sensor]
+                last_temp, last_target, last_power  = self.last_temps[sensor]
                 self.last_temps[sensor] = (
                     round(data[sensor].get('temperature', last_temp), 2),
-                    data[sensor].get('target', last_target))
+                    data[sensor].get('target', last_target),
+                    data[sensor].get('power', last_power))
 
     def _update_temperature_store(self):
         # XXX - If klippy is not connected, set values to zero
         # as they are unknown?
-        for sensor, (temp, target) in self.last_temps.items():
+        for sensor, (temp, target, power) in self.last_temps.items():
             self.temperature_store[sensor]['temperatures'].append(temp)
             self.temperature_store[sensor]['targets'].append(target)
+            self.temperature_store[sensor]['powers'].append(power)
 
     async def _handle_temp_store_request(self, web_request):
         store = {}


### PR DESCRIPTION
As presented in #66, add the pwm output to temperature_store to make it available downstream. Now with a proper commit message! Sorry about the closing the previous PR, I'm a bit daft about how to change an already pushed commit message.