### PR TITLE
power.py add parameter timer

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -219,6 +219,7 @@ port:
 address:
 password:
 output_id:
+timer:
 #   The above options are used for "tasmota" devices.  The
 #   address should be a valid ip or hostname for the tasmota device.
 #   Provide a password if configured in Tasmota (default is empty).
@@ -231,12 +232,16 @@ address:
 user:
 password:
 output_id:
+timer:
 #   The above options are used for "shelly" devices.  The
 #   address should be a valid ip or hostname for the Shelly device.
 #   Provide a user and password if configured in Shelly (default is empty).
 #   If password is set but user is empty the default user "admin" will be used
 #   Provided an output_id (relay id) if the Shelly device supports
 #   more than one (default is 0).
+#   When timer option is used to delay the turn off make sure to set
+#   the state to "on" in action call_remote_method.
+#   So we send a command to turn it on for x sec when its already on then it turns off.
 address:
 device:
 user:

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -427,7 +427,6 @@ class Tasmota(PowerDevice):
             out_cmd = f"Power{self.output_id}%20{command}"
             if self.timer != "" and command == "off":
                 out_cmd = f"Backlog%20Delay%20{self.timer}0%3B%20{out_cmd}"
-            else:
         elif command == "info":
             out_cmd = f"Power{self.output_id}"
         else:

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -420,10 +420,14 @@ class Tasmota(PowerDevice):
         self.addr = config.get("address")
         self.output_id = config.getint("output_id", 1)
         self.password = config.get("password", "")
+        self.timer = config.get("timer","")
 
     async def _send_tasmota_command(self, command, password=None):
         if command in ["on", "off"]:
-            out_cmd = f"Power{self.output_id}%20{command}"
+            if self.timer != "" and command == "off":
+                out_cmd = f"Backlog%20Delay%20{self.timer}0%3B%20Power{self.output_id}%20{command}"
+            else:
+                out_cmd = f"Power{self.output_id}%20{command}"
         elif command == "info":
             out_cmd = f"Power{self.output_id}"
         else:
@@ -471,13 +475,14 @@ class Tasmota(PowerDevice):
     async def set_power(self, state):
         try:
             res = await self._send_tasmota_command(state)
-            try: 
-                state = res[f"POWER{self.output_id}"].lower()
-            except KeyError as e:
-                if self.output_id == 1 :
-                    state = res[f"POWER"].lower()
-                else:
-                    raise KeyError(e)
+            if self.timer == "" or state != "off":
+                try: 
+                    state = res[f"POWER{self.output_id}"].lower()
+                except KeyError as e:
+                    if self.output_id == 1 :
+                        state = res[f"POWER"].lower()
+                    else:
+                        raise KeyError(e)
         except Exception:
             self.state = "error"
             msg = f"Error Setting Device Status: {self.name} to {state}"
@@ -494,10 +499,14 @@ class Shelly(PowerDevice):
         self.output_id = config.getint("output_id", 0)
         self.user = config.get("user", "admin")
         self.password = config.get("password", "")
+        self.timer = config.get("timer","")
 
     async def _send_shelly_command(self, command):
         if command in ["on", "off"]:
-            out_cmd = f"relay/{self.output_id}?turn={command}"
+            if self.timer != "":
+                out_cmd = f"relay/{self.output_id}?turn={command}&timer={self.timer}"
+            else:
+                out_cmd = f"relay/{self.output_id}?turn={command}"
         elif command == "info":
             out_cmd = f"relay/{self.output_id}"
         else:

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -424,10 +424,10 @@ class Tasmota(PowerDevice):
 
     async def _send_tasmota_command(self, command, password=None):
         if command in ["on", "off"]:
+            out_cmd = f"Power{self.output_id}%20{command}"
             if self.timer != "" and command == "off":
-                out_cmd = f"Backlog%20Delay%20{self.timer}0%3B%20Power{self.output_id}%20{command}"
+                out_cmd = f"Backlog%20Delay%20{self.timer}0%3B%20{out_cmd}"
             else:
-                out_cmd = f"Power{self.output_id}%20{command}"
         elif command == "info":
             out_cmd = f"Power{self.output_id}"
         else:


### PR DESCRIPTION
Adds a timer parameter to shelly and tasmota integration.

Use case: 3D printer mains power is connected to one of these devices. 
Just turning off the smart switch will kill power to the RaspberryPI. 
Adding a timer will allow the PI to shutdown cleanly before killing the power.

Example for Shelly:
printer.cfg
```
[idle_timeout]
timeout: 1800
gcode:
  TURN_OFF_MOTORS
  TURN_OFF_HEATERS
  LIGHT_OFF
  UPDATE_DELAYED_GCODE ID=delayed_printer_off DURATION=60

[gcode_macro POWER_OFF_SHELLY]
gcode:
  {action_call_remote_method("set_device_power", device="shelly_plug", state="on")}

[gcode_macro POWER_OFF_PRINTER]
gcode:
  POWER_OFF_SHELLY
  {action_call_remote_method("shutdown_machine")}


[delayed_gcode delayed_printer_off]
initial_duration: 0.
gcode:
  {% if printer.idle_timeout.state == "Idle" %}
    POWER_OFF_PRINTER
  {% endif %}
```
(yes state=on is correct here)

moonraker.conf
```
[power shelly_plug]
type: shelly
address: 192.168.1.x
timer: 15
```


Example for Tasmota:

printer.cfg
```
[idle_timeout]
timeout: 1800
gcode:
  TURN_OFF_MOTORS
  TURN_OFF_HEATERS
  LIGHT_OFF
  UPDATE_DELAYED_GCODE ID=delayed_printer_off DURATION=60


[gcode_macro POWER_OFF_TASMOTA]
gcode:
  {action_call_remote_method("set_device_power", device="tasmota_plug", state="off")}

[gcode_macro POWER_OFF_PRINTER]
gcode:
  POWER_OFF_TASMOTA
  {action_call_remote_method("shutdown_machine")}


[delayed_gcode delayed_printer_off]
initial_duration: 0.
gcode:
  {% if printer.idle_timeout.state == "Idle" %}
    POWER_OFF_PRINTER
  {% endif %}

 ```
moonraker.conf
```
[power tasmota_plug]
type: tasmota
address: 192.168.1.x
timer: 15
```


Signed-off-by: Dominik Weis fsironman@gmail.com