### PR TITLE
Fixes rounding issue in home assistant sensor

### DIFF
--- a/docs/example-home-assistant.yaml
+++ b/docs/example-home-assistant.yaml
@@ -56,7 +56,7 @@ sensor:
         unit_of_measurement: '%'
         icon_template: mdi:file-percent
         value_template: >-
-          {{ (states.sensor.voron_v0_sensor.attributes['display_status']['progress']) * 100 | round(1) if states('sensor.voron_v0_sensor') != 'unknown' else None }}
+          {{ (states.sensor.voron_v0_sensor.attributes['display_status']['progress'] * 100) | round(1) if states('sensor.voron_v0_sensor') != 'unknown' else None }}
 
       vzero_print_time:
         icon_template: mdi:clock-start


### PR DESCRIPTION
There was a minor issue with the Home Assistant template related to the priority of Jinja expressions (filters seem to take precedence over operations), so it would show "progress: 1.234567%" instead of "progress: 1.2%".

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>