### PR TITLE
power.py: fix issue with single relay tasmota

### DIFF
--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -455,7 +455,13 @@ class Tasmota(PowerDevice):
     async def refresh_status(self):
         try:
             res = await self._send_tasmota_command("info")
-            state = res[f"POWER{self.output_id}"].lower()
+            try: 
+                state = res[f"POWER{self.output_id}"].lower()
+            except KeyError as e:
+                if self.output_id == 1 :
+                    state = res[f"POWER"].lower()
+                else:
+                    raise KeyError(e)
         except Exception:
             self.state = "error"
             msg = f"Error Refeshing Device Status: {self.name}"
@@ -466,7 +472,13 @@ class Tasmota(PowerDevice):
     async def set_power(self, state):
         try:
             res = await self._send_tasmota_command(state)
-            state = res[f"POWER{self.output_id}"].lower()
+            try: 
+                state = res[f"POWER{self.output_id}"].lower()
+            except KeyError as e:
+                if self.output_id == 1 :
+                    state = res[f"POWER"].lower()
+                else:
+                    raise KeyError(e)
         except Exception:
             self.state = "error"
             msg = f"Error Setting Device Status: {self.name} to {state}"


### PR DESCRIPTION
add a check and handle consequently in case tasmota device is only one relay and would return a power value when asked a power1 value

Fixes #134 

Signed-off-by:  Arnaud Schaer <arnaud.schaer@wanadoo.fr>