### PR TITLE
power: Fix Shelly behavior when a timer is configured

### DIFF
--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -507,7 +507,7 @@ class Shelly(PowerDevice):
             if self.timer != "":
                 out_cmd = f"relay/{self.output_id}?turn=on&timer={self.timer}"
             else:
-                out_cmd = f"relay/{self.output_id}?turn={command}&timer={self.timer}"
+                out_cmd = f"relay/{self.output_id}?turn={command}"
         elif command == "info":
             out_cmd = f"relay/{self.output_id}"
         else:

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -97,10 +97,10 @@ class PrinterPower:
         ep = web_request.get_endpoint()
         if not args:
             raise self.server.error("No arguments provided")
-        requsted_devs = {k: self.devices.get(k, None) for k in args}
+        requested_devs = {k: self.devices.get(k, None) for k in args}
         result = {}
         req = ep.split("/")[-1]
-        for name, device in requsted_devs.items():
+        for name, device in requested_devs.items():
             if device is not None:
                 result[name] = await self._process_request(device, req)
             else:


### PR DESCRIPTION
As pointed out in #146, when having a timer set up for a Shelly power device, its behavior can be a bit weird.

For instance, if the device is off and one turns it on, the timer kicks in after a defined time and turns the device back off. This is probably not desirable when said power device controls the printer itself.

That's why the Shelly device now ignores the timer when the state is being set to _on_.

If applied in its simplest form however, my fix exposes a different issue: when powering off with a timer, the device responds with an "on" state anyway, so the client (mainsail in my case, what else is there anyway 😄 ) thinks it's still on too, and this state is kept that way until moonraker is restarted.

So I decided to make the Shelly device lie a little bit: If the off timer is ongoing and the device is still on, the state is reported as _off_. That way the client is updated on the more-or-less current state and the user can for example reverse the decision and power the device back on.

Perhaps moonraker's power component should expose the timer state so the clients can be aware of the states in-between?

cc @fsironman 