### PR TITLE
metadata.py: add more metadata

### DIFF
--- a/moonraker/components/file_manager/metadata.py
+++ b/moonraker/components/file_manager/metadata.py
@@ -26,7 +26,6 @@ from typing import (
     Dict,
     List,
     Type,
-    Union
 )
 if TYPE_CHECKING:
     pass

--- a/moonraker/components/file_manager/metadata.py
+++ b/moonraker/components/file_manager/metadata.py
@@ -179,6 +179,9 @@ class BaseSlicer(object):
     def parse_filament_weight_total(self) -> Optional[float]:
         return None
 
+    def parse_filament_name(self) -> Optional[str]:
+        return None
+
     def parse_filament_type(self) -> Optional[str]:
         return None
 
@@ -350,6 +353,10 @@ class PrusaSlicer(BaseSlicer):
         return _regex_find_string(
             r";\sfilament_type\s=\s(.*)", self.footer_data)
 
+    def parse_filament_name(self) -> Optional[str]:
+        return _regex_find_string(
+            r";\sfilament_settings_id\s=\s(.*)", self.footer_data)
+
     def parse_estimated_time(self) -> Optional[float]:
         time_match = re.search(
             r';\sestimated\sprinting\stime.*', self.footer_data)
@@ -471,6 +478,10 @@ class Cura(BaseSlicer):
         return _regex_find_string(
             r";Filament\stype\s=\s(.*)", self.header_data)
 
+    def parse_filament_name(self) -> Optional[str]:
+        return _regex_find_string(
+            r";Filament\sname\s=\s(.*)", self.header_data)
+
     def parse_estimated_time(self) -> Optional[float]:
         return self._parse_max_float(r";TIME:.*", self.header_data)
 
@@ -550,6 +561,10 @@ class Simplify3D(BaseSlicer):
     def parse_filament_weight_total(self) -> Optional[float]:
         return _regex_find_first(
             r";\s+Plastic\sweight:\s(\d+\.?\d*)\sg", self.footer_data)
