### PR TITLE
file_manager:  add support for external file events via inotify

### DIFF
--- a/docs/api_changes.md
+++ b/docs/api_changes.md
@@ -1,6 +1,48 @@
 ##
 This document keeps a record of all changes to Moonraker's web APIs.
 
+### May 8th 2021
+- The `file_manager` has been refactored to support system file
+  file events through `inotify`.  Only mutable `roots` are monitored,
+  (currently `gcodes` and `config`).  Subfolders within these
+  these roots are also monitored, however hidden folders are not.
+  The following changes API changes have been made to acccommodate
+  this functionality:
+    - The `notify_filelist_changed` actions have changed.  The new
+      actions are as follows:
+        - `create_file`: sent when a new file has been created.  This
+          includes file uploads and copied files.
+        - `create_dir`: sent when a new directory has been created.
+        - `delete_file`: sent when a file has been deleted.
+        - `delete_dir`: sent when a directory has been deleted.
+        - `move_file`: sent when a file has moved.
+        - `move_dir`: sent when a directory has moved.
+        - `modify_file`: sent when an existing file has been modified
+        - `root_update`: sent when a root directory location has been set.
+          For example, if a user changes the gcode path in Klipper, this
+          action is sent with a `notify_filelist_changed` notification.
+    - File list notifications for gcode files are now only sent after
+      all metadata has been processed.  Likewise, requests to copy,
+      move, or upload a file will only return after metadata has been
+      processed.  Notifications are synced with requests so that the
+      request should always return before the notification is sent.
+    - Thumbnails are now stored in the `.thumbs` directory to prevent
+      changes to thumbnails from emitting filelist notications. This
+      change will be reflected in the metadata's `relative_path` field,
+      so clients that use this field should not need to take additional
+      action.  Note that existing thumbnails will remain in the `thumbs`
+      directory and filelist notifications will be sent for changes to
+      these thumbnails.
+    - The `notify_metadata_update` notification has been removed  Clients
+    - can reliably expect metadata to be available for new or moved gcode
+      files when a request returns.
+    - The return values for several endpoints have been updated.  They
+      now contain information similar to that which is pushed by the
+      `notify_filelist_changed` notification.
+- The deprecated `data` field in gcode metadata has been removed.
+  The `size` field now returns the size of the `.png` file.
+
+
 ### March 15th 2021
 - The `data` field for gcode thumbnails is now deprecated and will
   be removed in the near future.  Thumbnails are now saved to png

--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -1158,15 +1158,13 @@ modified time, and size.
             "width": 32,
             "height": 32,
             "size": 2596,
-            "data": "{base64_data}"
-            "relative_path": "thumbs/3DBenchy_0.15mm_PLA_MK3S_2h6m-32x32.png"
+            "relative_path": ".thumbs/3DBenchy_0.15mm_PLA_MK3S_2h6m-32x32.png"
         },
         {
             "width": 400,
             "height": 300,
             "size": 73308,
-            "data": "{base64_data}",
-            "relative_path": "thumbs/3DBenchy_0.15mm_PLA_MK3S_2h6m-400x300.png"
+            "relative_path": "lthumbs/3DBenchy_0.15mm_PLA_MK3S_2h6m-400x300.png"
         }
     ],
     "first_layer_bed_temp": 60,
@@ -1180,11 +1178,6 @@ modified time, and size.
     The `print_start_time` and `job_id` fields are initialized to
     `null`.  They will be updated for each print job if the user has the
     `[history]` component configured
-
-!!! warning
-    The `data` field for each thumbnail is deprecated and will be removed
-    in a future release.  Clients should retrieve the png directly using the
-    `relative_path` field.
 
 #### Get directory information
 Returns a list of files and subdirectories given a supplied path.
@@ -1285,9 +1278,16 @@ JSON-RPC request:
 }
 ```
 
-Returns:
-
-`ok`
+Returns: Information about the created directory
+```json
+{
+    "item": {
+        "path": "gcodes/testdir",
+        "root": "gcodes"
+    },
+    "action": "create_dir"
+}
+```
 
 #### Delete directory
 Deletes a directory at the specified path.
@@ -1312,9 +1312,16 @@ JSON-RPC request:
     If the specified directory contains files then the delete request
     will fail unless the `force` argument is set to `true`.
 
-Returns:
-
-`ok`
+Returns:  Information about the deleted directory
+```json
+{
+    "item": {
+        "path": "gcodes/testdir",
+        "root": "gcodes"
+    },
+    "action": "delete_dir"
+}
+```
 
 #### Move a file or directory
 Moves a file or directory from one location to another. The following
@@ -1351,9 +1358,22 @@ JSON-RPC request:
 }
 ```
 
