### PR TITLE
Implemented config-based webcam settings for Cura

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -246,19 +246,19 @@ enable_ufp: True
 #   upload files in .gcode format.  This setting has no impact on other
 #   slicers.  The default is True.
 
-flipH: False
+flip_h: False
 #   Set the webcam horizontal flip.  The default is False.
-flipV: False
+flip_h: False
 #   Set the webcam vertical flip.  The default is False.
-rotate90: False
+rotate_90: False
 #   Set the webcam rotation by 90 degrees.  The default is False.
-streamUrl: /webcam/?action=stream
+stream_url: /webcam/?action=stream
 #   The URL to use for streaming the webcam.  It can be set to an absolute
 #   URL if needed. In order to get the webcam to work in Cura through
 #   an Octoprint connection, you can set this value to
 #   http://<octoprint ip>/webcam/?action=stream.  The default value is
 #   /webcam/?action=stream.
-webcamEnabled: True
+webcam_enabled: True
 #   Enables the webcam.  The default is True.
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -245,6 +245,7 @@ enable_ufp: True
 #   files will be uploaded in UFP format.  When set to False Cura will
 #   upload files in .gcode format.  This setting has no impact on other
 #   slicers.  The default is True.
+
 flipH: False
 #   Set the webcam horizontal flip.  The default is False.
 flipV: False
@@ -253,9 +254,10 @@ rotate90: False
 #   Set the webcam rotation by 90 degrees.  The default is False.
 streamUrl: /webcam/?action=stream
 #   The URL to use for streaming the webcam.  It can be set to an absolute
-#   URL if needed. In order to get the Cura webcam to work, you can set
-#   this value to http://<octoprint ip>/webcam/?action=stream.  The default
-#   value is /webcam/?action=stream.
+#   URL if needed. In order to get the webcam to work in Cura through
+#   an Octoprint connection, you can set this value to
+#   http://<octoprint ip>/webcam/?action=stream.  The default value is
+#   /webcam/?action=stream.
 webcamEnabled: True
 #   Enables the webcam.  The default is True.
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -245,6 +245,19 @@ enable_ufp: True
 #   files will be uploaded in UFP format.  When set to False Cura will
 #   upload files in .gcode format.  This setting has no impact on other
 #   slicers.  The default is True.
