### PR TITLE
[bugfix] notifier: typo at `job_state:completed`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1699,7 +1699,7 @@ events: *
 #   You can use multiple events, comma seperated.
 #   Valid events:
 #      started
-#      completed
+#      complete
 #      error
 #      cancelled
 body: "Your printer status has changed to {event_name}"

--- a/moonraker/components/notifier.py
+++ b/moonraker/components/notifier.py
@@ -59,9 +59,9 @@ class Notifier:
             "job_state:started",
             config)
 
-        self.events["completed"] = NotifierEvent(
-            "completed",
-            "job_state:completed",
+        self.events["complete"] = NotifierEvent(
+            "complete",
+            "job_state:complete",
             config)
 
         self.events["error"] = NotifierEvent(


### PR DESCRIPTION
There is a typo in `job_state:completed`. Should be `job_state:complete`.