### PR TITLE
Fix Home Assistant https support

### DIFF
--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -281,7 +281,8 @@ class HTTPDevice(PowerDevice):
                  config: ConfigHelper,
                  default_port: int = -1,
                  default_user: str = "",
-                 default_password: str = ""
+                 default_password: str = "",
+                 default_protocol: str = "http"
                  ) -> None:
         super().__init__(config)
         self.client = AsyncHTTPClient()
@@ -290,6 +291,7 @@ class HTTPDevice(PowerDevice):
         self.port = config.getint("port", default_port)
         self.user = config.get("user", default_user)
         self.password = config.get("password", default_password)
+        self.protocol = config.get("protocol", default_protocol)
 
     async def initialize(self) -> None:
         await self.refresh_status()
@@ -673,7 +675,7 @@ class HomeAssistant(HTTPDevice):
         else:
             raise self.server.error(
                 f"Invalid homeassistant command: {command}")
-        url = f"http://{self.addr}:{self.port}/{out_cmd}"
+        url = f"{self.protocol}://{self.addr}:{self.port}/{out_cmd}"
         headers = {
             'Authorization': f'Bearer {self.token}',
             'Content-Type': 'application/json'

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -699,8 +699,9 @@ class HomeAssistant(HTTPDevice):
         return res[f"state"]
 
     async def _send_power_request(self, state: str) -> str:
-        res = await self._send_homeassistant_command(state)
-        return res[0][f"state"]
+        await self._send_homeassistant_command(state)
+        res = await self._send_status_request()
+        return res
 
 class Loxonev1(HTTPDevice):
     def __init__(self, config: ConfigHelper) -> None:


### PR DESCRIPTION
My Home Assistant instance only uses https, and the existing code was hardcoded to http.

Added https support, and fixed a bug where it was expected Home Assistant would provide an updated status, but actually returns an empty body