### PR TITLE
metadata: add SliCR-3D support (fork of SuperSlicer)

### DIFF
--- a/moonraker/components/file_manager/metadata.py
+++ b/moonraker/components/file_manager/metadata.py
@@ -339,6 +339,16 @@ class SuperSlicer(PrusaSlicer):
             }
         return None
 
+class SliCR3D(SuperSlicer):
+    def check_identity(self, data: str) -> Optional[Dict[str, str]]:
+        match = re.search(r"SliCR-3D\s(.*)\son", data)
+        if match:
+            return {
+                'slicer': "SliCR-3D",
+                'slicer_version': match.group(1)
+            }
+        return None
+
 class Cura(PrusaSlicer):
     def check_identity(self, data: str) -> Optional[Dict[str, str]]:
         match = re.search(r"Cura_SteamEngine\s(.*)", data)
@@ -637,7 +647,7 @@ class IceSL(BaseSlicer):
 
 READ_SIZE = 512 * 1024
 SUPPORTED_SLICERS: List[Type[BaseSlicer]] = [
-    PrusaSlicer, Slic3rPE, Slic3r, SuperSlicer,
+    PrusaSlicer, Slic3rPE, Slic3r, SuperSlicer, SliCR3D,
     Cura, Simplify3D, KISSlicer, IdeaMaker, IceSL]
 SUPPORTED_DATA = [
     'layer_height', 'first_layer_height', 'object_height',


### PR DESCRIPTION
this PR adds SliCR-3D to the metadata export. It is a SuperSlicer fork.

Here you can find more informations about it: https://github.com/CR-3D/SliCR-3D

Signed-off-by: Stefan Dej <meteyou@gmail.com>