### PR TITLE
Add `on_when_upload:` to `power`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -201,6 +201,9 @@ type: gpio
 #   The type of device.  Can be either gpio, tplink_smartplug, tasmota
 #   shelly, homeseer, homeassistant, or loxonev1.
 #   This parameter must be provided.
+on_when_upload: False
+#   If set to True, Moonraker will power on the device when a upload happens.
+#   The default is False, thus no attempt to start printer is being made.
 off_when_shutdown: False
 #   If set to True the device will be powered off when Klipper enters
 #   the "shutdown" state.  This option applies to all device types.

--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -522,6 +522,7 @@ included.
         "power green_led": {
             "type": "gpio",
             "locked_while_printing": false,
+            "on_when_upload": false,
             "off_when_shutdown": false,
             "restart_klipper_when_powered": false,
             "pin": "gpiochip0/gpio26",

--- a/moonraker/moonraker.py
+++ b/moonraker/moonraker.py
@@ -263,6 +263,17 @@ class Server:
     def get_klippy_state(self) -> str:
         return self.klippy_state
 
+    async def wait_for_klippy_ready(self, timeout: float = 30.) -> bool:
+        # Retry every 1s
+        end_time = time.time() + timeout
+        while self.get_klippy_state() != "ready" and time.time() < end_time:
+            try:
+                await asyncio.sleep(1.)
+            except asyncio.CancelledError:
+                break
+
+        return self.get_klippy_state() != "ready"
+
     # ***** Klippy Connection *****
     async def _connect_klippy(self) -> None:
         if not self.server_running:


### PR DESCRIPTION
This makes a printer to auto power on when upload
happens on all plugs requested.

Signed-off-by: Kamil Trzcinski <ayufan@ayufan.eu>