### PR TITLE
Bump preprocess-cancellation to 0.1.6

### DIFF
--- a/scripts/moonraker-requirements.txt
+++ b/scripts/moonraker-requirements.txt
@@ -10,4 +10,4 @@ libnacl==1.7.2
 paho-mqtt==1.5.1
 pycurl==7.44.1
 zeroconf==0.37.0
-preprocess-cancellation==0.1.5
+preprocess-cancellation==0.1.6


### PR DESCRIPTION
This fixes a bug that caused retraction moves to be included in bounding box calculations.

Before:
![image](https://user-images.githubusercontent.com/259751/145436948-33a00697-4ab8-4186-9265-41e43e75b002.png)

After:
![image](https://user-images.githubusercontent.com/259751/145436983-c66a8f7d-469e-46af-aa7d-a7a8d83af81d.png)
