### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+## Get Code and Build venv
+FROM python:3 as build
+
+WORKDIR /opt
+COPY . moonraker
+
+RUN python -m venv venv \
+ && venv/bin/pip install -r moonraker/scripts/moonraker-requirements.txt
+
+## Runtime Image
+FROM python:3-slim as run
+
+RUN apt update \
+ && apt install -y \
+      libopenjp2-7 \
+      python3-libgpiod \
+      curl \
+      libcurl4-openssl-dev \
+      libssl-dev \
+      liblmdb0 \
+      libsodium-dev \
+      zlib1g-dev \
+  && apt clean
+
+WORKDIR /opt
+COPY --from=build /opt/moonraker ./moonraker
+COPY --from=build /opt/venv ./venv
+
+RUN mkdir run cfg gcode db
+RUN groupadd moonraker --gid 1000 \
+ && useradd moonraker --uid 1000 --gid moonraker \
+ && usermod moonraker --append --groups dialout \
+ && chown -R moonraker:moonraker /opt/*
+
+## Start Moonraker
+USER moonraker
+EXPOSE 7125
+VOLUME ["/opt/run", "/opt/cfg", "/opt/gcode", "/opt/db"]
+ENTRYPOINT ["/opt/venv/bin/python", "moonraker/moonraker/moonraker.py"]
+CMD ["-c", "cfg/moonraker.cfg"]
+


### PR DESCRIPTION
Hi There, 

for a recent Project of mine called [prind](https://github.com/mkuf/prind), I build [moonraker Docker Images](https://hub.docker.com/r/mkuf/moonraker) on a daily basis.  

These Images are decoupled from the actual Source-Repo and use git to fetch the code.  
Based on my work I created a Dockerfile that can be used directly with this Repo. 

The Image itself is a multistage Docker file to keep the runtime image as small as possible. 

As per [install-moonraker.sh](https://github.com/Arksine/moonraker/blob/master/scripts/install-moonraker.sh) there are multiple Apt packages installed in the runtime image, on which I am not sure if they are actually needed at runtime.  
Any Input here would be welcome, as omitting these Packages would slim down the Image even more. 

-Markus

