### PR TITLE
pause_resume: Make Moonraker to use `pause_resume/*` API

### DIFF
--- a/moonraker/components/klippy_apis.py
+++ b/moonraker/components/klippy_apis.py
@@ -60,13 +60,13 @@ class KlippyAPI(Subscribable):
             "/printer/firmware_restart", ['POST'], self._gcode_firmware_restart)
 
     async def _gcode_pause(self, web_request: WebRequest) -> str:
-        return await self.run_gcode("PAUSE")
+        return await self._send_klippy_request("pause_resume/pause", {})
 
     async def _gcode_resume(self, web_request: WebRequest) -> str:
-        return await self.run_gcode("RESUME")
+        return await self._send_klippy_request("pause_resume/resume", {})
 
     async def _gcode_cancel(self, web_request: WebRequest) -> str:
-        return await self.run_gcode("CANCEL_PRINT")
+        return await self._send_klippy_request("pause_resume/cancel", {})
 
     async def _gcode_start_print(self, web_request: WebRequest) -> str:
         filename: str = web_request.get_str('filename')


### PR DESCRIPTION
This switches Moonraker from calling `CANCEL_PRINT` and alikes
to rather use `pause_resume/` API that underneath calls
the relevant G-Codes.

This done, this way, allows Klipper to be able to interrupt
blocking operations gracefully.

Related:
- https://github.com/KevinOConnor/klipper/pull/4398
- This makes `Cancel of a print` (when called via API) to be immediate when during a heating phase

Signed-off-by: Kamil Trzcinski <ayufan@ayufan.eu>