### PR TITLE
Adding power option for SmartThings switches

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -894,9 +894,8 @@ port: 443
 device: 
 #   The Device guid of the switch to control. This parameter must be provided.
 token:
-#   A token used for request authorization.  This option accepts
-#   Jinja2 Templates, see the [secrets] section for details. This paramter
-#   must be provided.
+#   A token used for request authorization.  
+#   See https://developer-preview.smartthings.com/docs/advanced/authorization-and-permissions/
 ```
 
 Example:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -881,6 +881,36 @@ state_response_template:
 # not necessary to query after a command
 query_after_command: False
 ```
+####  SmartThings (HTTP)
+
+The following options are available for `smartthings` device types:
+
+```ini
+# moonraker.conf
+
+address: api.smartthings.com
+protocol: https
+port: 443
+device: 
+#   The Device guid of the switch to control. This parameter must be provided.
+token:
+#   A token used for request authorization.  This option accepts
+#   Jinja2 Templates, see the [secrets] section for details. This paramter
+#   must be provided.
+```
+
+Example:
+```ini
+# moonraker.conf
+
+[power smartthings_switch]
+type: smartthings
+address: api.smartthings.com
+protocol: https
+port: 443
+device: smartthings-device-id
+token: smartthings-very-long-token
+```
 
 #### Toggling device state from Klipper
 

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -51,7 +51,8 @@ class PrinterPower:
             "homeassistant": HomeAssistant,
             "loxonev1": Loxonev1,
             "rf": RFDevice,
-            "mqtt": MQTTDevice
+            "mqtt": MQTTDevice,
+            "smartthings": SmartThings
         }
 
         for section in prefix_sections:
@@ -945,6 +946,57 @@ class Shelly(HTTPDevice):
         timer_remaining = res[f"timer_remaining"] if self.timer != "" else 0
         return "on" if state and timer_remaining == 0 else "off"
 
+class SmartThings(HTTPDevice):
+    def __init__(self, config: ConfigHelper) -> None:
+        super().__init__(config, default_port=443, default_protocol="https")
+        self.addr: str = config.get("address", "api.smartthings.com")
+        self.device: str = config.get("device", "")
+        self.token: str = config.get("token", "")
+        self.status_delay: float = config.getfloat("status_delay", 1.)
+
+    async def _send_smartthings_command(self,
+                                          command: str
+                                          ) -> Dict[str, Any]:
+
+        if (command == "on" or command == "off"):
+            method = "POST"
+            url = f"{self.protocol}://{self.addr}/v1/devices/{self.device}/commands"
+            body = f'[{{"component":"main", "capability":"switch", "command": "{command}"}}]'
+        elif command == "info":
+            method = "GET"
+            url = f"{self.protocol}://{self.addr}/v1/devices/{self.device}/components/main/capabilities/switch/status"
+            body = None
+        else:
+            raise self.server.error(
+                f"Invalid SmartThings command: {command}")
+            
+        headers = {
+            'Authorization': f'Bearer {self.token}',
+            'Content-Type': 'application/json'
+        }
+        
+        try:
+            if method == "POST":
+                response = await self.client.fetch(
+                    url, method=method, headers=headers, body=body)
+            elif method == "GET":
+                response = await self.client.fetch(
+                    url, method=method, headers=headers)
+            data: Dict[str, Any] = json_decode(response.body)
+        except Exception:
+            msg = f"Error sending SmartThings command: {command}"
+            logging.exception(msg)
+            raise self.server.error(msg)
+        return data
+
+    async def _send_status_request(self) -> str:
+        res = await self._send_smartthings_command("info")
+        return res["switch"]["value"].lower()
+
+    async def _send_power_request(self, state: str) -> str:
+        res = await self._send_smartthings_command(state)
+        # Assume it was successful and return the requested state
+        return state
 
 class HomeSeer(HTTPDevice):
     def __init__(self, config: ConfigHelper) -> None:


### PR DESCRIPTION
See the following for access token generation: https://developer-preview.smartthings.com/docs/advanced/authorization-and-permissions/

The device guids for use in the configuration can be found by doing a GET against https://api.smartthings.com/v1/devices with your 'bearer' token.