### PR TITLE
metadata.py: fix parsing of IdeaMaker nozzle_diameter

### DIFF
--- a/moonraker/components/file_manager/metadata.py
+++ b/moonraker/components/file_manager/metadata.py
@@ -740,7 +740,7 @@ class IdeaMaker(BaseSlicer):
 
     def parse_nozzle_diameter(self) -> Optional[float]:
         return _regex_find_first(
-            r";Nozzle\sdiameter\s=\s(\d+\.\d*)", self.header_data)
+            r";Dimension:(?:\s\d+\.\d+){3}\s(\d+\.\d+)", self.header_data)
 
 class IceSL(BaseSlicer):
     def check_identity(self, data) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION
This PR will improve a method previously introduced by #322.

IdeaMaker already exports the nozzle diameter, so using a custom g-code comment is obsolete. The new regex pattern extracts the natively exported nozzle diameter.

Signed-off-by: Dominik Willner <th33xitus@gmail.com>