### PR TITLE
docs: document the protocol config option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -384,6 +384,8 @@ password:
 address:
 #   A valid ip address or hostname for the Home Assistant server.  This
 #   parameter must be provided.
+protocol:
+#   The protocol for the URL to the Home Assistant server. Default is http.
 port:
 #   The port the Home Assistant server is listening on.  Default is 8123.
 device:


### PR DESCRIPTION
Signed-off-by:  Travis Collins <travistx@gmail.com>

I am using Home Assistant with https, and had a difficult time getting the  moonraker`[power]` configuration working with this. Eventually I read through the code and discovered this undocumented [protocol](https://github.com/Arksine/moonraker/blob/ccb86ea039bf1309b9fd4bb520a29bdb3af2bf36/moonraker/components/power.py#L381) config option, which worked great! Adding it to the documentation for future travelers.