### PR TITLE
Add support for different types of homeassistant switches

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -281,9 +281,11 @@ address:
 port:
 device:
 token:
+domain:
 #   The above options are used for "homeassistant" devices.  The
 #   address should be a valid ip or hostname for the homeassistant controller.
 #   "device" should be the ID of the switch to control.
+#   "domain" is the class of device set managed by homeassistant, defaults to "switch".
 address:
 user:
 password:
@@ -337,6 +339,7 @@ address: 192.168.1.126
 port: 8123
 device: switch.1234567890abcdefghij
 token: home-assistant-very-long-token
+domain: switch
 ```
 
 It is possible to toggle device power from the Klippy host, this can be done

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -657,16 +657,17 @@ class HomeAssistant(HTTPDevice):
         super().__init__(config, default_port=8123)
         self.device: str = config.get("device")
         self.token: str = config.get("token")
+        self.domain: str = config.get("domain", "switch")
 
     async def _send_homeassistant_command(self,
                                           command: str
                                           ) -> Dict[Union[str, int], Any]:
         if command == "on":
-            out_cmd = f"api/services/switch/turn_on"
+            out_cmd = f"api/services/{self.domain}/turn_on"
             body = {"entity_id": self.device}
             method = "POST"
         elif command == "off":
-            out_cmd = f"api/services/switch/turn_off"
+            out_cmd = f"api/services/{self.domain}/turn_off"
             body = {"entity_id": self.device}
             method = "POST"
         elif command == "info":


### PR DESCRIPTION
Phillips Hue exposes all switches to the "lights" domain on home assistant, that doesn't work with the current implementation as that is hard-coded to the "switch" domain. 
I added a small change to allowing changing to other domains but keep "switch" the default.