### PR TITLE
feat(notifier): add notifier component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.idea/

--- a/moonraker/components/notifier.py
+++ b/moonraker/components/notifier.py
@@ -64,6 +64,16 @@ class Notifier:
             "job_state:started",
             config)
 
+        self.events["error"] = NotifierEvent(
+            "error",
+            "job_state:error",
+            config)
+
+        self.events["cancelled"] = NotifierEvent(
+            "cancelled",
+            "job_state:cancelled",
+            config)
+
 
 class NotifierEvent:
     def __init__(self, identifier: str, event_name: str, config: ConfigHelper):

--- a/moonraker/components/notifier.py
+++ b/moonraker/components/notifier.py
@@ -1,0 +1,62 @@
+# Moonraker Notifier
+#
+# Copyright (C) 2022 Pataar <me@pataar.nl>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+from __future__ import annotations
+
+import apprise
+from apprise import Apprise
+
+# Annotation imports
+from typing import (
+    TYPE_CHECKING,
+    Type,
+    Optional,
+    Dict,
+)
+
+if TYPE_CHECKING:
+    from confighelper import ConfigHelper
+    from . import klippy_apis
+
+    APIComp = klippy_apis.KlippyAPI
+
+
+class Notifier:
+    def __init__(self, config: ConfigHelper) -> None:
+        self.server = config.get_server()
+        self.apprise = apprise.Apprise()
+        self.notifiers: Dict[str, NotifierInstance] = {}
+        prefix_sections = config.get_prefix_sections("notifier")
+        for section in prefix_sections:
+            cfg = config[section]
+            notifier_class: Optional[Type[NotifierInstance]]
+            try:
+                notifier = NotifierInstance(cfg)
+            except Exception as e:
+                msg = f"Failed to load notifier[{cfg.get_name()}]\n{e}"
+                self.server.add_warning(msg)
+                continue
+            self.notifiers[notifier.get_name()] = notifier
+            self.apprise = notifier.add_to_notifier(self.apprise)
+
+
+class NotifierInstance:
+    def __init__(self, config: ConfigHelper) -> None:
+        name_parts = config.get_name().split(maxsplit=1)
+        if len(name_parts) != 2:
+            raise config.error(f"Invalid Section Name: {config.get_name()}")
+        self.server = config.get_server()
+        self.name = name_parts[1]
+        self.url: str = config.get('url')
+        self.events: str = "init"
+
+    def get_name(self) -> str:
+        return self.name
+
+    def add_to_notifier(self, appr: Apprise) -> Apprise:
+        appr.add(self.url)
+
+        return appr

--- a/moonraker/components/notifier.py
+++ b/moonraker/components/notifier.py
@@ -51,12 +51,15 @@ class Notifier:
 
     async def notify(self, body="test"):
         logging.info(f"Sending notification to thing")
-        await self.apprise.async_notify(body)
+        await self.apprise.async_notify(
+            title='Some good jokes.',
+            body='Hey guys, check out these!'
+        )
 
     async def _on_job_started(self,
-                        prev_stats: Dict[str, Any],
-                        new_stats: Dict[str, Any]
-                        ) -> None:
+                              prev_stats: Dict[str, Any],
+                              new_stats: Dict[str, Any]
+                              ) -> None:
         try:
             logging.info(f"Job started event triggered'")
             await self.notify("Started")
@@ -64,13 +67,14 @@ class Notifier:
             logging.info(f"Error subscribing to print_stats")
 
     async def _on_job_complete(self,
-                         prev_stats: Dict[str, Any],
-                         new_stats: Dict[str, Any]) -> None:
+                               prev_stats: Dict[str, Any],
+                               new_stats: Dict[str, Any]) -> None:
         try:
             logging.info(f"Job completed event triggered'")
             await self.notify("Completed")
         except self.server.error as e:
             logging.info(f"Error subscribing to print_stats")
+
 
 class NotifierInstance:
     def __init__(self, config: ConfigHelper) -> None:

--- a/moonraker/components/notifier.py
+++ b/moonraker/components/notifier.py
@@ -47,6 +47,7 @@ class Notifier:
             "server:klippy_started", self._handle_started)
 
     def notify(self, body="test"):
+        logging.info(f"Sending notification to thing")
         self.apprise.async_notify(body)
 
     async def _handle_started(self, state: str) -> None:

--- a/moonraker/components/notifier.py
+++ b/moonraker/components/notifier.py
@@ -44,17 +44,23 @@ class Notifier:
             self.apprise = notifier.add_to_notifier(self.apprise)
 
         self.server.register_event_handler(
-            "server:klippy_started", self._handle_started)
+            "job_state:started", self._on_job_started)
+        self.server.register_event_handler(
+            "job_state:complete", self._on_job_complete)
 
     def notify(self, body="test"):
         logging.info(f"Sending notification to thing")
         self.apprise.async_notify(body)
 
-    async def _handle_started(self, state: str) -> None:
-        if state != "ready":
-            return
+    async def _on_job_started(self, state: str) -> None:
         try:
             self.notify("Started")
