### PR TITLE
feat: secrets support for hosts in mqtt and power

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -466,6 +466,7 @@ address:
 #   to control socket index 1:
 #     192.168.1.127/1
 #   This parameter must be provided.
+#   This option accepts Jinja2 Templates, see the [secrets] section for details.
 port:
 #   The port to connect to.  Default is 9999.
 #
@@ -494,7 +495,8 @@ The following options are available for `tasmota` device types:
 #   Tasmota.
 address:
 #   A valid ip address or hostname for the tasmota device.  This parameter
-#   must be provided.
+#   must be provided. This option accepts Jinja2 Templates, see the [secrets]
+#   section for details.
 password:
 #   A password used to authenticate requests.  Default is no password.
 output_id:
@@ -527,7 +529,8 @@ The following options are available for `shelly` device types:
 
 address:
 #   A valid ip address or hostname for the shelly device.  This parameter
-#   must be provided.
+#   must be provided. This option accepts Jinja2 Templates, see the [secrets]
+#   section for details.
 user:
 #   A user name to use for request authentication.  This option accepts
 #   Jinja2 Templates, see the [secrets] section for details.  If no password
@@ -567,7 +570,8 @@ The following options are available for `homeseer` device types:
 
 address:
 #   A valid ip address or hostname for the homeseer device.  This parameter
-#   must be provided.
+#   must be provided. This option accepts Jinja2 Templates, see the [secrets]
+#   section for details.
 device:
 #   The ID of the device to control.
 #   To find out the ID in the HomeSeer UI, click on the device you want to
@@ -595,7 +599,8 @@ The following options are available for `homeassistant` device types:
 
 address:
 #   A valid ip address or hostname for the Home Assistant server.  This
-#   parameter must be provided.
+#   parameter must be provided. This option accepts Jinja2 Templates, see
+#   the [secrets] section for details.
 protocol:
 #   The protocol for the URL to the Home Assistant server. Default is http.
 port:
@@ -638,7 +643,8 @@ The following options are available for `loxone` device types:
 
 address:
 #   A valid ip address or hostname for the Loxone server.  This
-#   parameter must be provided.
+#   parameter must be provided. This option accepts Jinja2 Templates, see
+#   the [secrets] section for details.
 user:
 #   The user name used for request authorization.  This option accepts
 #   Jinja2 Templates, see the [secrets] section for details. The default is
@@ -990,7 +996,8 @@ publish and subscribe to topics.
 [mqtt]
 address:
 #   Address of the Broker.  This may be a hostname or IP Address.  This
-#   parameter must be provided.
+#   parameter must be provided. This option accepts Jinja2 Templates, see
+#   the [secrets] section for details.
 port:
 #   Port the Broker is listening on.  Default is 1883.
 username:
@@ -1255,9 +1262,10 @@ Example json file:
 
 The `secrets` object is added to Moonraker's Jinja2 environment as a
 global, thus it is available in all templates. All options in
-Moonraker's configuration that accept credentials support templates.
+Moonraker's configuration that accept credentials or hostnames support
+templates.
 
-MQTT configuration example with secret credentaials:
+MQTT configuration example with secret credentials:
 
 ```ini
 [mqtt]

--- a/moonraker/components/mqtt.py
+++ b/moonraker/components/mqtt.py
@@ -141,7 +141,7 @@ class MQTTClient(APITransport, Subscribable):
     def __init__(self, config: ConfigHelper) -> None:
         self.server = config.get_server()
         self.event_loop = self.server.get_event_loop()
-        self.address: str = config.get('address')
+        self.address: str = config.load_template("address", "").render()
         self.port: int = config.getint('port', 1883)
         user = config.gettemplate('username', None)
         self.user_name: Optional[str] = None

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -376,6 +376,7 @@ class PowerDevice:
 class HTTPDevice(PowerDevice):
     def __init__(self,
                  config: ConfigHelper,
+                 default_addr: str = "",
                  default_port: int = -1,
                  default_user: str = "",
                  default_password: str = "",
@@ -384,7 +385,7 @@ class HTTPDevice(PowerDevice):
         super().__init__(config)
         self.client = AsyncHTTPClient()
         self.request_mutex = asyncio.Lock()
-        self.addr: str = config.get("address")
+        self.addr: str = config.load_template("address", default_addr).render()
         self.port = config.getint("port", default_port)
         self.user = config.load_template("user", default_user).render()
         self.password = config.load_template(


### PR DESCRIPTION
Adding support for secrets in hostnames config fields for mqtt and power modules

Ideally, `cors_domains` and `trusted_clients` should also support secrets but that would require some refactoring in `getlists`, or it would require the secrets file to be in json. What do you think?