### PR TITLE
wled: Add serial support for direct communication

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1106,12 +1106,16 @@ Enables control of an WLED strip.
 # moonraker.conf
 
 [wled strip_name]
+type:
+#   The type of device. Can be either http, or serial.
+#   This parameter must be provided.
 address:
 #   The address should be a valid ip or hostname for the wled webserver.
-#   Address or serial must be specified.
+#   Required when type: http
 serial:
 #   The serial port to be used to communicate directly to wled. Requires wled
-#   0.13 Build 2108250 or later. Address or serial must be specified.
+#   0.13 Build 2108250 or later.
+#   Required when type: serial
 initial_preset:
 #   Initial preset ID (favourite) to use. If not specified initial_colors
 #   will be used instead.
@@ -1127,16 +1131,18 @@ color_order:
 #   Color order for WLED strip, RGB or RGBW (default: RGB)
 
 ```
-Below are some potential examples:
+Below are some examples:
 ```ini
 # moonraker.conf
 
 [wled case]
+type: http
 address: led1.lan
 initial_preset: 45
 chain_count: 76
 
 [wled lounge]
+type: http
 address: 192.168.0.45
 initial_red: 0.5
 initial_green: 0.4
@@ -1144,6 +1150,7 @@ initial_blue: 0.3
 chain_count: 42
 
 [wled stealthburner]
+type: serial
 serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
 initial_white: 0.6
 chain_count: 3

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1107,8 +1107,11 @@ Enables control of an WLED strip.
 
 [wled strip_name]
 address:
-#   The address should be a valid ip or hostname for the wled webserver and
-#   must be specified
+#   The address should be a valid ip or hostname for the wled webserver.
+#   Address or serial must be specified.
+serial:
+#   The serial port to be used to communicate directly to wled. Requires wled
+#   0.13 Build 2108250 or later. Address or serial must be specified.
 initial_preset:
 #   Initial preset ID (favourite) to use. If not specified initial_colors
 #   will be used instead.
@@ -1139,6 +1142,11 @@ initial_red: 0.5
 initial_green: 0.4
 initial_blue: 0.3
 chain_count: 42
