### PR TITLE
extract_metadata: assign correct data parameter

### DIFF
--- a/scripts/extract_metadata.py
+++ b/scripts/extract_metadata.py
@@ -521,7 +521,7 @@ class IdeaMaker(BaseSlicer):
 
     def parse_filament_total(self):
         filament = _regex_find_floats(
-            r";Material.\d\sUsed:.*", self.header_data, strict=True)
+            r";Material.\d\sUsed:.*", self.footer_data, strict=True)
         if filament:
             return sum(filament)
         return None


### PR DESCRIPTION
This should fix an issue where the total filament of g-code files generated by ideaMaker is not parsed correctly and therefore can't be displayed by clients.

![screenshot](http://puu.sh/Hx4Zu/9c093bf93e.png)

For testing purposes, here an example g-code created by ideaMaker 3.6.1.
[ideamaker_3.6.1.gcode.zip](https://github.com/Arksine/moonraker/files/6290062/ideamaker_3.6.1.gcode.zip)
