### PR TITLE
wled: Add extra control for wled effects

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1487,6 +1487,20 @@ gcode:
                              state=True,
                              preset=preset)}
 
+[gcode_macro WLED_CONTROL]
+description: Control effect values and brightness
+gcode:
+  {% set strip = params.STRIP|default('lights')|string %}
+  {% set brightness = params.BRIGHTNESS|default(-1)|int %}
+  {% set intensity = params.INTENSITY|default(-1)|int %}
+  {% set speed = params.SPEED|default(-1)|int %}
+
+  {action_call_remote_method("set_wled_state",
+                             strip=strip,
+                             brightness=brightness,
+                             intensity=intensity,
+                             speed=speed)}
+                             
 [gcode_macro WLED_OFF]
 description: Turn WLED strip off
 gcode:

--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -3466,7 +3466,7 @@ JSON-RPC request:
     "jsonrpc": "2.0",
     "method": "machine.device_power.off",
     "params": {
-        "dev_one":null,
+        "dev_one": null,
         "dev_two": null
     },
     "id": 4564
@@ -3477,6 +3477,340 @@ An object containing power state for each requested device:
 {
     "green_led": "off",
     "printer": "off"
+}
+```
+### WLED APIs
+The APIs for WLED are available when the `[wled]` component has been configured. For lower-level control of wled consider using the WLED [JOSN API](https://kno.wled.ge/interfaces/json-api/) directly.
+
+#### Get strips
+HTTP request:
+```http
+GET /machine/wled/strips
+```
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method":"machine.wled.strips",
+    "id": 7123
+}
+```
+Returns:
+
+Strip information for all wled strips.
+```json
+{
+    "result": {
+        "strips": {
+            "lights": {
+                "strip": "lights",
+                "status": "on",
+                "chain_count": 79,
+                "preset": -1,
+                "brightness": 255,
+                "intensity": -1,
+                "speed": -1,
+                "error": null
+            },
+            "desk": {
+                "strip": "desk",
+                "status": "on",
+                "chain_count": 60,
+                "preset": 8,
+                "brightness": -1,
+                "intensity": -1,
+                "speed": -1,
+                "error": null
+            }
+        }
+    }
+}
+```
+
+#### Get strip status
+HTTP request:
+```http
+GET /machine/wled/status?strip1&strip2
+```
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method":"machine.wled.status",
+    "params": {
+        "lights": null,
+        "desk": null
+    },
+    "id": 7124
+}
+```
+Returns:
+
+Strip information for requested strips.
+```json
+{
+    "result": {
+        "lights": {
+            "strip": "lights",
+            "status": "on",
+            "chain_count": 79,
+            "preset": -1,
+            "brightness": 255,
+            "intensity": -1,
+            "speed": -1,
+            "error": null
+        },
+        "desk": {
+            "strip": "desk",
+            "status": "on",
+            "chain_count": 60,
+            "preset": 8,
+            "brightness": -1,
+            "intensity": -1,
+            "speed": -1,
+            "error": null
+        }
+    }
+}
+```
+
+#### Turn strip on
+Turns the specified strips on to the initial colors or intial preset.
+
+HTTP request:
+```http
+POST /machine/wled/on?strip1&strip2
+```
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method":"machine.wled.on",
+    "params": {
+        "lights": null,
+        "desk": null
+    },
+    "id": 7125
+}
+```
+Returns:
+
+Strip information for requested strips.
+```json
+{
+    "result": {
+        "lights": {
+            "strip": "lights",
+            "status": "on",
+            "chain_count": 79,
+            "preset": -1,
+            "brightness": 255,
+            "intensity": -1,
+            "speed": -1,
+            "error": null
+        },
+        "desk": {
+            "strip": "desk",
+            "status": "on",
+            "chain_count": 60,
+            "preset": 8,
+            "brightness": -1,
+            "intensity": -1,
+            "speed": -1,
+            "error": null
+        }
+    }
+}
+```
+
+#### Turn strip off
+Turns off all specified strips.
+
+HTTP request:
+```http
+POST /machine/wled/off?strip1&strip2
+```
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method":"machine.wled.off",
+    "params": {
+        "lights": null,
+        "desk": null
+    },
+    "id": 7126
+}
+```
+Returns:
+
+The new state of the specified strips.
+```json
+{
+    "result": {
+        "lights": {
+            "strip": "lights",
+            "status": "off",
+            "chain_count": 79,
+            "preset": -1,
+            "brightness": 255,
+            "intensity": -1,
+            "speed": -1,
+            "error": null
+        },
+        "desk": {
+            "strip": "desk",
+            "status": "off",
+            "chain_count": 60,
+            "preset": 8,
+            "brightness": -1,
+            "intensity": -1,
+            "speed": -1,
+            "error": null
+        }
+    }
+}
+```
+
+#### Toggle strip on/off state
+Turns each strip off if it is on and on if it is off.
+
+HTTP request:
+```http
+POST /machine/wled/off?strip1&strip2
+```
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method":"machine.wled.toggle",
+    "params": {
+        "lights": null,
+        "desk": null
+    },
+    "id": 7127
+}
+```
+Returns:
+
+The new state of the specified strips.
+```json
+{
+    "result": {
+        "lights": {
+            "strip": "lights",
+            "status": "on",
+            "chain_count": 79,
+            "preset": -1,
+            "brightness": 255,
+            "intensity": -1,
+            "speed": -1,
+            "error": null
+        },
+        "desk": {
+            "strip": "desk",
+            "status": "off",
+            "chain_count": 60,
+            "preset": 8,
+            "brightness": -1,
+            "intensity": -1,
+            "speed": -1,
+            "error": null
+        }
+    }
+}
+```
+
+#### Control individual strip state
+Toggle, turn on, turn off, turn on with preset, turn on with brightness, or
+turn on preset will some of brightness, intensity, and speed. Or simply set
+some of brightness, intensity, and speed.
+
+HTTP requests:
+
+Turn strip `lights` off
+```http
+POST /machine/wled/strip?strip=lights&action=off
+```
+
+Turn strip `lights` on to the initial colors or intial preset.
+```http
+POST /machine/wled/strip?strip=lights&action=on
+```
+
+Turn strip `lights` on activating preset 3.
+```http
+POST /machine/wled/strip?strip=lights&action=on&preset=3
+```
+
+Turn strip `lights` on activating preset 3 while specifying speed and
+intensity.
+```http
+POST /machine/wled/strip?strip=lights&action=on&preset=3&intensity=50&speed=255
+```
+
+Change strip `lights` brightness (if on) and speed (if a preset is active).
+```http
+POST /machine/wled/strip?strip=lights&action=control&brightness=99&speed=50
+```
+
+JSON-RPC request:
+
+Returns information for the specified strip.
+```json
+{
+    "jsonrpc": "2.0",
+    "method":"machine.wled.get_strip",
+    "params": {
+        "strip": "lights",
+    },
+    "id": 7128
+}
+```
+
+Calls the action with the arguments for the specified strip.
+```json
+{
+    "jsonrpc": "2.0",
+    "method":"machine.wled.post_strip",
+    "params": {
+        "strip": "lights",
+        "action": "on",
+        "preset": 1,
+        "brightness": 255,
+        "intensity": 255,
+        "speed": 255
+    },
+    "id": 7129
+}
+```
+!!! note
+    The `action` argument may be `on`, `off`, `toggle` or `control`. Any
+    other value will result in an error.
+
+The `intensity` and `speed` arguments are only used if a preset is active.
+Permitted ranges are 1-255 for `brightness` and 0-255 for `intensity` and
+`speed`. When action is `on` a `preset` with some or all of `brightness`,
+`intensity` and `speed` may also be specified. If the action `control` is used
+one or all of `brightness`, `intensity`, and `speed` must be specified.
+
+Returns:
+
+State of the strip.
+```json
+{
+    "result": {
+        "lights": {
+            "strip": "lights",
+            "status": "on",
+            "chain_count": 79,
+            "preset": 1,
+            "brightness": 50,
+            "intensity": 255,
+            "speed": 255,
+            "error": null
+        }
+    }
 }
 ```
 

--- a/moonraker/components/wled.py
+++ b/moonraker/components/wled.py
@@ -178,7 +178,7 @@ class Strip():
                 control["bri"] = self.brightness
                 # Brightness in seg {} - only if a preset is on
                 if self.preset != -1:
-                  control["seg"]["bri"] = self.brightness
+                    control["seg"]["bri"] = self.brightness
 
         # Intensity - only if a preset is on
         if intensity > -1 and self.preset != -1:


### PR DESCRIPTION
For the "Percent" preset the intensity controls the amount of the bar lit up 0-100
Work around issue when preset is re-enabled if sending intensity or speed while no preset is active
Signed-off-by:  Richard Mitchell <richardjm+moonraker@gmail.com>