### PR TITLE
confighelper: update 'Invalid config option' warning

### DIFF
--- a/moonraker/confighelper.py
+++ b/moonraker/confighelper.py
@@ -153,9 +153,11 @@ class ConfigHelper:
             for opt, val in self.config.items(sect):
                 if opt not in parsed_opts:
                     self.server.add_warning(
-                        f"Invalid config option '{opt}' detected in section "
-                        f"[{sect}]. Remove the option to resolve this issue. "
-                        "In the future this will result in a startup error.")
+                        f"Invalid config option '{opt}: {val}' detected in "
+                        f"section [{sect}]. To solve this issue check your "
+                        "moonraker config. This option is invalid and has to "
+                        "be deleted or fixed. In the future this will result "
+                        "in a startup error.")
 
 def get_configuration(server: Server,
                       app_args: Dict[str, Any]


### PR DESCRIPTION
this is a suggestion for a better understandable message for invalid option warnings