-Returns:
-
-`ok`
+Returns:  Information about the moved file or directory
+```json
+{
+    "result": {
+        "item": {
+            "root": "gcodes",
+            "path": "test4/test3"
+        },
+        "source_item": {
+            "path": "gcodes/test4/test3",
+            "root": "gcodes"
+        },
+        "action": "move_dir"
+    }
+}
+```
 
 #### Copy a file or directory
 Copies a file or directory from one location to another.  A successful copy has
@@ -1378,9 +1398,16 @@ JSON-RPC request:
 }
 ```
 
-Returns:
-
-`ok`
+Returns: Information about the copied file or directory
+```json
+{
+    "item": {
+        "root": "gcodes",
+        "path": "test4/Voron_v2_350_aferburner_Filament Cover_0.2mm_ABS.gcode"
+    },
+    "action": "create_file"
+}
+```
 
 #### File download
 Retreives file `filename` at root `root`.  The `filename` must include
@@ -1439,21 +1466,16 @@ Arguments available only for the `gcodes` root:
 
 JSON-RPC request: Not Available
 
-Returns:
-
-The name of the uploaded file.
+Returns:  Information about the uploaded file.  Note that `print_started`
+is only included when the supplied root is set to `gcodes`.
 ```json
 {
-    "result": "{file_name}"
-}
-```
-
-If the supplied root is "gcodes", a "print_started" field is also
-returned.
-```json
-{
-    "result": "{file_name}",
-    "print_started": false
+    "item": {
+        "path": "Lock Body Shim 1mm_0.2mm_FLEX_MK3S_2h30m.gcode",
+        "root": "gcodes"
+    },
+    "print_started": false,
+    "action": "create_file"
 }
 ```
 
@@ -1476,9 +1498,16 @@ JSON-RPC request:
     "id": 1323
 }
 ```
-Returns:
-
-The name of the deleted file
+Returns:  Information about the deleted file
+```json
+{
+    "item": {
+        "path": "Lock Body Shim 1mm_0.2mm_FLEX_MK3S_2h30m.gcode",
+        "root": "gcodes"
+    },
+    "action": "delete_file"
+}
+```
 
 #### Download klippy.log
 HTTP request:
@@ -2908,29 +2937,22 @@ to alert all connected clients of the change:
 }
 ```
 The `source_item` field is only present for `move_item` and
-`copy_item` actions.  The following `action` field will be set
+`copy_item` actions.  The `action` field will be set
 to one of the following values:
 
-- `upload_file`
-- `delete_file`
+- `create_file`
 - `create_dir`
+- `delete_file`
 - `delete_dir`
-- `move_item`
-- `copy_item`
+- `move_file`
+- `move_dir`
+- `modify_file`
+- `root_update`
 
-#### Metadata Update
-When a new file is uploaded via the API a websocket notification is broadcast
-to all connected clients after parsing is complete:
-```json
-{
-    "jsonrpc": "2.0",
-    "method": "notify_metadata_update",
-    "params": [{metadata}]
-}
-```
-
-Where `metadata` is an object matching that returned from a
-[gcode metadata request](#get-gcode-metadata).
+Most of the above actions are self explanatory.  The `root_update`
+notification is sent when a `root` folder has changed its location,
+for example when a user configures a different gcode file path
+in Klipper.
 
 #### Update Manager Response
 The update manager will send asyncronous messages to the client during an

--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -1082,27 +1082,27 @@ A list of objects, where each object contains file data.
 ```json
 [
     {
-        "filename": "3DBenchy_0.15mm_PLA_MK3S_2h6m.gcode",
+        "path": "3DBenchy_0.15mm_PLA_MK3S_2h6m.gcode",
         "modified": 1615077020.2025201,
         "size": 4926481
     },
     {
-        "filename": "Shape-Box_0.2mm_PLA_Ender2_20m.gcode",
+        "path": "Shape-Box_0.2mm_PLA_Ender2_20m.gcode",
         "modified": 1614910966.946807,
         "size": 324236
     },
     {
-        "filename": "test_dir/A-Wing.gcode",
+        "path": "test_dir/A-Wing.gcode",
         "modified": 1605202259,
         "size": 1687387
     },
     {
-        "filename": "test_dir/CE2_CubeTest.gcode",
+        "path": "test_dir/CE2_CubeTest.gcode",
         "modified": 1614644445.4025,
         "size": 1467339
     },
     {
-        "filename": "test_dir/V350_Engine_Block_-_2_-_Scaled.gcode",
+        "path": "test_dir/V350_Engine_Block_-_2_-_Scaled.gcode",
         "modified": 1615768477.5133543,
         "size": 189713016
     },

--- a/moonraker/components/file_manager.py
+++ b/moonraker/components/file_manager.py
@@ -626,6 +626,8 @@ class INotifyHandler:
                 f"delete_{item_type}", root, item_path)
 
     def _remove_stale_cookie(self, cookie):
