### PR TITLE
docs: fix an incorrection in the notifier example

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1723,9 +1723,9 @@ url: tgram://{bottoken}/{ChatID}
 events: started
 body: Your printer started printing '{event_args[1].filename}'
 
-[notifier print_completed]
+[notifier print_complete]
 url: tgram://{bottoken}/{ChatID}
-events: completed
+events: complete
 body: Your printer completed printing '{event_args[1].filename}'
 attach: http://192.168.1.100/webcam/?action=snapshot
 


### PR DESCRIPTION
There was a small typo left after the recent 'completed' bugfix.
