### PR TITLE
wled: fix index for wled

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -759,7 +759,7 @@ api_qos:
 #   value specified by "default_qos" will be used.
 ```
 
-# `[wled]`
+### `[wled]`
 Enables control of an WLED strip.
 
 ```ini


### PR DESCRIPTION
Comparing to mqtt I think it should be H3 to appear in the index

Signed-off-by:  Richard Mitchell <richardjm+moonraker@gmail.com>