+flipH: False
+#   Set the webcam horizontal flip.  The default is False.
+flipV: False
+#   Set the webcam vertical flip.  The default is False.
+rotate90: False
+#   Set the webcam rotation by 90 degrees.  The default is False.
+streamUrl: /webcam/?action=stream
+#   The URL to use for streaming the webcam.  It can be set to an absolute
+#   URL if needed. In order to get the Cura webcam to work, you can set
+#   this value to http://<octoprint ip>/webcam/?action=stream.  The default
+#   value is /webcam/?action=stream.
+webcamEnabled: True
+#   Enables the webcam.  The default is True.
 ```
 
 !!! Tip

--- a/docs/moonraker.conf
+++ b/docs/moonraker.conf
@@ -19,8 +19,8 @@ cors_domains:
 # (PrusaSlicer, SuperSlicer)
 [octoprint_compat]
 # Default webcam config values:
-# flipH = false
-# flipV = false
-# rotate90 = false
-# streamUrl = /webcam/?action=stream
-# webcamEnabled = true
+# flip_h = false
+# flip_v = false
+# rotate_90 = false
+# stream_url = /webcam/?action=stream
+# webcam_enabled = true

--- a/docs/moonraker.conf
+++ b/docs/moonraker.conf
@@ -18,3 +18,9 @@ cors_domains:
 # Supports Cura, Slic3r, and Slic3r dervivatives
 # (PrusaSlicer, SuperSlicer)
 [octoprint_compat]
+# Default webcam config values:
+# flipH = false
+# flipV = false
+# rotate90 = false
+# streamUrl = /webcam/?action=stream
+# webcamEnabled = true

--- a/docs/user_changes.md
+++ b/docs/user_changes.md
@@ -2,6 +2,20 @@
 This file will track changes that require user intervention,
 such as a configuration change or a reinstallation.
 
+### February 16th 2022
+- Webcam settings can now be defined in the `moonraker.conf` file, under
+  the `[octoprint_compat]` section. The default values are being used as
+  default values.
+
+  Default values:
+
+  | --- | --- |
+  | flipH | False |
+  | flipV | False |
+  | rotate90 | False |
+  | streamUrl | /webcam/?action=stream |
+  | webcamEnabled | True |
+
 ### January 22th 2022
 - The `color_order` option in the `[wled]` section has been deprecated.
   This is configured in wled directly. This is not a breaking change,

--- a/docs/user_changes.md
+++ b/docs/user_changes.md
@@ -10,11 +10,11 @@ such as a configuration change or a reinstallation.
   Default values:
   | Setting | Default value |
   |---------|---------------|
-  | flipH | False |
-  | flipV | False |
-  | rotate90 | False |
-  | streamUrl | /webcam/?action=stream |
-  | webcamEnabled | True |
+  | flip_h | False |
+  | flip_v | False |
+  | rotate_90 | False |
+  | stream_url | /webcam/?action=stream |
+  | webcam_enabled | True |
 
 ### January 22th 2022
 - The `color_order` option in the `[wled]` section has been deprecated.

--- a/docs/user_changes.md
+++ b/docs/user_changes.md
@@ -8,8 +8,8 @@ such as a configuration change or a reinstallation.
   default values.
 
   Default values:
-
-  | --- | --- |
+  | Setting | Default value |
+  |---------|---------------|
   | flipH | False |
   | flipV | False |
   | rotate90 | False |

--- a/moonraker/components/octoprint_compat.py
+++ b/moonraker/components/octoprint_compat.py
@@ -48,7 +48,7 @@ class OctoprintCompat:
             'flipH': config.getboolean('flipH', False),
             'flipV': config.getboolean('flipV', False),
             'rotate90': config.getboolean('rotate90', False),
-            'streamUrl': config.getboolean('streamUrl', '/webcam/?action=stream'),
+            'streamUrl': config.get('streamUrl', '/webcam/?action=stream'),
             'webcamEnabled': config.getboolean('webcamEnabled', True),
         }
 

--- a/moonraker/components/octoprint_compat.py
+++ b/moonraker/components/octoprint_compat.py
@@ -45,11 +45,11 @@ class OctoprintCompat:
 
         # Get webcam settings from config
         self.webcam: Dict[str, Any] = {
-            'flipH': config.getboolean('flipH', False),
-            'flipV': config.getboolean('flipV', False),
-            'rotate90': config.getboolean('rotate90', False),
-            'streamUrl': config.get('streamUrl', '/webcam/?action=stream'),
-            'webcamEnabled': config.getboolean('webcamEnabled', True),
+            'flipH': config.getboolean('flip_h', False),
+            'flipV': config.getboolean('flip_v', False),
+            'rotate90': config.getboolean('rotate_90', False),
+            'streamUrl': config.get('stream_url', '/webcam/?action=stream'),
+            'webcamEnabled': config.getboolean('webcam_enabled', True),
         }
 
         # Local variables

--- a/moonraker/components/octoprint_compat.py
+++ b/moonraker/components/octoprint_compat.py
@@ -43,6 +43,15 @@ class OctoprintCompat:
             'software_version')
         self.enable_ufp: bool = config.getboolean('enable_ufp', True)
 
+        # Get webcam settings from config
+        self.webcam: Dict[str, Any] = {
+            'flipH': config.getboolean('flipH', False),
+            'flipV': config.getboolean('flipV', False),
+            'rotate90': config.getboolean('rotate90', False),
+            'streamUrl': config.getboolean('streamUrl', '/webcam/?action=stream'),
+            'webcamEnabled': config.getboolean('webcamEnabled', True),
+        }
+
         # Local variables
         self.klippy_apis: APIComp = self.server.lookup_component('klippy_apis')
         self.heaters: Dict[str, Dict[str, Any]] = {}
@@ -216,9 +225,6 @@ class OctoprintCompat:
                             ) -> Dict[str, Any]:
         """
         Used to parse Octoprint capabilities
-
-        Hardcode capabilities to be basically there and use default
-        fluid/mainsail webcam path.
         """
         settings = {
             'plugins': {},
@@ -226,15 +232,7 @@ class OctoprintCompat:
                 'sdSupport': False,
                 'temperatureGraph': False
             },
-            # TODO: Get webcam settings from config file to allow user
-            #       to customise this.
-            'webcam': {
-                'flipH': False,
-                'flipV': False,
-                'rotate90': False,
-                'streamUrl': '/webcam/?action=stream',
-                'webcamEnabled': True,
-            },
+            'webcam': self.webcam,
         }
         if self.enable_ufp:
             settings['plugins'] = {


### PR DESCRIPTION
Now reading configs from moonraker.conf file, octoprint_compat section. Values are set to the defaults that were previously hardcoded and reflected in the sample moonraker.conf file.