+        # This is a file or directory moved out of a watched parent.
+        # We treat this as a deleted file/directory.
         pending_evt = self.pending_move_events.pop(cookie, None)
         if pending_evt is None:
             # Event already processed
@@ -636,7 +638,11 @@ class INotifyHandler:
         item_type = "file"
         if is_dir:
             item_type = "dir"
-            self.remove_watch(prev_path)
+            for wpath in list(self.watches.keys()):
+                if wpath.startswith(prev_path):
+                    self.remove_watch(wpath)
+        # Metadata should have been cleared in the MOVE_TO event,
+        # so no need to clear it here
         self._notify_filelist_changed(
             f"delete_{item_type}", prev_root, prev_path)
 

--- a/moonraker/components/file_manager.py
+++ b/moonraker/components/file_manager.py
@@ -519,7 +519,7 @@ class FileManager:
         if list_format:
             flist = []
             for fname in sorted(filelist, key=str.lower):
-                fdict = {'filename': fname}
+                fdict = {'path': fname}
                 fdict.update(filelist[fname])
                 flist.append(fdict)
             return flist

--- a/moonraker/components/file_manager.py
+++ b/moonraker/components/file_manager.py
@@ -666,9 +666,7 @@ class InotifyNode:
             if os.path.isdir(item_path):
                 new_child = self.create_child_node(fname, False)
                 metadata_events.extend(new_child.scan_node(visited_dirs))
-            elif os.path.isfile(item_path) and \
-                    self.get_root() == "gcodes" and \
-                    ext in VALID_GCODE_EXTS:
+            elif os.path.isfile(item_path) and self.get_root() == "gcodes":
                 mevt = self.ihdlr.parse_gcode_metadata(item_path)
                 metadata_events.append(mevt)
         return metadata_events
@@ -988,13 +986,6 @@ class INotifyHandler:
 
     def parse_gcode_metadata(self, file_path):
         rel_path = self.file_manager.get_relative_path("gcodes", file_path)
-        if not rel_path:
-            logging.info(
-                f"File at path '{file_path}' is not in the gcode path"
-                ", metadata extraction aborted")
-            mevt = Event()
-            mevt.set()
-            return mevt
         path_info = self.file_manager.get_path_info(file_path)
         ext = os.path.splitext(file_path)[-1].lower()
         if ext == ".ufp":
@@ -1292,7 +1283,9 @@ class MetadataStorage:
 
     def parse_metadata(self, fname, path_info):
         mevt = Event()
+        ext = os.path.splitext(fname)[1]
         if fname in self.pending_requests or \
+                ext not in VALID_GCODE_EXTS or \
                 self._has_valid_data(fname, path_info):
             # request already pending or not necessary
             mevt.set()

--- a/moonraker/components/file_manager.py
+++ b/moonraker/components/file_manager.py
@@ -703,8 +703,8 @@ class INotifyHandler:
                 st = os.stat(full_path)
                 key = (st.st_dev, st.st_ino)
                 if key not in visited_dirs:
-                    # Don't watch "thumbs" directories in the gcodes root
-                    if not (root == "gcodes" and dname == "thumbs"):
+                    # Don't watch hidden directories
+                    if dname[0] != ".":
                         if moved_path is not None:
                             rel_path = os.path.relpath(
                                 full_path, start=dir_path)
@@ -777,8 +777,8 @@ class INotifyHandler:
                 self._process_file_event(evt, root, child_path)
 
     def _process_dir_event(self, evt, root, child_path):
-        if root == "gcodes" and evt.name == "thumbs":
-            # ignore changes to the thumbs directory
+        if evt.name and evt.name[0] == ".":
+            # ignore changes to the hidden directories
             return
         if evt.mask & iFlags.CREATE:
             logging.debug(f"Inotify directory create: {root}, {evt.name}")

