### PR TITLE
feat: support for token file for Home Assitant Power

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -411,7 +411,9 @@ port:
 device:
 #   The device ID of the switch to control. This parameter must be provided.
 token:
-#   A token used for request authorization.  This paramter must be provided.
+#   A token used for request authorization.  This parameter must be provided if token_file is not defined
+token_file:
+# A path to a file containing the token used for request authorization. This parameter must be provided if token is not defined.
 domain:
 #   The class of device managed by Home Assistant. Default is "switch".
 status_delay: 1.0

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -773,7 +773,7 @@ class HomeAssistant(HTTPDevice):
         self.domain: str = config.get("domain", "switch")
         self.status_delay: float = config.getfloat("status_delay", 1.)
         token_file = config.get('token_file', None)
-        token = None
+        token = ""
         if token_file is not None:
             pw_file = pathlib.Path(token_file).expanduser().absolute()
             if not pw_file.exists():

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -11,6 +11,7 @@ import struct
 import socket
 import asyncio
 import time
+import pathlib
 from tornado.httpclient import AsyncHTTPClient
 from tornado.escape import json_decode
 
@@ -769,9 +770,17 @@ class HomeAssistant(HTTPDevice):
     def __init__(self, config: ConfigHelper) -> None:
         super().__init__(config, default_port=8123)
         self.device: str = config.get("device")
-        self.token: str = config.get("token")
         self.domain: str = config.get("domain", "switch")
         self.status_delay: float = config.getfloat("status_delay", 1.)
+        token_file = config.get('token_file', None)
+        if token_file is not None:
+            pw_file = pathlib.Path(token_file).expanduser().absolute()
+            if not pw_file.exists():
+                raise config.error(
+                    f"Home Assistant Token file '{pw_file}' does not exist")
+            self.token: str = pw_file.read_text().strip()
+        else:
+            self.token: str = config.get("token")
 
     async def _send_homeassistant_command(self,
                                           command: str

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -773,14 +773,16 @@ class HomeAssistant(HTTPDevice):
         self.domain: str = config.get("domain", "switch")
         self.status_delay: float = config.getfloat("status_delay", 1.)
         token_file = config.get('token_file', None)
+        token = None
         if token_file is not None:
             pw_file = pathlib.Path(token_file).expanduser().absolute()
             if not pw_file.exists():
                 raise config.error(
                     f"Home Assistant Token file '{pw_file}' does not exist")
-            self.token: str = pw_file.read_text().strip()
+            token = pw_file.read_text().strip()
         else:
-            self.token: str = config.get("token")
+            token = config.get("token")
+        self.token: str = token
 
     async def _send_homeassistant_command(self,
                                           command: str


### PR DESCRIPTION
I don't like to store the token in the configuration as I store that on git.

This PR allows to use a file to provide the token for Home Assistant Power devices.