### PR TITLE
power: Add CMD device to allow using shell commands for power control

### DIFF
--- a/moonraker/plugins/power.py
+++ b/moonraker/plugins/power.py
@@ -558,6 +558,7 @@ class NeoPixel(PowerDevice):
         pass
 
     def set_all(self, color):
+        print("Set color", color)
         for i in range(self.neopixel.numPixels()):
             self.neopixel.setPixelColor(i, color)
         self.neopixel.show()

--- a/scripts/moonraker-requirements.txt
+++ b/scripts/moonraker-requirements.txt
@@ -4,3 +4,4 @@ pyserial==3.4
 pillow==8.0.1
 lmdb==1.1.1
 streaming-form-data==1.8.1
+rpi-ws281x==1.1.3


### PR DESCRIPTION
This adds a cmd "device" to the power module to allow running shell scripts to check for status and power on/off the printer.
It is configured  as follows:

```
[power printer]
type: cmd
on: /my/shell/script.sh arguments go here
off: /my/other/script.sh arguments go here
status: /my/third/script.sh arguments go here
```

The `status` script is expected to indicate current printer status via exit code.
Code 0 means "on", code 1 means "off", any other code triggers an error.
This follows (mostly) the usage of the PSU control OctoPrint plugin (as to make scripts port easier).