--- a/moonraker/components/file_manager.py
+++ b/moonraker/components/file_manager.py
@@ -296,23 +296,10 @@ class FileManager:
                 ext = os.path.splitext(fname)[-1].lower()
                 gc_path = self.file_paths.get('gcodes', None)
                 if gc_path is not None and full_path.startswith(gc_path) and \
-                        ext in VALID_GCODE_EXTS:
-                    if ext == ".ufp":
-                        try:
-                            full_path = self.process_ufp_from_refresh(
-                                full_path)
-                        except Exception:
-                            logging.exception("Error processing ufp file")
-                            continue
-                        path_info = self.get_path_info(full_path)
-                        path_info['filename'] = os.path.split(full_path)[-1]
+                        ext in VALID_GCODE_EXTS and is_extended:
                     rel_path = os.path.relpath(full_path, start=gc_path)
-                    self.gcode_metadata.parse_metadata(
-                        rel_path, path_info['size'], path_info['modified'],
-                        notify=True)
-                    metadata = self.gcode_metadata.get(rel_path, None)
-                    if metadata is not None and is_extended:
-                        path_info.update(metadata)
+                    metadata = self.gcode_metadata.get(rel_path, {})
+                    path_info.update(metadata)
                 flist['files'].append(path_info)
         usage = shutil.disk_usage(path)
         flist['disk_usage'] = usage._asdict()
@@ -511,20 +498,11 @@ class FileManager:
                 if root == 'gcodes' and ext not in VALID_GCODE_EXTS:
                     continue
                 full_path = os.path.join(dir_path, name)
-                if root == 'gcodes' and ext == ".ufp":
-                    try:
-                        full_path = self.process_ufp_from_refresh(full_path)
-                    except Exception:
-                        logging.exception("Error processing ufp file")
-                        continue
                 if not os.path.exists(full_path):
                     continue
                 fname = full_path[len(path) + 1:]
                 finfo = self.get_path_info(full_path)
                 filelist[fname] = finfo
-                if root == 'gcodes':
-                    self.gcode_metadata.parse_metadata(
-                        fname, finfo['size'], finfo['modified'])
         if list_format:
             flist = []
             for fname in sorted(filelist, key=str.lower):

--- a/moonraker/components/file_manager.py
+++ b/moonraker/components/file_manager.py
@@ -131,6 +131,10 @@ class FileManager:
             if root in FULL_ACCESS_ROOTS:
                 # Refresh the file list and add watches
                 self.inotify_handler.add_root_watch(root, path)
+            else:
+                IOLoop.current().spawn_callback(
+                    self.inotify_handler.notify_filelist_changed,
+                    "root_update", root, path)
         return True
 
     def get_sd_directory(self):

--- a/scripts/extract_metadata.py
+++ b/scripts/extract_metadata.py
@@ -213,7 +213,7 @@ class PrusaSlicer(BaseSlicer):
             r"; thumbnail begin[;/\+=\w\s]+?; thumbnail end", self.header_data)
         if not thumb_matches:
             return None
-        thumb_dir = os.path.join(os.path.dirname(self.path), "thumbs")
+        thumb_dir = os.path.join(os.path.dirname(self.path), ".thumbs")
         if not os.path.exists(thumb_dir):
             try:
                 os.mkdir(thumb_dir)
@@ -238,7 +238,7 @@ class PrusaSlicer(BaseSlicer):
                 continue
             thumb_name = f"{thumb_base}-{info[0]}x{info[1]}.png"
             thumb_path = os.path.join(thumb_dir, thumb_name)
