### PR TITLE
machine.py : allow user shutdown and reboot scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 *.py[cod]
 *$py.class
+scripts/pre_*_sequence.sh

--- a/moonraker/components/machine.py
+++ b/moonraker/components/machine.py
@@ -4,6 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 import logging
+import os
 from tornado.ioloop import IOLoop
 
 ALLOWED_SERVICES = ["moonraker", "klipper", "webcamd"]
@@ -42,9 +43,17 @@ class Machine:
         return "ok"
 
     async def shutdown_machine(self):
+        myfile = os.path.join(
+            os.path.dirname(__file__),'../../scripts/pre_shutdown_sequence.sh' )
+        if os.path.isfile(myfile) and os.access(myfile, os.X_OK):
+            await self._execute_cmd("bash -c " + myfile)
         await self._execute_cmd("sudo shutdown now")
 
     async def reboot_machine(self):
+        myfile = os.path.join(
+            os.path.dirname(__file__),'../../scripts/pre_reboot_sequence.sh' )
+        if os.path.isfile(myfile) and os.access(myfile, os.X_OK):
+            await self._execute_cmd("bash -c " + myfile)        
         await self._execute_cmd("sudo shutdown -r now")
 
     async def do_service_action(self, action, service_name):


### PR DESCRIPTION
add the ability for a user to alter the default behaviour when using the API to reboot or poweroff the host by executing shell scripts if present :

- scripts/pre_shutdown_sequence.sh
- scripts/pre_reboot_sequence.sh

files must be executable.

it is mainly useful for "last will" commands, for example if you want to tell your home automation software that the host (pi) is going to shutdown, and it can switch the smartplug "off" in some time


if you are open to this change, I suppose that some doc/example should be modified too (I personnaly need this to shutdown the smartplug after I shutdown the printer, as I can change OS systemd scripts, but that is un-reliable and one time out of 2, my home automation is not aware of the printer shutdown - the curl does not fire before network shutdown)

