### PR TITLE
docs: updates to new Fluidd repo address

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -464,7 +464,7 @@ type: web
 #   "prerelease" on GitHub.  This parameter must be provided.
 repo:
 #   This is the GitHub repo of the client, in the format of user/client.
-#   For example, this could be set to cadriel/fluidd to update Fluidd or
+#   For example, this could be set to fluidd-core/fluidd to update Fluidd or
 #   meteyou/mainsail to update Mainsail.  This parameter must be provided.
 path:
 #   The path to the client's files on disk.  This parameter must be provided.

--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -520,7 +520,7 @@ included.
         },
         "update_manager client fluidd": {
             "type": "web",
-            "repo": "cadriel/fluidd",
+            "repo": "fluidd-core/fluidd",
             "path": "~/fluidd",
             "persistent_files": null
         },


### PR DESCRIPTION
Ensures all Fluidd repo references are pointing to the new org-based address.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>