### PR TITLE
extract_metadata: parse filament_weight_total

### DIFF
--- a/scripts/extract_metadata.py
+++ b/scripts/extract_metadata.py
@@ -323,6 +323,10 @@ class Cura(PrusaSlicer):
             filament *= 1000
         return filament
 
+    def parse_filament_weight_total(self):
+        return _regex_find_first(
+            r";Filament\sweight\s=\s.(\d+\.\d+).", self.header_data)
+
     def parse_estimated_time(self):
         return self._parse_max_float(r";TIME:.*", self.header_data)
 

--- a/scripts/extract_metadata.py
+++ b/scripts/extract_metadata.py
@@ -282,6 +282,17 @@ class Slic3r(Slic3rPE):
             }
         return None
 
+    def parse_filament_total(self):
+        filament = _regex_find_first(
+            r";\sfilament\_length\_m\s=\s(\d+\.\d*)", self.footer_data)
+        if filament is not None:
+            filament *= 1000
+        return filament
+
+    def parse_filament_weight_total(self):
+        return _regex_find_first(
+            r";\sfilament\smass\_g\s=\s(\d+\.\d*)", self.footer_data)
+
     def parse_estimated_time(self):
         return None
 


### PR DESCRIPTION
There was a request of adding filament weight as an additional key for clients to work with as can be seen here: https://discord.com/channels/758059413700345988/826580737154089051/829425183168135189

A new key `filament_weight_total` was defined clients can access.
Supports G-Code from:
 - PrusaSlicer
 - SuperSlicer
 - Slic3r
 - Simplify3D
 - ideaMaker
 - Cura

**Note:**
Cura offers a special placeholder for the filament weight that was used here.
This requires the user to have a specific comment in the start g-code section defined:
`;Filament weight = {filament_weight}`

**Client developers should mention this requirement in their documentation.**

---

Additional change:
- Added parsing of `filament_total` for Slic3r