+        except self.server.error as e:
+            logging.info(f"Error subscribing to print_stats")
+
+    async def _on_job_complete(self, state: str) -> None:
+        try:
+            self.notify("Completed")
         except self.server.error as e:
             logging.info(f"Error subscribing to print_stats")
 

--- a/moonraker/components/notifier.py
+++ b/moonraker/components/notifier.py
@@ -62,7 +62,7 @@ class NotifierEvent:
         self.event_name = event_name
         self.server = config.get_server()
         self.apprise = apprise.Apprise()
-        self.notifiers = Dict[str, NotifierInstance] = {}
+        self.notifiers: Dict[str, NotifierInstance] = {}
 
         self.server.register_event_handler(self.event_name, self._handle)
 

--- a/moonraker/components/notifier.py
+++ b/moonraker/components/notifier.py
@@ -16,6 +16,7 @@ from typing import (
     Optional,
     Dict,
     Any,
+    List,
 )
 
 if TYPE_CHECKING:
@@ -41,7 +42,8 @@ class Notifier:
                 notifier = NotifierInstance(cfg)
 
                 for event in self.events:
-                    self.events[event].register_notifier(notifier)
+                    if event in notifier.events or "*" in notifier.events:
+                        self.events[event].register_notifier(notifier)
 
             except Exception as e:
                 msg = f"Failed to load notifier[{cfg.get_name()}]\n{e}"
@@ -103,7 +105,7 @@ class NotifierInstance:
         self.server = config.get_server()
         self.name = name_parts[1]
         self.url: str = config.get('url')
-        self.events: str = "init"
+        self.events: List[str] = config.get('events').split(",")
 
     def get_name(self) -> str:
         return self.name

--- a/moonraker/components/notifier.py
+++ b/moonraker/components/notifier.py
@@ -42,6 +42,12 @@ class Notifier:
             self.notifiers[notifier.get_name()] = notifier
             self.apprise = notifier.add_to_notifier(self.apprise)
 
+    def notify(self, body="test"):
+        self.apprise.async_notify(body)
+
+    def load_component(config: ConfigHelper) -> Notifier:
+        return Notifier(config)
+
 
 class NotifierInstance:
     def __init__(self, config: ConfigHelper) -> None:

--- a/moonraker/components/notifier.py
+++ b/moonraker/components/notifier.py
@@ -49,9 +49,9 @@ class Notifier:
         self.server.register_event_handler(
             "job_state:complete", self._on_job_complete)
 
-    def notify(self, body="test"):
+    async def notify(self, body="test"):
         logging.info(f"Sending notification to thing")
-        self.apprise.async_notify(body)
+        await self.apprise.async_notify(body)
 
     async def _on_job_started(self,
                         prev_stats: Dict[str, Any],
@@ -59,7 +59,7 @@ class Notifier:
                         ) -> None:
         try:
             logging.info(f"Job started event triggered'")
-            self.notify("Started")
+            await self.notify("Started")
         except self.server.error as e:
             logging.info(f"Error subscribing to print_stats")
 
@@ -68,7 +68,7 @@ class Notifier:
                          new_stats: Dict[str, Any]) -> None:
         try:
             logging.info(f"Job completed event triggered'")
-            self.notify("Completed")
+            await self.notify("Completed")
         except self.server.error as e:
             logging.info(f"Error subscribing to print_stats")
 

--- a/moonraker/components/notifier.py
+++ b/moonraker/components/notifier.py
@@ -117,8 +117,12 @@ class NotifierInstance:
             raise config.error(f"Invalid Section Name: {config.get_name()}")
         self.server = config.get_server()
         self.name = name_parts[1]
+
+        if len(config.get('url', '')) < 2:
+            raise config.error(f"Invalid url for: {config.get_name()}")
+
         self.url: str = config.get('url')
-        self.events: List[str] = config.get('events').split(",")
+        self.events: List[str] = config.get('events', '').split(",")
 
     def get_name(self) -> str:
         return self.name

--- a/moonraker/components/notifier.py
+++ b/moonraker/components/notifier.py
@@ -45,8 +45,6 @@ class Notifier:
     def notify(self, body="test"):
         self.apprise.async_notify(body)
 
-    def load_component(config: ConfigHelper) -> Notifier:
-        return Notifier(config)
 
 
 class NotifierInstance:
@@ -66,3 +64,7 @@ class NotifierInstance:
         appr.add(self.url)
 
         return appr
+
+
+def load_component(config: ConfigHelper) -> Notifier:
+    return Notifier(config)

--- a/moonraker/components/notifier.py
+++ b/moonraker/components/notifier.py
@@ -53,14 +53,19 @@ class Notifier:
         logging.info(f"Sending notification to thing")
         self.apprise.async_notify(body)
 
