### PR TITLE
fix: Fix update manager klipper host repo Incorrect

### DIFF
--- a/moonraker/components/update_manager/base_config.py
+++ b/moonraker/components/update_manager/base_config.py
@@ -39,7 +39,7 @@ BASE_CONFIG: Dict[str, Dict[str, str]] = {
         "requirements": "scripts/klippy-requirements.txt",
         "venv_args": "-p python2",
         "install_script": "scripts/install-octopi.sh",
-        "host_repo": "arksine/moonraker",
+        "host_repo": "Klipper3d/klipper",
         "managed_services": "klipper"
     }
 }


### PR DESCRIPTION
The "host_repo" in klipper is not correct.  
change line 42 from `"host_repo": "arksine/moonraker"` to `"host_repo": "Klipper3d/klipper"`