### PR TITLE
job_queue: a FIFO queue for G-Code print jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ to see if any action is necessary on their part.  The date of the most
 recent change is included.
 
 Users:\
-[user_changes.md](https://moonraker.readthedocs.io/en/latest/user_changes/) - April 19th 2021
+[user_changes.md](https://moonraker.readthedocs.io/en/latest/user_changes/) - November 7th 2021
 
 Developers:\
 [api_changes.md](https://moonraker.readthedocs.io/en/latest/api_changes/) - March 15th 2021

--- a/docs/user_changes.md
+++ b/docs/user_changes.md
@@ -2,6 +2,18 @@
 This file will track changes that require user intervention,
 such as a configuration change or a reinstallation.
 
+### November 7th 2021
+- Previously all core components received configuration through
+  the `[server]` config section.  As Moonraker's core functionality
+  has expanded this is becoming unsustainable, thus core components
+  should now be configured in their own section. For example, the
+  `config_path` and `log_path` should now be configured in the
+  `[file_manager]` section of `moonraker.conf`.  See the
+  [configuration documentation](https://moonraker.readthedocs.io/en/latest/configuration/)
+  for details.  This is not a breaking change, core components
+  will still fall back to checking the `[server]` section for
+  configuration.
+
 ### April 19th 2021
 - The `[authorization]` module is now a component, thus is only
   loaded if the user has it configured in `moonraker.conf`.  This

--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -2076,6 +2076,320 @@ deleted item.
 }
 ```
 
+### Job Queue APIs
+
+The following enpoints may be used to manage Moonraker's job queue.
+Note that Moonraker's Job Queue is impelemented as a FIFO queue and it may
+contain multiple references to the same job.
+
+!!! Note
+    All filenames provided to and returned by these endpoints are relative to
+    the `gcodes` root.
+
+#### Retrieve the job queue status
+
+Retreives the current state of the job queue
+
+HTTP request:
+```http
+GET /server/job_queue/status
+```
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "server.job_queue.status",
+    "id": 4654
+}
+```
+
+Returns:
+
+The current state of the job queue:
+
+```json
+{
+    "queued_jobs": [
+        {
+            "filename": "job1.gcode",
+            "job_id": "0000000066D99C90",
+            "time_added": 1636151050.7666452,
+            "time_in_queue": 21.89680004119873
+        },
+        {
+            "filename": "job2.gcode",
+            "job_id": "0000000066D991F0",
+            "time_added": 1636151050.7766452,
+            "time_in_queue": 21.88680004119873
+        },
+        {
+            "filename": "subdir/job3.gcode",
+            "job_id": "0000000066D99D80",
+            "time_added": 1636151050.7866452,
+            "time_in_queue": 21.90680004119873
+        }
+    ],
+    "queue_state": "ready"
+}
+```
+
+Below is a description of the returned fields:
+
+- `queued_jobs`: an array of objects representing each queued job.  Each
+  object contains the `filename` of the enqueued job and a unique `job_id`
+  generated for each job.  The `job_id` is a 64-bit Hexadecimal string value.
+  On 32-bit systems the most significant bits will always contain zeros.  Items
+  are ordered by the time they were queued, the first item will be the next job
+  loaded.
+- `queue_state`: The current state of the queue.  Can be one of the following:
+    - `ready`: The queue is active and will load the next job upon completion
+      of the current job
+    - `loading`: The queue is currently loading the next job. If the user
+      specified a `job_transition_delay` and/or `job_transition_gcode`, the
+      queue will remain in the `loading` state until both are completed or
+      an error is encountered.
+    - `starting`: The queue enters this state after the `loading` phase is
+      complete before attempting to start the job.
+    - `paused`:  The queue is currently paused and will not load the next job
+      upon completion of the current job.  The queue will enter the `paused`
+      state if an error is encountered during the `loading` or `starting` phases,
+      or if the user pauses the queue through the provided endpoint.
+- `time_added`: The time (in Unix Time) the job was added to the queue
+- `time_in_queue`: The cumulative amount of time (in seconds) the job has been
+  pending in the queue
+
+#### Enqueue a job
+
+Adds a job, or an array of jobs, to the end of the job queue.  The same
+filename may be specified multiple times to queue a job that repeats.
+When multiple jobs are specfied they will be enqued in the order they
+are received.  If the queue is empty and in the `ready` state, the first
+job supplied will be started.
+
+!!! Note
+    The request will be aborted and return an error if any of the supplied
+    files do not exist.
+
+HTTP request:
+```http
+POST /server/job_queue/job?filenames=job1.gcode,job2.gcode,subdir/job3.gocde
+```
+
+!!! Note
+    Multiple jobs are should be comma separated as shown above.
+    Alternatively `filenames` maybe be specified as a json object
+    in the body of the request.
+
+```http
+POST /server/job_queue/job
+Content-Type: applicaton/json
+
+{
+    "filenames": [
+        "job1.gcode",
+        "job2.gcode",
+        "subdir/job3.gocde",
+    ]
+}
+```
+
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "server.job_queue.post_job",
+    "params": {
+        "filenames": [
+            "job1.gcode",
+            "job2.gcode",
+            "subir/job3.gocde",
+        ]
+    },
+    "id": 4654
+}
+```
+
+Returns:
+
+The current state of the job queue:
+
+```json
+{
+    "queued_jobs": [
+        {
+            "filename": "job1.gcode",
+            "job_id": "0000000066D99C90",
+            "time_added": 1636151050.7666452,
+            "time_in_queue": 21.89680004119873
+        },
+        {
+            "filename": "job2.gcode",
+            "job_id": "0000000066D991F0",
+            "time_added": 1636151050.7766452,
+            "time_in_queue": 21.88680004119873
+        },
+        {
+            "filename": "subdir/job3.gcode",
+            "job_id": "0000000066D99D80",
+            "time_added": 1636151050.7866452,
+            "time_in_queue": 21.90680004119873
+        }
+    ],
+    "queue_state": "ready"
+}
+```
+
+#### Remove a Job
+
+Removes one or more jobs from the queue.
+
+!!! Note
+    Unlike the POST version of this method, it is not necessary that
+    all job ids exist.  If any supplied job id does not exist in the
+    queue it will be silently ignored.  Clients can verify the contents
+    of the queue via the return value.
+
+HTTP request:
+```http
+DELETE /server/job_queue/job?job_ids=0000000066D991F0,0000000066D99D80
+```
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "server.job_queue.delete_job",
+    "params": {
+        "job_ids": [
+            "0000000066D991F0".
+            "0000000066D99D80"
+        ]
+    },
+    "id": 4654
+}
+```
+!!! Tip
+    Alternatively `all=true` (`"all": true` for JSON-RPC) may specified
+    to clear the job queue.
+
+Returns:
+
+The current state of the job queue:
+
+```json
+{
+    "queued_jobs": [
+        {
+            "filename": "job1.gcode",
+            "job_id": "0000000066D99C90",
+            "time_added": 1636151050.7666452,
+            "time_in_queue": 21.89680004119873
+        }
+    ],
+    "queue_state": "ready"
+}
+```
+#### Pause the job queue
+
+Sets the job queue state to "pause", which prevents the next job
+in the queue from loading after an job in progress is complete.
+
+!!! Note
+    If the queue is paused while the queue is in the `loading` state
+    the load will be aborted.
+
+HTTP request:
+```http
+POST /server/job_queue/pause
+```
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "server.job_queue.pause",
+    "id": 4654
+}
+```
+
+Returns:
+
+The current state of the job queue:
+
+```json
+{
+    "queued_jobs": [
+        {
+            "filename": "job1.gcode",
+            "job_id": "0000000066D99C90",
+            "time_added": 1636151050.7666452,
+            "time_in_queue": 21.89680004119873
+        },
+        {
+            "filename": "job2.gcode",
+            "job_id": "0000000066D991F0",
+            "time_added": 1636151050.7766452,
+            "time_in_queue": 21.88680004119873
+        },
+        {
+            "filename": "subdir/job3.gcode",
+            "job_id": "0000000066D99D80",
+            "time_added": 1636151050.7866452,
+            "time_in_queue": 21.90680004119873
+        }
+    ],
+    "queue_state": "paused"
+}
+```
+
+#### Resume the job queue
+
+Sets the job queue state to "resume".  This will set the job
+queue to state to "idle".  If the queue is not empty the next job
+in the queue will be loaded.
+
+HTTP request:
+```http
+POST /server/job_queue/resume
+```
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "server.job_queue.resume",
+    "id": 4654
+}
+```
+
+Returns:
+
+The current state of the job queue:
+
+```json
+{
+    "queued_jobs": [
+        {
+            "filename": "job1.gcode",
+            "job_id": "0000000066D99C90",
+            "time_added": 1636151050.7666452,
+            "time_in_queue": 21.89680004119873
+        },
+        {
+            "filename": "job2.gcode",
+            "job_id": "0000000066D991F0",
+            "time_added": 1636151050.7766452,
+            "time_in_queue": 21.88680004119873
+        },
+        {
+            "filename": "subdir/job3.gcode",
+            "job_id": "0000000066D99D80",
+            "time_added": 1636151050.7866452,
+            "time_in_queue": 21.90680004119873
+        }
+    ],
+    "queue_state": "loading"
+}
+```
+
+
 ### Update Manager APIs
 The following endpoints are available when the `[update_manager]` component has
 been configured:
@@ -2918,6 +3232,38 @@ An object containing the following total job statistics:
 ```json
 {
     "job_totals": {
+        "total_jobs": 3,
+        "total_time": 11748.077333278954,
+        "total_print_time": 11348.794790096988,
+        "total_filament_used": 11615.718840001999,
+        "longest_job": 11665.191012736992,
+        "longest_print": 11348.794790096988
+    }
+}
+```
+
+#### Reset totals
+Resets the persistent "job totals" to zero.
+
+HTTP request:
+```http
+POST /server/history/reset_totals
+```
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "server.history.reset_totals",
+    "id": 5534
+}
+
+Returns:
+
+The totals prior to the reset:
+
+```json
+{
+    "last_totals": {
         "total_jobs": 3,
         "total_time": 11748.077333278954,
         "total_print_time": 11348.794790096988,

--- a/moonraker/components/job_queue.py
+++ b/moonraker/components/job_queue.py
@@ -1,0 +1,283 @@
+# Print Job Queue Implementation
+#
+# Copyright (C) 2021 Eric Callahan <arksine.code@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+from __future__ import annotations
+import asyncio
+import time
+import logging
+
+# Annotation imports
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Optional,
+    Dict,
+    List,
+    Union,
+)
+if TYPE_CHECKING:
+    from confighelper import ConfigHelper
+    from websockets import WebRequest
+    from .klippy_apis import KlippyAPI
+    from .file_manager.file_manager import FileManager
+
+class JobQueue:
+    def __init__(self, config: ConfigHelper) -> None:
+        self.server = config.get_server()
+        self.queued_jobs: Dict[str, QueuedJob] = {}
+        self.queue_state: str = "ready"
+        self.lock = asyncio.Lock()
+        self.load_on_start = config.getboolean("load_on_startup", False)
+        self.job_delay = config.getfloat("job_transition_delay", 0.01)
+        if self.job_delay <= 0.:
+            raise config.error(
+                "Value for option 'job_transition_delay' in section [job_queue]"
+                " must be above 0.0")
+        self.job_transition_gcode = config.get(
+            "job_transition_gcode", "").strip()
+        self.pop_queue_handle: Optional[asyncio.TimerHandle] = None
+
+        self.server.register_event_handler(
+            "server:klippy_ready", self._handle_ready)
+        self.server.register_event_handler(
+            "server:klippy_shutdown", self._handle_shutdown)
+        self.server.register_event_handler(
+            "job_state:complete", self._on_job_complete)
+        self.server.register_event_handler(
+            "job_state:error", self._on_job_abort)
+        self.server.register_event_handler(
+            "job_state:cancelled", self._on_job_abort)
+
+        self.server.register_endpoint(
+            "/server/job_queue/job", ['POST', 'DELETE'],
+            self._handle_job_request)
+        self.server.register_endpoint(
+            "/server/job_queue/pause", ['POST'], self._handle_pause_queue)
+        self.server.register_endpoint(
+            "/server/job_queue/resume", ['POST'], self._handle_resume_queue)
+        self.server.register_endpoint(
+            "/server/job_queue/status", ['GET'], self._handle_queue_status)
+
+    async def _handle_ready(self) -> None:
+        async with self.lock:
+            if not self.load_on_start or not self.queued_jobs:
+                return
+            # start a queued print
+            if self.queue_state in ['ready', 'paused']:
+                event_loop = self.server.get_event_loop()
+                self.queue_state = "loading"
+                self.pop_queue_handle = event_loop.delay_callback(
+                    0.01, self._pop_job, False)
+
+    async def _handle_shutdown(self) -> None:
+        await self.pause_queue()
+        if not self.queued_jobs:
+            self.queue_state = "ready"
+
+    async def _on_job_complete(self,
+                               prev_stats: Dict[str, Any],
+                               new_stats: Dict[str, Any]
+                               ) -> None:
+        async with self.lock:
+            # Transition to the next job in the queue
+            if self.queue_state == "ready" and self.queued_jobs:
+                event_loop = self.server.get_event_loop()
+                self.queue_state = "loading"
+                self.pop_queue_handle = event_loop.delay_callback(
+                    self.job_delay, self._pop_job)
+
+    async def _on_job_abort(self,
+                            prev_stats: Dict[str, Any],
+                            new_stats: Dict[str, Any]
+                            ) -> None:
+        async with self.lock:
+            if self.queued_jobs:
+                self.queue_state = "paused"
+
+    async def _pop_job(self, need_transition: bool = True) -> None:
+        self.pop_queue_handle = None
+        async with self.lock:
+            if self.queue_state == "paused":
+                return
+            if not self.queued_jobs:
+                self.queue_state = "ready"
+                return
+            kapis: KlippyAPI = self.server.lookup_component('klippy_apis')
+            uid, job = list(self.queued_jobs.items())[0]
+            filename = str(job)
+            can_print = await self._check_can_print()
+            if not can_print or self.queue_state != "loading":
+                self.queue_state = "paused"
+                return
+            try:
+                if self.job_transition_gcode and need_transition:
+                    await kapis.run_gcode(self.job_transition_gcode)
+                    # Check to see if the queue was paused while running
+                    # the job transition gcode
+                    if self.queue_state != "loading":
+                        raise self.server.error(
+                            "Queue State Changed during Transition Gcode")
+                self.queue_state = "starting"
+                await kapis.start_print(filename)
+            except self.server.error:
+                logging.exception(f"Error Loading print: {filename}")
+                self.queue_state = "paused"
+            else:
+                self.queued_jobs.pop(uid, None)
+                if self.queue_state == "starting":
+                    # If the queue was not paused while starting the print,
+                    # reset state to "ready"
+                    self.queue_state = "ready"
+
+    async def _check_can_print(self) -> bool:
+        # Query the latest stats
+        kapis: KlippyAPI = self.server.lookup_component('klippy_apis')
+        try:
+            result = await kapis.query_objects({"print_stats": None})
+        except Exception:
+            # Klippy not connected
+            return False
+        if 'print_stats' not in result:
+            return False
+        state: str = result['print_stats']['state']
+        if state in ["printing", "paused"]:
+            return False
+        return True
+
+    async def queue_job(self, filename: str,
+                        check_exists: bool = True
+                        ) -> bool:
+        async with self.lock:
+            # Make sure that the file exists
+            if check_exists:
+                self._check_job_file(filename)
+            can_print = await self._check_can_print()
+            if (
+                self.queue_state == "ready" and
+                not self.queued_jobs and
+                can_print
+            ):
+                # Printer is ready to accept a print
+                kapis: KlippyAPI = self.server.lookup_component('klippy_apis')
+                try:
+                    await kapis.start_print(filename)
+                except self.server.error:
+                    # Attempt to start print failed, queue the print
+                    pass
+                else:
+                    return True
+            queued_job = QueuedJob(filename)
+            self.queued_jobs[queued_job.job_id] = queued_job
+            return False
+
+    async def pause_queue(self) -> None:
+        self.queue_state = "paused"
+        if self.pop_queue_handle is not None:
+            self.pop_queue_handle.cancel()
+            self.pop_queue_handle = None
+        # Acquire the lock to wait for any pending operations to
+        # complete
+        await self.lock.acquire()
+        self.lock.release()
+
+    def _job_map_to_list(self) -> List[Dict[str, Any]]:
+        cur_time = time.time()
+        return [job.as_dict(cur_time) for
+                job in self.queued_jobs.values()]
+
+    def _check_job_file(self, job_name: str) -> None:
+        fm: FileManager = self.server.lookup_component('file_manager')
+        if not fm.check_file_exists("gcodes", job_name):
+            raise self.server.error(
+                f"G-Code File {job_name} does not exist")
+
+    async def _handle_job_request(self,
+                                  web_request: WebRequest
+                                  ) -> Dict[str, Any]:
+        action = web_request.get_action()
+        if action == "POST":
+            files: Union[List[str], str] = web_request.get('filenames')
+            if isinstance(files, str):
+                files = [f.strip() for f in files.split(',') if f.strip()]
+            # Validate that all files exist before queueing
+            for fname in files:
+                self._check_job_file(fname)
+            for fname in files:
+                await self.queue_job(fname, check_exists=False)
+        elif action == "DELETE":
+            if web_request.get_boolean("all", False):
+                async with self.lock:
+                    self.queued_jobs.clear()
+            else:
+                job_ids: Union[List[str], str] = web_request.get('job_ids')
+                if isinstance(job_ids, str):
+                    job_ids = [f.strip() for f in job_ids.split(',')
+                               if f.strip()]
+                async with self.lock:
+                    for uid in job_ids:
+                        self.queued_jobs.pop(uid, None)
+        else:
+            raise self.server.error(f"Invalid action: {action}")
+        return {
+            'queued_jobs': self._job_map_to_list(),
+            'queue_state': self.queue_state
+        }
+
+    async def _handle_pause_queue(self,
+                                  web_request: WebRequest
+                                  ) -> Dict[str, Any]:
+        await self.pause_queue()
+        return {
+            'queued_jobs': self._job_map_to_list(),
+            'queue_state': self.queue_state
+        }
+
+    async def _handle_resume_queue(self,
+                                   web_request: WebRequest
+                                   ) -> Dict[str, Any]:
+        async with self.lock:
+            if self.queue_state == "paused":
+                self.queue_state = "ready"
+                if self.queued_jobs and self.pop_queue_handle is None:
+                    self.queue_state = "loading"
+                    event_loop = self.server.get_event_loop()
+                    self.pop_queue_handle = event_loop.delay_callback(
+                        0.01, self._pop_job)
+        return {
+            'queued_jobs': self._job_map_to_list(),
+            'queue_state': self.queue_state
+        }
+
+    async def _handle_queue_status(self,
+                                   web_request: WebRequest
+                                   ) -> Dict[str, Any]:
+        return {
+            'queued_jobs': self._job_map_to_list(),
+            'queue_state': self.queue_state
+        }
+
+    async def close(self):
+        await self.pause_queue()
+
+class QueuedJob:
+    def __init__(self, filename: str) -> None:
+        self.filename = filename
+        self.job_id = f"{id(self):016X}"
+        self.time_added = time.time()
+
+    def __str__(self) -> str:
+        return self.filename
+
+    def as_dict(self, cur_time: float) -> Dict[str, Any]:
+        return {
+            'filename': self.filename,
+            'job_id': self.job_id,
+            'time_added': self.time_added,
+            'time_in_queue': cur_time - self.time_added
+        }
+
+def load_component(config: ConfigHelper) -> JobQueue:
+    return JobQueue(config)

--- a/moonraker/components/job_state.py
+++ b/moonraker/components/job_state.py
@@ -1,0 +1,76 @@
+# Klippy job state event handlers
+#
+# Copyright (C) 2021 Eric Callahan <arksine.code@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+from __future__ import annotations
+import logging
+
+# Annotation imports
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Optional,
+    Dict,
+    List,
+)
+if TYPE_CHECKING:
+    from confighelper import ConfigHelper
+    from .klippy_apis import KlippyAPI
+
+class JobState:
+    def __init__(self, config: ConfigHelper) -> None:
+        self.server = config.get_server()
+        self.last_print_stats: Dict[str, Any] = {}
+        self.server.register_event_handler(
+            "server:klippy_ready", self._handle_ready)
+        self.server.register_event_handler(
+            "server:status_update", self._status_update)
+
+    async def _handle_ready(self) -> None:
+        kapis: KlippyAPI = self.server.lookup_component('klippy_apis')
+        sub: Dict[str, Optional[List[str]]] = {"print_stats": None}
+        try:
+            result = await kapis.subscribe_objects(sub)
+        except self.server.error as e:
+            logging.info(f"Error subscribing to print_stats")
+        self.last_print_stats = result.get("print_stats", {})
+
+    async def _status_update(self, data: Dict[str, Any]) -> None:
+        if 'print_stats' not in data:
+            return
+        ps = data['print_stats']
+        if "state" in ps:
+            prev_ps = dict(self.last_print_stats)
+            old_state: str = prev_ps['state']
+            new_state: str = ps['state']
+            new_ps = dict(self.last_print_stats)
+            new_ps.update(ps)
+            if new_state is not old_state:
+                if new_state == "printing":
+                    # The "printing" state needs some special handling
+                    # to detect "resets" and a transition from pause to resume
+                    if self._check_resumed(prev_ps, new_ps):
+                        new_state = "resumed"
+                    else:
+                        new_state = "started"
+                self.server.send_event(
+                    f"job_state:{new_state}", prev_ps, new_ps)
+        self.last_print_stats.update(ps)
+
+    def _check_resumed(self,
+                       prev_ps: Dict[str, Any],
+                       new_ps: Dict[str, Any]
+                       ) -> bool:
+        return (
+            prev_ps['state'] == "paused" and
+            prev_ps['filename'] == new_ps['filename'] and
+            prev_ps['total_duration'] < new_ps['total_duration']
+        )
+
+    def get_last_stats(self) -> Dict[str, Any]:
+        return dict(self.last_print_stats)
+
+def load_component(config: ConfigHelper) -> JobState:
+    return JobState(config)

--- a/moonraker/components/klippy_apis.py
+++ b/moonraker/components/klippy_apis.py
@@ -108,9 +108,11 @@ class KlippyAPI(Subscribable):
         # Escape existing double quotes in the file name
         filename = filename.replace("\"", "\\\"")
         script = f'SDCARD_PRINT_FILE FILENAME="{filename}"'
+        await self.server.wait_connection_initialized()
         return await self.run_gcode(script)
 
     async def do_restart(self, gc: str) -> str:
+        await self.server.wait_connection_initialized()
         try:
             result = await self.run_gcode(gc)
         except self.server.error as e:

--- a/moonraker/components/machine.py
+++ b/moonraker/components/machine.py
@@ -82,10 +82,7 @@ class Machine:
         self.server.register_remote_method(
             "reboot_machine", self.reboot_machine)
 
-        # Retreive list of services
-        event_loop = self.server.get_event_loop()
         self.init_evt = asyncio.Event()
-        event_loop.register_callback(self._initialize)
 
     def _update_log_rollover(self, log: bool = False) -> None:
         sys_info_msg = "\nSystem Info:"
@@ -104,7 +101,7 @@ class Machine:
         except asyncio.TimeoutError:
             pass
 
-    async def _initialize(self):
+    async def component_init(self):
         if not self.inside_container:
             await self._check_virt_status()
         await self._find_active_services()

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -920,5 +920,5 @@ class Loxonev1(HTTPDevice):
 
 
 # The power component has multiple configuration sections
-def load_component_multi(config: ConfigHelper) -> PrinterPower:
+def load_component(config: ConfigHelper) -> PrinterPower:
     return PrinterPower(config)

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -316,7 +316,7 @@ class PowerDevice:
             return
         self.need_scheduled_restart = False
         if state == "ready":
-            logging.info("Klipper reports 'ready', aborting firmware restart")
+            logging.info("Klipper reports 'ready', aborting FIRMWARE_RESTART")
             return
         event_loop = self.server.get_event_loop()
         kapis: APIComp = self.server.lookup_component("klippy_apis")
@@ -348,7 +348,11 @@ class PowerDevice:
             await machine_cmp.do_service_action(action, self.bound_service)
         if self.state == "on" and self.klipper_restart:
             self.need_scheduled_restart = True
-            if self._is_bound_to_klipper():
+            klippy_state = self.server.get_klippy_state()
+            if klippy_state in ["disconnected", "startup"]:
+                # If klippy is currently disconnected or hasn't proceeded past
+                # the startup state, schedule the restart in the
+                # "klippy_started" event callback.
                 return
             self._schedule_firmware_restart()
 

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -315,6 +315,9 @@ class PowerDevice:
         if not self.need_scheduled_restart:
             return
         self.need_scheduled_restart = False
+        if state == "ready":
+            logging.info("Klipper reports 'ready', aborting firmware restart")
+            return
         event_loop = self.server.get_event_loop()
         kapis: APIComp = self.server.lookup_component("klippy_apis")
         event_loop.delay_callback(

--- a/moonraker/eventloop.py
+++ b/moonraker/eventloop.py
@@ -11,16 +11,16 @@ import functools
 from concurrent.futures import ThreadPoolExecutor
 from typing import (
     TYPE_CHECKING,
+    Awaitable,
     Callable,
     Coroutine,
-    List,
     Optional,
     TypeVar
 )
 
 if TYPE_CHECKING:
     _T = TypeVar("_T")
-    FlexCallback = Callable[..., Optional[Coroutine]]
+    FlexCallback = Callable[..., Optional[Awaitable]]
 
 class EventLoop:
     TimeoutError = asyncio.TimeoutError

--- a/moonraker/eventloop.py
+++ b/moonraker/eventloop.py
@@ -13,6 +13,7 @@ from typing import (
     TYPE_CHECKING,
     Callable,
     Coroutine,
+    List,
     Optional,
     TypeVar
 )
@@ -32,6 +33,7 @@ class EventLoop:
         self.remove_reader = self.aioloop.remove_reader
         self.remove_writer = self.aioloop.remove_writer
         self.get_loop_time = self.aioloop.time
+        self.create_future = self.aioloop.create_future
 
     def register_callback(self,
                           callback: FlexCallback,

--- a/moonraker/moonraker.py
+++ b/moonraker/moonraker.py
@@ -195,13 +195,9 @@ class Server:
             return self.components[component_name]
         try:
             module = importlib.import_module("components." + component_name)
-            func_name = "load_component"
-            if hasattr(module, "load_component_multi"):
-                func_name = "load_component_multi"
-            if component_name not in CORE_COMPONENTS and \
-                    func_name == "load_component":
+            if component_name in config:
                 config = config[component_name]
-            load_func = getattr(module, func_name)
+            load_func = getattr(module, "load_component")
             component = load_func(config)
         except Exception:
             msg = f"Unable to load component: ({component_name})"

--- a/moonraker/moonraker.py
+++ b/moonraker/moonraker.py
@@ -53,7 +53,7 @@ MAX_LOG_ATTEMPTS = 10 * LOG_ATTEMPT_INTERVAL
 
 CORE_COMPONENTS = [
     'database', 'file_manager', 'klippy_apis', 'machine',
-    'data_store', 'shell_command', 'proc_stats']
+    'data_store', 'shell_command', 'proc_stats', 'job_state']
 
 SENTINEL = SentinelClass.get_instance()
 

--- a/moonraker/moonraker.py
+++ b/moonraker/moonraker.py
@@ -211,14 +211,17 @@ class Server:
             self.set_failed_component(name)
 
     def _load_components(self, config: confighelper.ConfigHelper) -> None:
+        cfg_sections = [s.split()[0] for s in config.sections()]
+        cfg_sections.remove('server')
+
         # load core components
         for component in CORE_COMPONENTS:
             self.load_component(config, component)
+            if component in cfg_sections:
+                cfg_sections.remove(component)
 
-        # check for optional components
-        opt_sections = set([s.split()[0] for s in config.sections()])
-        opt_sections.remove('server')
-        for section in opt_sections:
+        # load remaining optional components
+        for section in cfg_sections:
             self.load_component(config, section, None)
 
     def load_component(self,

--- a/moonraker/moonraker.py
+++ b/moonraker/moonraker.py
@@ -53,7 +53,9 @@ MAX_LOG_ATTEMPTS = 10 * LOG_ATTEMPT_INTERVAL
 
 CORE_COMPONENTS = [
     'database', 'file_manager', 'klippy_apis', 'machine',
-    'data_store', 'shell_command', 'proc_stats', 'job_state']
+    'data_store', 'shell_command', 'proc_stats', 'job_state',
+    'job_queue'
+]
 
 SENTINEL = SentinelClass.get_instance()
 

--- a/moonraker/moonraker.py
+++ b/moonraker/moonraker.py
@@ -845,7 +845,18 @@ def main() -> None:
         # it is ok to use a blocking sleep here
         time.sleep(.5)
         logging.info("Attempting Server Restart...")
-        asyncio.set_event_loop(asyncio.new_event_loop())
+        for _ in range(5):
+            # Sometimes the new loop does not properly instantiate.
+            # Give 5 attempts before raising an exception
+            new_loop = asyncio.new_event_loop()
+            if not new_loop.is_closed():
+                break
+            logging.info("Failed to create open eventloop, "
+                         "retyring in .5 seconds...")
+            time.sleep(.5)
+        else:
+            raise RuntimeError("Unable to create new open eventloop")
+        asyncio.set_event_loop(new_loop)
         event_loop = EventLoop()
     event_loop.close()
     logging.info("Server Shutdown")


### PR DESCRIPTION
This primary purpose of the Pull Request is to provide central documentation for the new `job_queue` component, along with changes made to Moonraker to accommodate it.  When implementing the job_queue I came across several potential issues that required refactoring some parts of the core server.  Those changes will be outlined below.

Two new core modules are added, `job_state` and `job_queue`.  The `job_state` module is primarily of interest to Moonraker developers.  Its purpose is to process Klipper's `print_stats` module, determine changes in print state, and fire off events in response.  The result is a reduction in duplicated code, as it is likely that several Moonraker components will need to react to changes in print state.  The `history` module has been refactored to use the `job_state` component, and the `job_queue` uses it.

The `job_queue` APIs have been documented.  While the module itself isn't incredibly complex, it went through several revisions before I was happy with how it functions.   That said, I am open to making changes after client developers being playing with it and testing.  I'm notorious for typos in the API documentation, so if something doesn't make sense please let me know.

Up to this point all of configuration for Moonraker's core components have been provided in the `[server]` section.  As more core components are added and more options are added this is becoming unsustainable.  Going forward, each core component should now have its configuration specifed in its own section, ie: `[file_manager]`, `[job_queue]`, etc.  This is not a breaking change, if the section is not found in the configuration Moonraker will fall back to using the server section, however we should update all documentation and encourage the new format going forward.  One thing to keep in mind is that it isn't necessary to add an empty section to load a core component and that behavior won't change.

I also noticed potential timing issues when moonraker starts.  The tornado documentation suggests that that the server should be started before the asyncio event loop is started.  Most components can initialize outside of the event loop, however some components require that that event loop be started to finish initialization, the `machine`, `power`, and `update_manager` are examples.  This can result in clients attempting to access component APIs before the components are fully initialized.  Up until now I have used locks to prevent this behavior, however that too is becoming unsustainable.  After looking at Tornado's source I have determined that there is no reason that the server cannot be started after the event loop, so I have delayed its startup wait until after all components are fully initialized.  This is going to delay the time the websocket and other APIs are unavailable after a server restart, so its something clients should keep in mind.

Finally, since I was working with the `history` and `power` modules, I added some requested functionality.  The `history` module now has a `/server/history/reset_totals` endpoint.  The power module can be configured to power on a device when a gcode upload is queued.