### PR TITLE
docs: fix incorrect identify method

### DIFF
--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -182,7 +182,7 @@ JSON-RPC request (Websocket Only):
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "server.connection.idenity",
+    "method": "server.connection.identify",
     "params": {
         "client_name": "moontest",
         "version": "0.0.1",


### PR DESCRIPTION
Fixes a typo in the [websocket identify RPC request](https://github.com/Arksine/moonraker/blob/efeea0d8e1d84e8201997a58c58274c79d8601b2/moonraker/websockets.py#L282)