### PR TITLE
machine: add serial number attribute for cpu

### DIFF
--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -839,6 +839,7 @@ Returns: Information about the host system in the following format:
             "bits": "32bit",
             "processor": "armv7l",
             "cpu_desc": "ARMv7 Processor rev 4 (v7l)",
+            "serial_number": "b898bdb4",
             "hardware_desc": "BCM2835",
             "model": "Raspberry Pi 3 Model B Rev 1.2",
             "total_memory": 945364,

--- a/moonraker/components/machine.py
+++ b/moonraker/components/machine.py
@@ -237,6 +237,7 @@ class Machine:
             'bits': platform.architecture()[0],
             'processor': platform.processor() or platform.machine(),
             'cpu_desc': "",
+            'serial_number': "",
             'hardware_desc': "",
             'model': "",
             'total_memory': None,
@@ -255,6 +256,9 @@ class Machine:
                 hw_match = re.search(r"Hardware\s+:\s+(.+)", cpu_items[-1])
                 if hw_match is not None:
                     cpu_info['hardware_desc'] = hw_match.group(1).strip()
+                sn_match = re.search(r"Serial\s+:\s+0*(.+)", cpu_items[-1])
+                if sn_match is not None:
+                    cpu_info['serial_number'] = sn_match.group(1).strip()
                 model_match = re.search(r"Model\s+:\s+(.+)", cpu_items[-1])
                 if model_match is not None:
                     cpu_info['model'] = model_match.group(1).strip()


### PR DESCRIPTION
Adds the property "serial_number" to the cpu info structure.

Adding this property gives us a persistent unique id that allows better integration into Home Assistant (something else I am working on at the moment).