### PR TITLE
Add API key info to example-home-assistant.yaml

### DIFF
--- a/docs/example-home-assistant.yaml
+++ b/docs/example-home-assistant.yaml
@@ -14,8 +14,12 @@ sensor:
       - display_status
       - virtual_sdcard
     value_template: >-
-      {{ 'OK' if ('result' in value_json) else None }}
-
+      {{ 'OK' if ('result' in value_json) else None }}    
+    #  Adding an API key is only necessary while using the [authorization] component
+    #  and if Home Assistant is not a trusted client
+    headers:
+      x-api-key: 123456789abcdefghijklmno
+      
   - platform: template
     sensors:
 


### PR DESCRIPTION
Currently the file makes no mention of any type of auth, so I've added a short example with an explanation of when you should use it.

Signed-off-by:  Rafael Schridi <r.schridi@gmail.com>