### PR TITLE
docs: Remove ambiguity from documentation index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 #  Moonraker - API Web Server for Klipper
 
 Moonraker is a Python 3 based web server that exposes APIs with which
-client applications may use to interact with
+client applications may use to interact with the 3D printing firmware
 [Klipper](https://github.com/KevinOConnor/klipper). Communcation between
 the Klippy host and Moonraker is done over a Unix Domain Socket.  Tornado
 is used to provide Moonraker's server functionality.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,11 @@
 # Welcome to Moonraker Documentation
 
+Moonraker is a Python 3 based web server that exposes APIs with which
+client applications may use to interact with the 3D printing firmware
+[Klipper](https://github.com/KevinOConnor/klipper). Communcation between
+the Klippy host and Moonraker is done over a Unix Domain Socket.  Tornado
+is used to provide Moonraker's server functionality.
+
 Users should refer to the [Installation](installation.md) and
 [Configuration](configuration.md) sections for documentation on how
 to install and configure Moonraker.


### PR DESCRIPTION
Presently the index page of the documentation makes no attempt to
clarify what Moonraker is or even that it has anything to do with 3D
printing or CNC machine control.  This attempts to add a basic
clarification by using the top level description from README.md.

Additionally this adds a second clarification that Klipper is a "3D
printer firmware" (as referenced in the Klipper `README.md`) in this
projects `README.md`.

Signed-off-by: Brian 'Redbeard' Harrington <redbeard@dead-city.org>