### PR TITLE
Adds Home Assistant power switch example

### DIFF
--- a/docs/example-home-assistant.yaml
+++ b/docs/example-home-assistant.yaml
@@ -13,7 +13,8 @@ sensor:
       - toolhead
       - display_status
       - virtual_sdcard
-    value_template: 'OK'
+    value_template: >-
+      {{ 'OK' if ('result' in value_json) else None }}
 
   - platform: template
     sensors:
@@ -23,65 +24,65 @@ sensor:
         device_class: temperature
         unit_of_measurement: '°C'
         value_template: >-
-          {{ states.sensor.voron_v0_sensor.attributes['extruder']['target'] | float | round(1) if states('sensor.voron_v0_sensor') != 'unknown' else None }}
+          {{ states.sensor.voron_v0_sensor.attributes['extruder']['target'] | float | round(1) if is_state('sensor.voron_v0_sensor', 'OK') else None }}
 
       vzero_hotend_actual:
         device_class: temperature
         unit_of_measurement: '°C'
         value_template: >-
-          {{ states.sensor.voron_v0_sensor.attributes['extruder']['temperature'] | float | round(1) if states('sensor.voron_v0_sensor') != 'unknown' else None }}
+          {{ states.sensor.voron_v0_sensor.attributes['extruder']['temperature'] | float | round(1) if is_state('sensor.voron_v0_sensor', 'OK') else None }}
 
       vzero_bed_target:
         device_class: temperature
         unit_of_measurement: '°C'
         value_template: >-
-          {{ states.sensor.voron_v0_sensor.attributes['heater_bed']['target'] | float | round(1) if states('sensor.voron_v0_sensor') != 'unknown' else None }}
+          {{ states.sensor.voron_v0_sensor.attributes['heater_bed']['target'] | float | round(1) if is_state('sensor.voron_v0_sensor', 'OK') else None }}
 
       vzero_bed_actual:
         device_class: temperature
         unit_of_measurement: '°C'
         value_template: >-
-          {{ states.sensor.voron_v0_sensor.attributes['heater_bed']['temperature'] | float | round(1) if states('sensor.voron_v0_sensor') != 'unknown' else None }}
+          {{ states.sensor.voron_v0_sensor.attributes['heater_bed']['temperature'] | float | round(1) if is_state('sensor.voron_v0_sensor', 'OK') else None }}
 
       vzero_state:
         icon_template: mdi:printer-3d
         value_template: >-
-          {{ states.sensor.voron_v0_sensor.attributes['print_stats']['state'] if states('sensor.voron_v0_sensor') != 'unknown' else None }}
+          {{ states.sensor.voron_v0_sensor.attributes['print_stats']['state'] if is_state('sensor.voron_v0_sensor', 'OK') else None }}
 
       vzero_current_print:
         value_template: >-
-          {{ states.sensor.voron_v0_sensor.attributes['print_stats']['filename'] if states('sensor.voron_v0_sensor') != 'unknown' else None }}
+          {{ states.sensor.voron_v0_sensor.attributes['print_stats']['filename'] if is_state('sensor.voron_v0_sensor', 'OK') else None }}
 
       vzero_current_progress:
         unit_of_measurement: '%'
         icon_template: mdi:file-percent
         value_template: >-
-          {{ (states.sensor.voron_v0_sensor.attributes['display_status']['progress'] * 100) | round(1) if states('sensor.voron_v0_sensor') != 'unknown' else None }}
+          {{ (states.sensor.voron_v0_sensor.attributes['display_status']['progress'] * 100) | round(1) if is_state('sensor.voron_v0_sensor', 'OK') else None }}
 
       vzero_print_time:
         icon_template: mdi:clock-start
         value_template: >-
-          {{ states.sensor.voron_v0_sensor.attributes['print_stats']['print_duration'] | timestamp_custom("%H:%M:%S", 0) if states('sensor.voron_v0_sensor') != 'unknown' else None }}
+          {{ states.sensor.voron_v0_sensor.attributes['print_stats']['print_duration'] | timestamp_custom("%H:%M:%S", 0) if is_state('sensor.voron_v0_sensor', 'OK') else None }}
 
       vzero_time_remaining:
         icon_template: mdi:clock-end
         value_template: >-
-          {{ (((states.sensor.voron_v0_sensor.attributes['print_stats']['print_duration'] / states.sensor.voron_v0_sensor.attributes['display_status']['progress'] - states.sensor.voron_v0_sensor.attributes['print_stats']['print_duration']) if states.sensor.voron_v0_sensor.attributes['display_status']['progress'] > 0 else 0)) | timestamp_custom("%H:%M:%S", 0) if states('sensor.voron_v0_sensor') != 'unknown' else None }}
+          {{ (((states.sensor.voron_v0_sensor.attributes['print_stats']['print_duration'] / states.sensor.voron_v0_sensor.attributes['display_status']['progress'] - states.sensor.voron_v0_sensor.attributes['print_stats']['print_duration']) if states.sensor.voron_v0_sensor.attributes['display_status']['progress'] > 0 else 0) | timestamp_custom('%H:%M:%S', 0)) if is_state('sensor.voron_v0_sensor', 'OK') else None }}
 
       vzero_eta:
         icon_template: mdi:clock-outline
         value_template: >-
