### PR TITLE
Reversed Data Source hierarchy from "distro" Module

### DIFF
--- a/moonraker/components/machine.py
+++ b/moonraker/components/machine.py
@@ -42,6 +42,8 @@ SD_MFGRS = {
     '74': "PNY"
 }
 IP_FAMILIES = {'inet': 'ipv4', 'inet6': 'ipv6'}
+
+
 class Machine:
     def __init__(self, config: ConfigHelper) -> None:
         self.server = config.get_server()
@@ -55,8 +57,6 @@ class Machine:
             }
         else:
             dist_info = {"name": distro.name(pretty=True)}
-        dist_info.update(distro.info())
-        dist_info = {'name': distro.name(pretty=True)}
         dist_info.update(distro.info())
         self.inside_container = False
         self.virt_id = "none"
@@ -460,6 +460,7 @@ class Machine:
         if notify and network != prev_network:
             self.server.send_event("machine:net_state_changed", network)
         self.system_info['network'] = network
+
 
 def load_component(config: ConfigHelper) -> Machine:
     return Machine(config)

--- a/moonraker/components/machine.py
+++ b/moonraker/components/machine.py
@@ -46,6 +46,16 @@ class Machine:
     def __init__(self, config: ConfigHelper) -> None:
         self.server = config.get_server()
         dist_info: Dict[str, Any]
+        if len(distro.distro_release_info()) > 0:
+            dist_info = {
+                "name": distro.distro_release_info()["name"]
+                + " "
+                + distro.distro_release_info()["version_id"],
+                "codename": distro.name(pretty=True),
+            }
+        else:
+            dist_info = {"name": distro.name(pretty=True)}
+        dist_info.update(distro.info())
         dist_info = {'name': distro.name(pretty=True)}
         dist_info.update(distro.info())
         self.inside_container = False


### PR DESCRIPTION
* By default distro.* reads from distro-release file at last.
* To show custom distro names in Frontends
* reversed that and grab first that distro-release file.
* See https://distro.readthedocs.io/en/latest/#distro-release-file
* If file present read that first, if not stick with default behavior.

default:
`"distribution":{
   "name":"Raspbian GNU/Linux 10 (buster)",
   "id":"raspbian",
   "version":"10",
   "version_parts":{
      "major":"10",
      "minor":"",
      "build_number":""
   },
   "like":"debian",
   "codename":"buster"
},`
 tested:
`"distribution":{
   "name":"MainsailOS 0.5.0",
   "codename":"buster",
   "id":"raspbian",
   "version":"10",
   "version_parts":{
      "major":"10",
      "minor":"",
      "build_number":""
   },
   "like":"debian"
},`

/etc/mainsailos-release :
`MainsailOS release 0.5.0 (Jack Sparrow)`

(Note: This codename is a joke ;) And only to be LSB conform. )


Signed-off-by: Stephan Wendel <me@stephanwe.de>