### PR TITLE
power: Add NeoPixel control for RasPi

### DIFF
--- a/scripts/moonraker-requirements.txt
+++ b/scripts/moonraker-requirements.txt
@@ -4,3 +4,4 @@ pyserial==3.4
 pillow==8.0.1
 lmdb==1.1.1
 streaming-form-data==1.8.1
+rpi_ws281x==4.2.6


### PR DESCRIPTION
Make sure to read the instructions/warnings at https://pypi.org/project/rpi-ws281x/


As you indicated, you don't want shell scripts for security reasons, which is understandable, this is my attempt to bring the control I need directly into Moonraker (as opposed to calling out an external python script).
I understand if you don't want this either, as it is RasPi specific and adds an additional dependency.

I will also be contributing a HomeSeer (home automation system) integration as that is what I use to control the printer's power itself. That should be less of an open question as that is just "the usual" HTTP call-outs.


On another note, I am aware Klipper can control NeoPixels itself, however not on a RasPi (as a RasPi's GPIO is technically too slow to control them well, the rpi_ws281x module gets around this on certain pins by using DMA)