-          {{ (as_timestamp(now()) + 2 * 60 * 60 + ((states.sensor.voron_v0_sensor.attributes['print_stats']['print_duration'] / states.sensor.voron_v0_sensor.attributes['display_status']['progress'] - states.sensor.voron_v0_sensor.attributes['print_stats']['print_duration']) if states.sensor.voron_v0_sensor.attributes['display_status']['progress'] > 0 else 0)) | timestamp_custom("%H:%M:%S", 0) if states('sensor.voron_v0_sensor') != 'unknown' else None }}
+          {{ (as_timestamp(now()) + 2 * 60 * 60 + ((states.sensor.voron_v0_sensor.attributes['print_stats']['print_duration'] / states.sensor.voron_v0_sensor.attributes['display_status']['progress'] - states.sensor.voron_v0_sensor.attributes['print_stats']['print_duration']) if states.sensor.voron_v0_sensor.attributes['display_status']['progress'] > 0 else 0)) | timestamp_custom("%H:%M:%S", 0) if is_state('sensor.voron_v0_sensor', 'OK') else None }}
 
       vzero_nozzletemp:
         icon_template: mdi:thermometer
         value_template: >-
-          {{ [(states.sensor.voron_v0_sensor.attributes['extruder']['temperature'] | float | round(1) | string), " / ", (states.sensor.voron_v0_sensor.attributes['extruder']['target'] | float | round(1) | string)] | join if states('sensor.voron_v0_sensor') != 'unknown' else None }}
+          {{ [(states.sensor.voron_v0_sensor.attributes['extruder']['temperature'] | float | round(1) | string), " / ", (states.sensor.voron_v0_sensor.attributes['extruder']['target'] | float | round(1) | string)] | join if is_state('sensor.voron_v0_sensor', 'OK') else None }}
 
       vzero_bedtemp:
         icon_template: mdi:thermometer
         value_template: >-
-          {{ [(states.sensor.voron_v0_sensor.attributes['heater_bed']['temperature'] | float | round(1) | string), " / ", (states.sensor.voron_v0_sensor.attributes['heater_bed']['target'] | float | round(1) | string)] | join if states('sensor.voron_v0_sensor') != 'unknown' else None }}
+          {{ [(states.sensor.voron_v0_sensor.attributes['heater_bed']['temperature'] | float | round(1) | string), " / ", (states.sensor.voron_v0_sensor.attributes['heater_bed']['target'] | float | round(1) | string)] | join if is_state('sensor.voron_v0_sensor', 'OK') else None }}
 
 #  The following will allow you to control the power of devices configured in the "[power]" sections of moonraker
 #  Make sure to change the `Printer` name below to the device name on your configuration
@@ -95,4 +96,4 @@ switch:
     headers:
       Content-Type: 'application/json'
     is_on_template: >-
-      {{ (value_json.result.values() | list | first) == "on" }}
+      {{ 'result' in value_json and (value_json.result.values() | list | first == "on") }}

--- a/docs/example-home-assistant.yaml
+++ b/docs/example-home-assistant.yaml
@@ -1,5 +1,5 @@
 #  Example Home Assistant configuration file for a Voron V0.
-#  Credit to GitHub user @Kruppes
+#  Credit to GitHub users @Kruppes and @pedrolamas
 #
 sensor:
   - platform: rest
@@ -82,3 +82,17 @@ sensor:
         icon_template: mdi:thermometer
         value_template: >-
           {{ [(states.sensor.voron_v0_sensor.attributes['heater_bed']['temperature'] | float | round(1) | string), " / ", (states.sensor.voron_v0_sensor.attributes['heater_bed']['target'] | float | round(1) | string)] | join if states('sensor.voron_v0_sensor') != 'unknown' else None }}
+
+#  The following will allow you to control the power of devices configured in the "[power]" sections of moonraker
+#  Make sure to change the `Printer` name below to the device name on your configuration
+#
+switch:
+  - platform: rest
+    name: Voron_V0_power
+    resource: "http://192.168.178.56:7125/machine/device_power/device?device=Printer"
+    body_on: '{"action": "on"}'
+    body_off: '{"action": "off"}'
+    headers:
+      Content-Type: 'application/json'
+    is_on_template: >-
+      {{ (value_json.result.values() | list | first) == "on" }}


### PR DESCRIPTION
Small example showing how to add a switch in Home Assistant that will allow users to control the power of devices configured in the `[power]` sections of moonraker.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>