### PR TITLE
wled: Show config errors

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1130,8 +1130,10 @@ initial_white:
 #   initial_white will only be used for RGBW wled strips (defaults: 0.5)
 chain_count:
 #   Number of addressable neopixels for use (default: 1)
-color_order:
-#   Color order for WLED strip, RGB or RGBW (default: RGB)
+color_config:
+#   Indicates if any strip connected to wled supports the white channel.
+#   The actual color order is set per GPIO in wled directly. Must be
+#   either RGB or RGBW (default: RGB)
 
 ```
 Below are some examples:
@@ -1157,6 +1159,7 @@ type: serial
 serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
 initial_white: 0.6
 chain_count: 3
+color_config: RGBW
 ```
 
 It is possible to control wled from the klippy host, this can be done using

--- a/moonraker/components/wled.py
+++ b/moonraker/components/wled.py
@@ -150,6 +150,9 @@ class Strip():
     async def wled_off(self: Strip) -> None:
         logging.debug(f"WLED: {self.name} off")
         self.onoff = OnOff.off
+        # Without this calling SET_WLED for a single pixel after WLED_OFF
+        # would send just that pixel
+        self.send_full_chain_data = True
         await self._send_wled_command({"on": False})
 
     def _wled_pixel(self: Strip, index: int) -> List[int]:

--- a/moonraker/components/wled.py
+++ b/moonraker/components/wled.py
@@ -168,16 +168,15 @@ class Strip():
         self._update_color_data(red, green, blue, white, index)
         if transmit:
 
-            if self.onoff == OnOff.off:
+            if self.onoff == OnOff.off or self.send_full_chain_data:
                 # Without a separate On call individual led control doesn"t
                 # turn the led strip back on or doesn't set brightness
-                # correctly
+                # correctly from off or a preset
                 self.onoff = OnOff.on
                 await self._send_wled_command({"on": True,
                                                "tt": 0,
                                                "bri": 255,
-                                               "seg": {"bri": 255,
-                                                       "i": []}})
+                                               "seg": {"bri": 255}})
 
             # Base command for setting an led (for all active segments)
             # See https://kno.wled.ge/interfaces/json-api/
@@ -192,7 +191,7 @@ class Strip():
                 self.send_full_chain_data = False
                 cdata = []
                 for i in range(self.chain_count):
-                    cdata.append(self._wled_pixel(i-1))
+                    cdata.append(self._wled_pixel(i+1))
                 state["seg"]["i"] = cdata
             else:
                 # Only one pixel has changed since last full data sent


### PR DESCRIPTION
Support more synonym strings for colors
Case insensitive string type checks
Show errors in UI if e.g. wrong color was selected
Public color_config not color_order as it has confused users
Fix documentation for white stealthburner example

Signed-off-by:  Richard Mitchell <richardjm+moonraker@gmail.com>