+
+    def parse_filament_name(self) -> Optional[str]:
+        return _regex_find_string(
+            r";\s+printMaterial,(.*)", self.header_data)
 
     def parse_estimated_time(self) -> Optional[float]:
         time_match = re.search(
@@ -693,6 +708,10 @@ class IdeaMaker(BaseSlicer):
         return _regex_find_string(
             r";Filament\stype\s=\s(.*)", self.header_data)
 
+    def parse_filament_name(self) -> Optional[str]:
+        return _regex_find_string(
+            r";Filament\sname\s=\s(.*)", self.header_data)
+
     def parse_filament_weight_total(self) -> Optional[float]:
         pi = 3.141592653589793
         length = _regex_find_floats(
@@ -771,9 +790,10 @@ SUPPORTED_DATA = [
     'first_layer_height',
     'first_layer_extr_temp',
     'first_layer_bed_temp',
+    'filament_name',
+    'filament_type',
     'filament_total',
     'filament_weight_total',
-    'filament_type',
     'thumbnails']
 
 def process_objects(file_path: str) -> None:

--- a/moonraker/components/file_manager/metadata.py
+++ b/moonraker/components/file_manager/metadata.py
@@ -254,6 +254,9 @@ class BaseSlicer(object):
     def parse_layer_count(self) -> Optional[int]:
         return None
 
+    def parse_nozzle_diameter(self) -> Optional[float]:
+        return None
+
 class UnknownSlicer(BaseSlicer):
     def check_identity(self, data: str) -> Optional[Dict[str, str]]:
         return {'slicer': "Unknown"}
@@ -359,6 +362,10 @@ class PrusaSlicer(BaseSlicer):
         return _regex_find_first(
             r"; first_layer_bed_temperature = (\d+\.?\d*)", self.footer_data)
 
+    def parse_nozzle_diameter(self) -> Optional[float]:
+        return _regex_find_first(
+            r";\snozzle_diameter\s=\s(\d+\.\d*)", self.footer_data)
+
     def parse_layer_count(self) -> Optional[int]:
         match = re.search(r"; total layers count = (\d+)", self.footer_data)
         val: Optional[int] = None
@@ -456,6 +463,10 @@ class Cura(BaseSlicer):
     def parse_first_layer_bed_temp(self) -> Optional[float]:
         return _regex_find_first(
             r"M190 S(\d+\.?\d*)", self.header_data)
+
+    def parse_nozzle_diameter(self) -> Optional[float]:
+        return _regex_find_first(
+            r";Nozzle\sdiameter\s=\s(\d+\.\d*)", self.header_data)
 
     def parse_thumbnails(self) -> Optional[List[Dict[str, Any]]]:
         # Attempt to parse thumbnails from file metadata
@@ -562,6 +573,10 @@ class Simplify3D(BaseSlicer):
 
     def parse_first_layer_bed_temp(self) -> Optional[float]:
         return self._get_first_layer_temp("Heated Bed")
+
+    def parse_nozzle_diameter(self) -> Optional[float]:
+        return _regex_find_first(
+            r";\s+extruderDiameter,(\d+\.\d*)", self.header_data)
 
 class KISSlicer(BaseSlicer):
     def check_identity(self, data: str) -> Optional[Dict[str, Any]]:
@@ -683,6 +698,10 @@ class IdeaMaker(BaseSlicer):
         return _regex_find_first(
             r"M190 S(\d+\.?\d*)", self.header_data)
 
+    def parse_nozzle_diameter(self) -> Optional[float]:
+        return _regex_find_first(
+            r";Nozzle\sdiameter\s=\s(\d+\.\d*)", self.header_data)
+
 class IceSL(BaseSlicer):
     def check_identity(self, data) -> Optional[Dict[str, Any]]:
         match = re.search(r"; <IceSL.*>", data)
@@ -720,10 +739,19 @@ SUPPORTED_SLICERS: List[Type[BaseSlicer]] = [
     KISSlicer, IdeaMaker, IceSL
 ]
 SUPPORTED_DATA = [
-    'layer_height', 'first_layer_height', 'object_height',
-    'filament_total', 'filament_weight_total', 'estimated_time',
-    'thumbnails', 'first_layer_bed_temp', 'first_layer_extr_temp',
-    'gcode_start_byte', 'gcode_end_byte', 'layer_count']
+    'gcode_start_byte',
+    'gcode_end_byte',
+    'layer_count',
+    'object_height',
+    'estimated_time',
+    'nozzle_diameter',
+    'layer_height',
+    'first_layer_height',
+    'first_layer_extr_temp',
+    'first_layer_bed_temp',
+    'filament_total',
+    'filament_weight_total',
+    'thumbnails']
 
 def process_objects(file_path: str) -> None:
     fname = os.path.basename(file_path)


### PR DESCRIPTION
This PR will add parsing of 3 new, optional metadata types for:
- PrusaSlicer and it's derivatives
- Simplify3D
- Cura
- IdeaMaker

Those types are:
* Nozzle diameter
* Filament type
* Filament name

Note: As far as i am aware Simplify3D does not provide any info about the filament type. At least i didn't find anything during research and testing. So in case of Simplify3D, this PR will only provide filament name and nozzle diameter.

For Cura and IdeaMaker it is necessary to add a custom start g-code comment because they do not output the requested metadata to the g-code file by default. But they do provide internal placeholder variables for those values. The required lines for the start g-code are as follows (it is important to have the exact syntax as shown) :

Cura:
```
;Nozzle diameter = {machine_nozzle_size}
;Filament type = {material_type}
;Filament name = {material_name}
```

IdeaMaker:
```
;Nozzle diameter = {machine_nozzle_diameter1}
;Filament type = {filament_name_abbreviation1}
;Filament name = {filament_name1}
```



Signed-off-by: Dominik Willner <th33xitus@gmail.com>