-    async def _on_job_started(self, state: str) -> None:
+    async def _on_job_started(self,
+                        prev_stats: Dict[str, Any],
+                        new_stats: Dict[str, Any]
+                        ) -> None:
         try:
             logging.info(f"Job started event triggered'")
             self.notify("Started")
         except self.server.error as e:
             logging.info(f"Error subscribing to print_stats")
 
-    async def _on_job_complete(self, state: str) -> None:
+    async def _on_job_complete(self,
+                         prev_stats: Dict[str, Any],
+                         new_stats: Dict[str, Any]) -> None:
         try:
             logging.info(f"Job completed event triggered'")
             self.notify("Completed")

--- a/moonraker/components/notifier.py
+++ b/moonraker/components/notifier.py
@@ -40,6 +40,7 @@ class Notifier:
                 msg = f"Failed to load notifier[{cfg.get_name()}]\n{e}"
                 self.server.add_warning(msg)
                 continue
+            logging.info(f"Loaded notifier: '{notifier.get_name()}'")
             self.notifiers[notifier.get_name()] = notifier
             self.apprise = notifier.add_to_notifier(self.apprise)
 
@@ -54,12 +55,14 @@ class Notifier:
 
     async def _on_job_started(self, state: str) -> None:
         try:
+            logging.info(f"Job started event triggered'")
             self.notify("Started")
         except self.server.error as e:
             logging.info(f"Error subscribing to print_stats")
 
     async def _on_job_complete(self, state: str) -> None:
         try:
+            logging.info(f"Job completed event triggered'")
             self.notify("Completed")
         except self.server.error as e:
             logging.info(f"Error subscribing to print_stats")

--- a/moonraker/components/notifier.py
+++ b/moonraker/components/notifier.py
@@ -45,11 +45,12 @@ class Notifier:
                     if event in notifier.events or "*" in notifier.events:
                         self.events[event].register_notifier(notifier)
 
+                logging.info(f"Registered notifier: '{notifier.get_name()}'")
+
             except Exception as e:
                 msg = f"Failed to load notifier[{cfg.get_name()}]\n{e}"
                 self.server.add_warning(msg)
                 continue
-            logging.info(f"Loaded notifier: '{notifier.get_name()}'")
             self.notifiers[notifier.get_name()] = notifier
 
     def register_events(self, config: ConfigHelper):
@@ -94,13 +95,15 @@ class NotifierEvent:
                       new_stats: Dict[str, Any]
                       ) -> None:
         try:
-            logging.info(f"Job completed event triggered'")
+            logging.info(f"'{self.event_name}' event triggered'")
             await self.notify(self.event_name)
         except self.server.error as e:
             logging.info(f"Error subscribing to print_stats")
 
     async def notify(self, body="test"):
-        logging.info(f"Sending notification to thing")
+        logging.info(
+            f"Notifying '{self.event_name}' to {len(self.notifiers.keys())} n"
+        )
         await self.apprise.async_notify(
             title='Moonraker',
             body=body

--- a/moonraker/components/notifier.py
+++ b/moonraker/components/notifier.py
@@ -98,7 +98,7 @@ class NotifierEvent:
             logging.info(f"'{self.event_name}' event triggered'")
             await self.notify(self.event_name)
         except self.server.error as e:
-            logging.info(f"Error subscribing to print_stats")
+            logging.info(f"Error while notifiying '{self.event_name}'")
 
     async def notify(self, body="test"):
         logging.info(

--- a/moonraker/components/notifier.py
+++ b/moonraker/components/notifier.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import apprise
 from apprise import Apprise
+import logging
 
 # Annotation imports
 from typing import (
@@ -42,10 +43,19 @@ class Notifier:
             self.notifiers[notifier.get_name()] = notifier
             self.apprise = notifier.add_to_notifier(self.apprise)
 
+        self.server.register_event_handler(
+            "server:klippy_started", self._handle_started)
+
     def notify(self, body="test"):
         self.apprise.async_notify(body)
 
-
+    async def _handle_started(self, state: str) -> None:
+        if state != "ready":
+            return
+        try:
+            self.notify("Started")
+        except self.server.error as e:
+            logging.info(f"Error subscribing to print_stats")
 
 class NotifierInstance:
     def __init__(self, config: ConfigHelper) -> None:

--- a/scripts/moonraker-requirements.txt
+++ b/scripts/moonraker-requirements.txt
@@ -13,3 +13,4 @@ zeroconf==0.37.0
 preprocess-cancellation==0.1.6
 jinja2==3.0.3
 dbus-next==0.2.3
+apprise==0.9.7


### PR DESCRIPTION
# Notifier component
This component will be a bridge between moonraker and https://github.com/caronc/apprise. This way users can easily add all kind of notification services to their printer. 

Each notifier can subscribe to events.

## Event types
- completed
- started
- error
- canceled


## Configuration syntax

```conf
[notifier my_personal_discord]
events: started,completed
url: https://discord.com/api/webhooks/{id}/{secret}}

[notifier telegram]
events: started,completed
url: tgram://{bottoken}/{ChatID}

[notifier mqtt]
events: *
url: mqtt://{user}@{hostname}/{topic}
```