### PR TITLE
Following polkit versioning scheme change

### DIFF
--- a/scripts/set-policykit-rules.sh
+++ b/scripts/set-policykit-rules.sh
@@ -45,7 +45,7 @@ add_polkit_rules()
         echo "PolicyKit not installed"
         exit 1
     fi
-    POLKIT_VERSION="$( pkaction --version | grep -Po "(\d?\.\d+)" )"
+    POLKIT_VERSION="$( pkaction --version | grep -Po "(\d+\.?\d*)" )"
     report_status "PolicyKit Version ${POLKIT_VERSION} Detected"
     if [ "$POLKIT_VERSION" = "0.105" ]; then
         # install legacy pkla file


### PR DESCRIPTION
Polkit changed its versioning scheme starting with version 121 (the preceding version was 0.120) causing set-policykit-rules.sh to fail.