### PR TITLE
Cura Octoprint plugin support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,6 +95,17 @@ cors_domains:
 The sections outlined here are optional and enable additional
 functionality in moonraker.
 
+## Octoprint compatibility
+Enables partial support of Octoprint API is implemented with the purpose of
+allowing uploading of sliced prints to a mainsail instance.
+Currently we support Slic3r derivatives and Cura with Cura-Octoprint.
+
+```
+# moonraker.conf
+
+[octoprint_compat]
+```
+
 ## paneldue
 Enables PanelDue display support.  The PanelDue should be connected to the
 host machine, either via the machine's UART GPIOs or through a USB-TTL

--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -1284,6 +1284,195 @@ The APIs below are available when the `[power]` plugin has been configured.
   }
   ```
 
+## Octoprint API emulation
+Partial support of Octoprint API is implemented with the purpose of
+allowing uploading of sliced prints to a mainsail instance.
+Currently we support Slic3r derivatives and Cura with Cura-Octoprint.
+
+### Version information
+- HTTP command:\
+  `GET /api/version`
+
+- Returns:\
+  An object containing simulated Octoprint version information
+  ```json
+  {
+    server: "1.5.0",
+    api: "0.1",
+    text: "Octoprint (Moonraker v0.3.1-12)"
+  }
+  ```
+
+### Server status
+- HTTP command:\
+  `GET /api/server`
+
+- Returns:\
+  An object containing simulated Octoprint server status
+  ```json
+  {
+    server: "1.5.0",
+    safemode: <None or "settings">
+  }
+  ```
+
+### Login verification & User information
+- HTTP command:\
+  `GET /api/login`
+
+- HTTP command:\
+  `GET /api/server`
+
+- Returns:\
+  An object containing stubbed Octoprint login/user verification
+  ```json
+  {
+    _is_external_client: false,
+    _login_mechanism: "apikey",
+    name: "_api",
+    active: true,
+    user: true,
+    admin: true,
+    apikey: null,
+    permissions: [],
+    groups: ["admins", "users"],
+  }
+  ```
+
+### Get settings
+- HTTP command:\
+  `GET /api/server`
+
+- Returns:\
+  An object containing stubbed Octoprint settings.
+  The webcam route is hardcoded to Fluidd/Mainsail default path.
+  We say we have the UFP plugin installed so that Cura-Octoprint will
+  upload in the preferred UFP format.
+  ```json
+  {
+    plugins: {
+      UltimakerFormatPackage: {
+        align_inline_thumbnail: false,
+        inline_thumbnail: false,
+        inline_thumbnail_align_value: "left",
+        inline_thumbnail_scale_value: "50",
+        installed: true,
+        installed_version: "0.2.2",
+        scale_inline_thumbnail: false,
+        state_panel_thumbnail: true
+      }
+    },
+    feature: {
+      sdSupport: false,
+      temperatureGraph: false
+    },
+    webcam: {
+      flipH: false,
+      flipV: false,
+      rotate90: false,
+      streamUrl: "/webcam/?action=stream",
+      webcamEnabled': true
+    }
+  }
+  ```
+
+### File Upload
+- HTTP command:\
+  `POST /api/files/local`
+  Otherwise identical to the standard Moonraker `POST /server/files/upload` API.
+
+### Get Job status
+- HTTP command:\
+  `GET /api/job`
+
+- Returns:\
+  An object containing stubbed Octoprint Job status
+  ```json
+  {
+    job: {
+      file: {name: null},
+      estimatedPrintTime: null,
+      filament: {length: null},
+      user: None
+    },
+    progress: {
+      completion: null,
+      filepos: null,
+      printTime: null,
+      printTimeLeft: null,
+      printTimeOrigin: null
+    },
+    state: <One of "Offline","Error", "Operational", "Printing", "Paused">
+  }
+  ```
+
+### Get Printer status
+- HTTP command:\
+  `GET /api/printer`
+
+- Returns:\
+  An object containing Octoprint Printer status
+  ```json
+  {
+    temperature: {
+      <list of heater names: "bed", "tool<n>">: {
+        actual: <actual temp>,
+        offset: 0,
+        target: <target temp>
+      }
+    },
+    state: {
+      text': state,
+      flags': {
+        operational: <bool>,
+        paused: <bool>,
+        printing: <bool>,
+        cancelling: <bool>,
+        pausing: False,
+        error: <bool>,
+        ready: <bool>,
+        closedOrError: <bool>
+      }
+    }
+  }
+  ```
+
+### Send GCode command
+- HTTP command:\
+  `POST /api/printer/command`
+
+  JSON payload with parameter:
+  * commands: List of GCode strings
+
+- Returns:\
+  An blank JSON object
+  ```json
+  {}
+  ```
+
+### List Printer profiles
+- HTTP command:\
+  `GET /api/printerprofiles`
+
+- Returns:\
+  An object containing simulates Octoprint Printer profile
+  ```json
+  {
+    profiles: {
+      _default: {
+        id: "_default",
+        name: "Default",
+        color: "default",
+        model: "Default",
+        default': true,
+        current': true,
+        heatedBed: <true if "heater_bed" heater exists>,
+        heatedChamber: <true if "chamber" heater exists>
+      }
+    }
+  }
+  ```
+
 ## Websocket notifications
 Printer generated events are sent over the websocket as JSON-RPC 2.0
 notifications.  These notifications are sent to all connected clients

--- a/moonraker/app.py
+++ b/moonraker/app.py
@@ -169,14 +169,6 @@ class MoonrakerApp:
             params['is_remote'] = False
             self.mutable_router.add_handler(uri, DynamicRequestHandler, params)
             self.registered_base_handlers.append(uri)
-        if "http_octo" in protocol:
-            msg += f" - HTTP: ({' '.join(request_methods)}) {uri}"
-            params = {}
-            params['methods'] = request_methods
-            params['arg_parser'] = api_def.parser
-            params['callback'] = callback
-            self.mutable_router.add_handler(uri, LocalOctoRequestHandler, params)
-            self.registered_base_handlers.append(uri)
         if "websocket" in protocol:
             msg += f" - Websocket: {', '.join(api_def.ws_methods)}"
             self.wsm.register_local_handler(api_def, callback)
@@ -342,20 +334,6 @@ class DynamicRequestHandler(AuthorizedRequestHandler):
         if self.wrap_result:
             result = {'result': result}
         self.finish(result)
-
-class LocalOctoRequestHandler(LocalRequestHandler):
-    async def _process_http_request(self, method):
-        try:
-            args = json.loads(self.request.body)
-        except json.decoder.JSONDecodeError:
-            args = {}
-        try:
-            result = await self.callback(args)
-        except ServerError as e:
-            raise tornado.web.HTTPError(
-                e.status_code, str(e)) from e
-        self.finish(result)
-
 
 class FileRequestHandler(AuthorizedFileHandler):
     def set_extra_headers(self, path):

--- a/moonraker/moonraker.py
+++ b/moonraker/moonraker.py
@@ -30,7 +30,7 @@ MAX_LOG_ATTEMPTS = 10 * LOG_ATTEMPT_INTERVAL
 
 CORE_PLUGINS = [
     'database', 'file_manager', 'klippy_apis',
-    'machine', 'data_store', 'shell_command']
+    'machine', 'data_store', 'shell_command', 'octoprint_compat']
 
 class Sentinel:
     pass

--- a/moonraker/plugins/octoprint_compat.py
+++ b/moonraker/plugins/octoprint_compat.py
@@ -1,0 +1,280 @@
+# Octoprint API compatibility
+#
+# Copyright (C) 2021 Nickolas Grigoriadis <nagrigoriadis@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import logging
+
+import utils
+
+OCTO_VERSION = '1.5.0'
+
+
+class OctoprintCompat:
+    """
+    Minimal implementation of the REST API as described here:
+    https://docs.octoprint.org/en/master/api/index.html
+
+    So that Cura Octoprint plugin will function for:
+    * Handshake
+    * Upload gcode/ufp
+    * Webcam config
+    * Manual GCode submission
+    * Heater temperatures
+    """
+
+    def __init__(self, config):
+        self.server = config.get_server()
+
+        # Local variables
+        self.klippy_apis = None
+        self.heaters = []
+
+        # Register status update event
+        self.server.register_event_handler(
+            'server:klippy_ready', self._init)
+
+        # Version & Server information
+        self.server.register_endpoint(
+            '/api/version', ['GET'], self._get_version, protocol=['http_octo'])
+        self.server.register_endpoint(
+            '/api/server', ['GET'], self._get_server, protocol=['http_octo'])
+
+        # Login, User & Settings
+        self.server.register_endpoint(
+            '/api/login', ['POST'], self._post_login_user,
+            protocol=['http_octo'])
+        self.server.register_endpoint(
+            '/api/currentuser', ['GET'], self._post_login_user,
+            protocol=['http_octo'])
+        self.server.register_endpoint(
+            '/api/settings', ['GET'], self._get_settings,
+            protocol=['http_octo'])
+
+        # File operations
+        # Note that file upload is handled in file_manager.py
+        # TODO: List/info/select/delete files
+
+        # Job operations
+        self.server.register_endpoint(
+            '/api/job', ['GET'], self._get_job, protocol=['http_octo'])
+        # TODO: start/cancel/restart/pause jobs
+
+        # Printer operations
+        self.server.register_endpoint(
+            '/api/printer', ['GET'], self._get_printer, protocol=['http_octo'])
+        self.server.register_endpoint(
+            '/api/printer/command', ['POST'], self._post_command,
+            protocol=['http_octo'])
+        # TODO: head/tool/bed/chamber specific read/issue
+
+        # Printer profiles
+        self.server.register_endpoint(
+            '/api/printerprofiles', ['GET'], self._get_printerprofiles,
+            protocol=['http_octo'])
+
+        # System
+        # TODO: shutdown/reboot/restart operations
+
+    async def _init(self):
+        self.klippy_apis = self.server.lookup_plugin('klippy_apis')
+        # Fetch heaters
+        try:
+            result = await self.klippy_apis.query_objects({'heaters': None})
+        except self.server.error as e:
+            logging.info(f'Error Configuring heaters: {e}')
+            return
+        self.heaters = result.get('heaters', {}).get('available_sensors', [])
+
+    async def printer_state(self):
+        if not self.klippy_apis:
+            return 'Offline'
+        if self.server.klippy_state != 'ready':
+            return 'Error'
+        result = await self.klippy_apis.query_objects({'print_stats': None})
+        return {
+            'standby': 'Operational',
+            'printing': 'Printing',
+            'paused': 'Paused',
+            'complete': 'Operational'
+        }.get(result.get('state', 'standby'), 'Error')
+
+    async def printer_temps(self):
+        temps = {}
+        if not self.klippy_apis:
+            return temps
+        if self.heaters:
+            result = await self.klippy_apis.query_objects(
+                {heater: None for heater in self.heaters})
+            for heater in self.heaters:
+                data = result[heater]
+                name = 'bed'
+                if heater.startswith('extruder'):
+                    try:
+                        tool_no = int(heater[8:])
+                    except ValueError:
+                        tool_no = 0
+                    name = f'tool{tool_no}'
+
+                temps[name] = {
+                    'actual': int(data['temperature'] * 100.0) / 100.0,
+                    'offset': 0,
+                    'target': data['target'],
+                }
+        return temps
+
+    async def _get_version(self, args):
+        """
+        Version information
+        """
+        ver = utils.get_software_version()
+        return {
+            'server': OCTO_VERSION,
+            'api': '0.1',
+            'text': f'OctoPrint (Moonraker {ver})',
+        }
+
+    async def _get_server(self, args):
+        """
+        Server status
+        """
+        return {
+            'server': OCTO_VERSION,
+            'safemode': (
+                None if self.server.klippy_state == 'ready' else 'settings')
+        }
+
+    async def _post_login_user(self, args):
+        """
+        Confirm session login.
+
+        Since we only support apikey auth, do nothing.
+        Report hardcoded user called _api
+        """
+        return {
+            '_is_external_client': False,
+            '_login_mechanism': 'apikey',
+            'name': '_api',
+            'active': True,
+            'user': True,
+            'admin': True,
+            'apikey': None,
+            'permissions': [],
+            'groups': ['admins', 'users'],
+        }
+
+    async def _get_settings(self, args):
+        """
+        Used to parse Octoprint capabilities
+
+        Hardcode capabilities to be basically there and use default
+        fluid/mainsail webcam path.
+        """
+        return {
+            'plugins': {
+                'UltimakerFormatPackage': {
+                    'align_inline_thumbnail': False,
+                    'inline_thumbnail': False,
+                    'inline_thumbnail_align_value': 'left',
+                    'inline_thumbnail_scale_value': '50',
+                    'installed': True,
+                    'installed_version': '0.2.2',
+                    'scale_inline_thumbnail': False,
+                    'state_panel_thumbnail': True,
+                },
+            },
+            'feature': {
+                'sdSupport': False,
+                'temperatureGraph': False
+            },
+            # TODO: Get webcam settings from config file to allow user
+            #       to customise this.
+            'webcam': {
+                'flipH': False,
+                'flipV': False,
+                'rotate90': False,
+                'streamUrl': '/webcam/?action=stream',
+                'webcamEnabled': True,
+            },
+        }
+
+    async def _get_job(self, args):
+        """
+        Get current job status
+        """
+        return {
+            'job': {
+                'file': {'name': None,},
+                'estimatedPrintTime': None,
+                'filament': {'length': None},
+                'user': None,
+            },
+            'progress': {
+                'completion': None,
+                'filepos': None,
+                'printTime': None,
+                'printTimeLeft': None,
+                'printTimeOrigin': None,
+            },
+            'state': await self.printer_state()
+        }
+
+    async def _get_printer(self, args):
+        """
+        Get Printer status
+        """
+        state = await self.printer_state()
+        return {
+            'temperature': await self.printer_temps(),
+            'state': {
+                'text': state,
+                'flags': {
+                    'operational': state not in ['Error', 'Offline'],
+                    'paused': state == 'Paused',
+                    'printing': state == 'Printing',
+                    'cancelling': state == 'Cancelling',
+                    'pausing': False,
+                    'error': state == 'Error',
+                    'ready': state == 'Operational',
+                    'closedOrError': state in ['Error', 'Offline'],
+                },
+            },
+        }
+
+    async def _post_command(self, args):
+        """
+        Request to run some gcode command
+        """
+        commands = args.get('commands', [])
+        for command in commands:
+            logging.info(f'Executing GCode: {command}')
+            try:
+                    await self.klippy_apis.run_gcode(command)
+            except self.server.error:
+                msg = f"Error executing GCode {command}"
+                logging.exception(msg)
+
+        return {}
+
+    async def _get_printerprofiles(self, args):
+        """
+        Get Printer profiles
+        """
+        return {
+            'profiles': {
+                '_default': {
+                    'id': '_default',
+                    'name': 'Default',
+                    'color': 'default',
+                    'model': 'Default',
+                    'default': True,
+                    'current': True,
+                    'heatedBed': 'heater_bed' in self.heaters,
+                    'heatedChamber': 'chamber' in self.heaters,
+                }
+            }
+        }
+
+
+def load_plugin(config):
+    return OctoprintCompat(config)


### PR DESCRIPTION
This PR is a minimal implementation of the Octoprint REST API that is required for Cura to be able to establish a connection and  send gcode/UFP files to moonraker without errors. Currently it only supports the "global apikey authentication" method.

I didn't implement all the API's, as this will now meet my requirements.
Some functionality that the Cura plugin supports that I have not implemented:
* "Selecting" a print (not applicable)
* Starting a print
* Monitoring print progress

I tried to keep this PR as non intrusive as possible.

DONE:
* [x] Connection handshake
* [x] Printer status (errored or not)
* [x] Heater info
* [x] Simulate an Octoprint plugin to allow UFP upload (so images come along)
* [x] Documentation 