-            rel_thumb_path = os.path.join("thumbs", thumb_name)
+            rel_thumb_path = os.path.join(".thumbs", thumb_name)
             with open(thumb_path, "wb") as f:
                 f.write(base64.b64decode(data.encode()))
             parsed_matches.append({
@@ -355,11 +355,11 @@ class Cura(PrusaSlicer):
         if thumbs is not None:
             return thumbs
         # Check for thumbnails extracted from the ufp
-        thumb_dir = os.path.join(os.path.dirname(self.path), "thumbs")
+        thumb_dir = os.path.join(os.path.dirname(self.path), ".thumbs")
         thumb_base = os.path.splitext(os.path.basename(self.path))[0]
         thumb_path = os.path.join(thumb_dir, f"{thumb_base}.png")
-        rel_path_full = os.path.join("thumbs", f"{thumb_base}.png")
-        rel_path_small = os.path.join("thumbs", f"{thumb_base}-32x32.png")
+        rel_path_full = os.path.join(".thumbs", f"{thumb_base}.png")
+        rel_path_small = os.path.join(".thumbs", f"{thumb_base}-32x32.png")
         thumb_path_small = os.path.join(thumb_dir, f"{thumb_base}-32x32.png")
         if not os.path.isfile(thumb_path):
             return None

--- a/scripts/extract_metadata.py
+++ b/scripts/extract_metadata.py
@@ -249,7 +249,7 @@ class PrusaSlicer(BaseSlicer):
                 f.write(base64.b64decode(data.encode()))
             parsed_matches.append({
                 'width': info[0], 'height': info[1],
-                'size': info[2], 'data': data,
+                'size': os.path.getsize(thumb_path),
                 'relative_path': rel_thumb_path})
         return parsed_matches
 
@@ -372,28 +372,20 @@ class Cura(PrusaSlicer):
         # read file
         thumbs = []
         try:
-            with open(thumb_path, 'rb') as thumb_file:
-                fbytes = thumb_file.read()
-                with Image.open(io.BytesIO(fbytes)) as im:
-                    thumb_full_b64 = base64.b64encode(fbytes).decode()
-                    thumbs.append({
-                        'width': im.width, 'height': im.height,
-                        'size': len(thumb_full_b64), 'data': thumb_full_b64,
-                        'relative_path': rel_path_full
-                    })
-                    # Create 32x32 thumbnail
-                    im.thumbnail((32, 32), Image.ANTIALIAS)
-                    tmp_thumb = io.BytesIO()
-                    im.save(tmp_thumb, format="PNG")
-                    im.save(thumb_path_small, format="PNG")
-                    thumb_small_b64 = base64.b64encode(
-                        tmp_thumb.getbuffer()).decode()
-                    tmp_thumb.close()
-                    thumbs.insert(0, {
-                        'width': im.width, 'height': im.height,
-                        'size': len(thumb_small_b64), 'data': thumb_small_b64,
-                        'relative_path': rel_path_small
-                    })
+            with Image.open(thumb_path) as im:
+                thumbs.append({
+                    'width': im.width, 'height': im.height,
+                    'size': os.path.getsize(thumb_path),
+                    'relative_path': rel_path_full
+                })
+                # Create 32x32 thumbnail
+                im.thumbnail((32, 32), Image.ANTIALIAS)
+                im.save(thumb_path_small, format="PNG")
+                thumbs.insert(0, {
+                    'width': im.width, 'height': im.height,
+                    'size': os.path.getsize(thumb_path_small),
+                    'relative_path': rel_path_small
+                })
         except Exception as e:
             log_to_stderr(str(e))
             return None

--- a/scripts/moonraker-requirements.txt
+++ b/scripts/moonraker-requirements.txt
@@ -5,3 +5,4 @@ pillow==8.1.2
 lmdb==1.2.1
 streaming-form-data==1.8.1
 distro==1.5.0
+inotify-simple==1.3.5

--- a/test/client/js/main.js
+++ b/test/client/js/main.js
@@ -798,7 +798,7 @@ function handle_file_list_changed(file_info) {
     // Update the jstree based on the action and info
     let parent_node = parse_node_path(file_info.item.root, file_info.item.path);
     $("#filelist").jstree('refresh_node', parent_node);
-    if (file_info.action == "move_item") {
+    if (file_info.action.startsWith("move_")) {
         let src_parent_node = parse_node_path(
             file_info.source_item.root, file_info.source_item.path)
         if (src_parent_node != parent_node)


### PR DESCRIPTION
This is a proposal to add support for inotify events to Moonraker.  This amounts to a significant refactoring of the file_manager, so I want to slow roll merging this PR, with the option to abort if we feel that it could cause significant issues. 

From the Client API perspective the changes are rather mild, and mostly pertain to the `notify_filelist_changed` notification.  Specifically the actions have changes, as some of the exisiting actions do not make sense when dealing with inotify.  The [api_changes.md](https://github.com/Arksine/moonraker/blob/17f9eff89d13db9af11b958fda3b5b6d09a49ad5/docs/api_changes.md) document in this PR contains details on all the API changes in this pull request.  It may also be useful to look at the diff of `web_api.md`. 

As mentioned in the linked api_changes doc, there are some additional changes such as the removal of `notify_metadata_changed` and differences to the return values of some of the file operation requests.  Ultimately my goal with this is to create more consistency within the file manager API, where clients can expect a request to return before the a notification is received.  It also makes sense that if metadata processing is necessary then it should occur before a request returns, as the client is then free to request metadata for a file or directory after a notification has been received.

@meteyou @cadriel @jordanruthe 