+
+[wled stealthburner]
+serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+initial_white: 0.6
+chain_count: 3
 ```
 
 It is possible to control wled from the klippy host, this can be done using

--- a/moonraker/components/wled.py
+++ b/moonraker/components/wled.py
@@ -219,17 +219,17 @@ class StripHttp(Strip):
         self.client = AsyncHTTPClient()
 
     async def send_wled_command_impl(self: StripHttp,
-                                state: Dict[str, Any]) -> None:
+                                     state: Dict[str, Any]) -> None:
         async with self.request_mutex:
             logging.debug(f"WLED: url:{self.url} json:{state}")
 
             headers = {"Content-Type": "application/json"}
             request = HTTPRequest(url=self.url,
-                                    method="POST",
-                                    headers=headers,
-                                    body=json.dumps(state),
-                                    connect_timeout=self.timeout,
-                                    request_timeout=self.timeout)
+                                  method="POST",
+                                  headers=headers,
+                                  body=json.dumps(state),
+                                  connect_timeout=self.timeout,
+                                  request_timeout=self.timeout)
             response = await self.client.fetch(request)
 
             logging.debug(
@@ -252,7 +252,7 @@ class StripSerial(Strip):
                                  write_timeout=0)
 
     async def send_wled_command_impl(self: StripSerial,
-                                state: Dict[str, Any]) -> None:
+                                     state: Dict[str, Any]) -> None:
         async with self.request_mutex:
             logging.debug(f"WLED: serial:{self.ser.name} json:{state}")
 
@@ -261,7 +261,7 @@ class StripSerial(Strip):
 
             # asyncio support is still experimental in pySerial
             self.ser.write(json.dumps(state).encode())
-    
+
     def close(self: StripSerial):
         if self.ser.is_open:
             self.ser.close()

--- a/moonraker/components/wled.py
+++ b/moonraker/components/wled.py
@@ -9,6 +9,8 @@
 # Wiki at https://kno.wled.ge/
 
 from __future__ import annotations
+from abc import ABC, abstractmethod
+from collections import UserString
 from enum import Enum
 import logging
 import json
@@ -50,7 +52,7 @@ class OnOff(str, Enum):
     on: str = "on"
     off: str = "off"
 
-class Strip:
+class Strip(ABC):
     def __init__(self: Strip,
                  name: str,
                  color_order: ColorOrder,
@@ -60,28 +62,6 @@ class Strip:
 
         self.name = name
         self.color_order = color_order
-
-        # Read the uri information
-        addr: str = cfg.get("address", "")
-        port: int = cfg.getint("port", 80)
-        protocol: str = cfg.get("protocol", "http")
-        self.url = f"{protocol}://{addr}:{port}/json"
-
-        # Read the serial information (requires wled 0.13 2108250 or greater)
-        serialport: str = cfg.get("serial", "")
-        baud: int = cfg.getint("baud", 115200, above=49)
-
-        self.timeout: float = cfg.getfloat("timeout", 2.)
-
-        self.use_http: bool = True
-        if addr != "":
-            self.client = AsyncHTTPClient()
-        elif serialport != "":
-            self.ser = serial.Serial(serialport, baud,
-                                     write_timeout=self.timeout)
-            self.use_http = False
-        else:
-            raise cfg.error(f"Address or serial must be specified")
 
         self.initial_preset: int = cfg.getint("initial_preset", -1)
         self.initial_red: float = cfg.getfloat("initial_red", 0.5)
@@ -142,13 +122,19 @@ class Strip:
             elem_size = len(led_data)
             self._chain_data[(index-1)*elem_size:index*elem_size] = led_data
 
+    @abstractmethod
+    async def send_wled_command_impl(self: Strip,
+                                     state: Dict[str, Any]) -> None:
+        """Sends the json request to wled"""
+
+    @abstractmethod
+    def close(self: Strip):
+        """Closes any wled communication mechanism"""
+
     async def _send_wled_command(self: Strip,
                                  state: Dict[str, Any]) -> None:
         try:
-            if self.use_http:
-                await self._send_wled_command_http(state)
-            else:
-                await self._send_wled_command_serial(state)
+            await self.send_wled_command_impl(state)
 
             self.error_state = None
         except Exception as e:
@@ -157,43 +143,9 @@ class Strip:
             logging.exception(msg)
             raise self.server.error(msg)
 
-    async def _send_wled_command_http(self: Strip,
-                                      state: Dict[str, Any]) -> None:
-        async with self.request_mutex:
-            logging.debug(f"WLED: url:{self.url} json:{state}")
-
-            headers = {"Content-Type": "application/json"}
-            request = HTTPRequest(url=self.url,
-                                  method="POST",
-                                  headers=headers,
-                                  body=json.dumps(state),
-                                  connect_timeout=self.timeout,
-                                  request_timeout=self.timeout)
-            response = await self.client.fetch(request)
-
-            logging.debug(
-                f"WLED: url:{self.url} status:{response.code} "
-                f"response:{response.body}")
-
-    async def _send_wled_command_serial(self: Strip,
-                                        state: Dict[str, Any]) -> None:
-        async with self.request_mutex:
-            logging.debug(f"WLED: serial:{self.ser.name} json:{state}")
-
-            if not self.ser.is_open:
-                self.ser.open()
-
-            # asyncio support is still experimental in pySerial
-            self.ser.write(json.dumps(state).encode())
-            self.ser.flush()
-
-            logging.debug(f"WLED: serial:{self.ser.name} flushed")
-
-            self.ser.close()
-
     async def wled_on(self: Strip, preset: int) -> None:
         self.onoff = OnOff.on
-        logging.debug(f"WLED: on {self.name} PRESET={preset}")
+        logging.debug(f"WLED: {self.name} on PRESET={preset}")
         if preset < 0:
             # WLED_ON STRIP=strip (no args) - reset to default
             await self.initialize()
@@ -203,7 +155,7 @@ class Strip:
             await self._send_wled_command({"on": True, "ps": preset})
 
     async def wled_off(self: Strip) -> None:
-        logging.debug(f"WLED: off {self.name}")
+        logging.debug(f"WLED: {self.name} off")
         self.onoff = OnOff.off
         await self._send_wled_command({"on": False})
 
@@ -254,6 +206,72 @@ class Strip:
             # next transmitting
             self.send_full_chain_data = True
 
+class StripHttp(Strip):
+    def __init__(self: StripHttp,
+                 name: str,
+                 color_order: ColorOrder,
+                 cfg: ConfigHelper):
+        super().__init__(name, color_order, cfg)
+
+        # Read the uri information
+        addr: str = cfg.get("address")
+        port: int = cfg.getint("port", 80)
+        protocol: str = cfg.get("protocol", "http")
+        self.url = f"{protocol}://{addr}:{port}/json"
+
+        self.timeout: float = cfg.getfloat("timeout", 2.)
+        self.client = AsyncHTTPClient()
+
+    async def send_wled_command_impl(self: StripHttp,
+                                state: Dict[str, Any]) -> None:
+        logging.debug(f"WLED: url:{self.url} json:{state}")
+
+        headers = {"Content-Type": "application/json"}
+        request = HTTPRequest(url=self.url,
+                                method="POST",
+                                headers=headers,
+                                body=json.dumps(state),
+                                connect_timeout=self.timeout,
+                                request_timeout=self.timeout)
+        response = await self.client.fetch(request)
+
+        logging.debug(
+            f"WLED: url:{self.url} status:{response.code} "
+            f"response:{response.body}")
+
+    def close(self: StripHttp):
+        pass
+
+class StripSerial(Strip):
+    def __init__(self: StripSerial,
+                 name: str,
+                 color_order: ColorOrder,
+                 cfg: ConfigHelper):
+        super().__init__(name, color_order, cfg)
+
+        # Read the serial information (requires wled 0.13 2108250 or greater)
+        serialport: str = cfg.get("serial")
+        baud: int = cfg.getint("baud", 115200, above=49)
+
+        # write_timeout of 0 is non-blocking
+        self.ser = serial.Serial(serialport, baud,
+                                 write_timeout=0)
+
+    async def send_wled_command_impl(self: StripSerial,
+                                state: Dict[str, Any]) -> None:
+        async with self.request_mutex:
+            logging.debug(f"WLED: serial:{self.ser.name} json:{state}")
+
+            if not self.ser.is_open:
+                self.ser.open()
+
+            # asyncio support is still experimental in pySerial
+            self.ser.write(json.dumps(state).encode())
+    
+    def close(self: StripSerial):
+        if self.ser.is_open:
+            self.ser.close()
+
 class WLED:
     def __init__(self: WLED, config: ConfigHelper) -> None:
         try:
@@ -266,6 +284,10 @@ class WLED:
             color_orders = {
                 "RGB": ColorOrder.RGB,
                 "RGBW": ColorOrder.RGBW
+            }
+            strip_types = {
+                "http": StripHttp,
+                "serial": StripSerial
             }
             self.strips = {}
             for section in prefix_sections:
@@ -285,7 +307,19 @@ class WLED:
                     raise cfg.error(
                         f"Color order not supported: {color_order_cfg}")
 
-                self.strips[name] = Strip(name, color_order, cfg)
+                strip_type: str = cfg.get("type", "http")
+                strip_class: Optional[Type[Strip]]
+                strip_class = strip_types.get(strip_type)
+                if strip_class is None:
+                    raise cfg.error(f"Unsupported Strip Type: {strip_type}")
+                try:
+                    strip = strip_class(name, color_order, cfg)
+                except Exception as e:
+                    msg = f"Failed to initialise strip [{cfg.get_name()}]\n{e}"
+                    self.server.add_warning(msg)
+                    continue
+
+                self.strips[name] = strip
 
             # Register two remote methods for GCODE
             self.server.register_remote_method(
@@ -465,6 +499,10 @@ class WLED:
             return strip.get_strip_info()
 
         raise self.server.error(f"Unsupported wled request: {req}")
+
+    def close(self) -> None:
+        for strip in self.strips.values():
+            strip.close()
 
 def load_component(config: ConfigHelper) -> WLED:
     return WLED(config)

--- a/moonraker/components/wled.py
+++ b/moonraker/components/wled.py
@@ -158,7 +158,7 @@ class Strip:
             raise self.server.error(msg)
 
     async def _send_wled_command_http(self: Strip,
-                                 state: Dict[str, Any]) -> None:
+                                      state: Dict[str, Any]) -> None:
         async with self.request_mutex:
             logging.debug(f"WLED: url:{self.url} json:{state}")
 
@@ -176,7 +176,7 @@ class Strip:
                 f"response:{response.body}")
 
     async def _send_wled_command_serial(self: Strip,
-                                 state: Dict[str, Any]) -> None:
+                                        state: Dict[str, Any]) -> None:
         async with self.request_mutex:
             logging.debug(f"WLED: serial:{self.ser.name} json:{state}")
 

--- a/moonraker/components/wled.py
+++ b/moonraker/components/wled.py
@@ -13,6 +13,7 @@ from enum import Enum
 import logging
 import json
 import asyncio
+import os
 import serial
 from tornado.httpclient import AsyncHTTPClient
 from tornado.httpclient import HTTPRequest
@@ -250,6 +251,8 @@ class StripSerial(Strip):
         # write_timeout of 0 is non-blocking
         self.ser = serial.Serial(serialport, baud,
                                  write_timeout=0)
+        fd = self.ser.fileno()
+        os.set_blocking(fd, False)                         
 
     async def send_wled_command_impl(self: StripSerial,
                                      state: Dict[str, Any]) -> None:

--- a/moonraker/components/wled.py
+++ b/moonraker/components/wled.py
@@ -73,13 +73,13 @@ class Strip:
 
         self.timeout: float = cfg.getfloat("timeout", 2.)
 
+        self.use_http: bool = True
         if addr != "":
             self.client = AsyncHTTPClient()
-            self.use_http: bool = True
         elif serialport != "":
             self.ser = serial.Serial(serialport, baud,
                                      write_timeout=self.timeout)
-            self.use_http: bool = False
+            self.use_http = False
         else:
             raise cfg.error(f"Address or serial must be specified")
 

--- a/moonraker/components/wled.py
+++ b/moonraker/components/wled.py
@@ -1,6 +1,6 @@
 # WLED neopixel support
 #
-# Copyright (C) 2021  Richard Mitchell <richardjm+moonraker@gmail.com>
+# Copyright (C) 2021-2022 Richard Mitchell <richardjm+moonraker@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -81,8 +81,7 @@ class Strip:
                                      write_timeout=self.timeout)
             self.use_http: bool = False
         else:
-            raise cfg.error(
-                        f"Address or serial must be specified")
+            raise cfg.error(f"Address or serial must be specified")
 
         self.initial_preset: int = cfg.getint("initial_preset", -1)
         self.initial_red: float = cfg.getfloat("initial_red", 0.5)
@@ -165,11 +164,11 @@ class Strip:
 
             headers = {"Content-Type": "application/json"}
             request = HTTPRequest(url=self.url,
-                                    method="POST",
-                                    headers=headers,
-                                    body=json.dumps(state),
-                                    connect_timeout=self.timeout,
-                                    request_timeout=self.timeout)
+                                  method="POST",
+                                  headers=headers,
+                                  body=json.dumps(state),
+                                  connect_timeout=self.timeout,
+                                  request_timeout=self.timeout)
             response = await self.client.fetch(request)
 
             logging.debug(
@@ -188,9 +187,8 @@ class Strip:
             self.ser.write(json.dumps(state).encode())
             self.ser.flush()
 
-            logging.debug(
-                f"WLED: serial:{self.ser.name} flushed")
-                
+            logging.debug(f"WLED: serial:{self.ser.name} flushed")
+
             self.ser.close()
 
     async def wled_on(self: Strip, preset: int) -> None:

--- a/moonraker/components/wled.py
+++ b/moonraker/components/wled.py
@@ -252,7 +252,7 @@ class StripSerial(Strip):
         self.ser = serial.Serial(serialport, baud,
                                  write_timeout=0)
         fd = self.ser.fileno()
-        os.set_blocking(fd, False)                         
+        os.set_blocking(fd, False)
 
     async def send_wled_command_impl(self: StripSerial,
                                      state: Dict[str, Any]) -> None:


### PR DESCRIPTION
- For mobile printers such as Voron 0.1 having to reconfigure wifi in each location is a pain
- In the 0.13 release (still in beta) direct serial communication was added - and seems to work very nicely

Signed-off-by:  Richard Mitchell <richardjm+moonraker@gmail.com>