### PR TITLE
docs: fix incorrect wording. 'mainsail' should correctly read 'moonraker'

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,7 +97,7 @@ functionality in moonraker.
 
 ## Octoprint compatibility
 Enables partial support of Octoprint API is implemented with the purpose of
-allowing uploading of sliced prints to a mainsail instance.
+allowing uploading of sliced prints to a moonraker instance.
 Currently we support Slic3r derivatives and Cura with Cura-Octoprint.
 
 ```

--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -1420,7 +1420,7 @@ The APIs below are available when the `[power]` plugin has been configured.
 
 ## Octoprint API emulation
 Partial support of Octoprint API is implemented with the purpose of
-allowing uploading of sliced prints to a mainsail instance.
+allowing uploading of sliced prints to a moonraker instance.
 Currently we support Slic3r derivatives and Cura with Cura-Octoprint.
 
 ### Version information


### PR DESCRIPTION
Fixes a small technically incorrect wording in configuration.md and web_api.md. G-code files are uploaded to a moonraker instance and not to a mainsail instance.