### PR TITLE
expand user in path

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -348,7 +348,9 @@ updating.
 [update_manager client service_name]
 type: git_repo
 path:
-#   The path to the client's files on disk.  This parameter must be provided.
+#   The absolute path to the client's files on disk. This parameter must be provided.
+#   Example:
+#     path: ~/service_name
 origin:
 #   The full GitHub URL of the "origin" remote for the repository.  This can
 #   be be viewed by navigating to your repository and running:

--- a/moonraker/plugins/update_manager.py
+++ b/moonraker/plugins/update_manager.py
@@ -420,7 +420,7 @@ class GitUpdater:
         self.owner = "?"
         self.repo_path = path
         if path is None:
-            self.repo_path = config.get('path')
+            self.repo_path = os.path.expanduser(config.get('path'))
         self.env = config.get("env", env)
         dist_packages = None
         if self.env is not None:


### PR DESCRIPTION
update_manager: expand user in path

An initial component of `~` or `~user` replaced by that user’s home directory.

Signed-off-by:  Eugene Rush <rush.zlo@gmail.com>