### PR TITLE
Allow configuring the virtualenv location

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -136,6 +136,16 @@ particularly for those upgrading:
   This is useful for installations that occur outside of a standard environment
   where systemd is not running.
 
+Additionally, installation may be customized with the following environment
+variables:
+
+- `MOONRAKER_VENV`
+- `MOONRAKER_REBUILD_ENV`
+- `MOONRAKER_FORCE_DEFAULTS`
+- `MOONRAKER_DISABLE_SYSTEMCTL`
+- `MOONRAKER_CONFIG_PATH`
+- `MOONRAKER_LOG_PATH`
+
 When the script completes it should start both Moonraker and Klipper. In
 `/tmp/klippy.log` you should find the following entry:
 

--- a/scripts/install-moonraker.sh
+++ b/scripts/install-moonraker.sh
@@ -2,7 +2,7 @@
 # This script installs Moonraker on a Raspberry Pi machine running
 # Raspbian/Raspberry Pi OS based distributions.
 
-PYTHONDIR="${MOONRAKER_VENV:-${HOME}/envs/moonraker}"
+PYTHONDIR="${MOONRAKER_VENV:-${HOME}/moonraker-env}"
 SYSTEMDDIR="/etc/systemd/system"
 REBUILD_ENV="${MOONRAKER_REBUILD_ENV:-n}"
 FORCE_DEFAULTS="${MOONRAKER_FORCE_DEFAULTS:-n}"

--- a/scripts/install-moonraker.sh
+++ b/scripts/install-moonraker.sh
@@ -2,13 +2,13 @@
 # This script installs Moonraker on a Raspberry Pi machine running
 # Raspbian/Raspberry Pi OS based distributions.
 
-PYTHONDIR="${HOME}/moonraker-env"
+PYTHONDIR="${MOONRAKER_VENV:-${HOME}/envs/moonraker}"
 SYSTEMDDIR="/etc/systemd/system"
-REBUILD_ENV="n"
-FORCE_DEFAULTS="n"
-DISABLE_SYSTEMCTL="n"
-CONFIG_PATH="${HOME}/moonraker.conf"
-LOG_PATH="/tmp/moonraker.log"
+REBUILD_ENV="${MOONRAKER_REBUILD_ENV:-n}"
+FORCE_DEFAULTS="${MOONRAKER_FORCE_DEFAULTS:-n}"
+DISABLE_SYSTEMCTL="${MOONRAKER_DISABLE_SYSTEMCTL:-n}"
+CONFIG_PATH="${MOONRAKER_CONFIG_PATH:-${HOME}/moonraker.conf}"
+LOG_PATH="${MOONRAKER_LOG_PATH:-/tmp/moonraker.log}"
 
 # Step 2: Clean up legacy installation
 cleanup_legacy() {


### PR DESCRIPTION
Also allow setting defaults for installation command line
flags from the environment

```sh
MOONRAKER_VENV=$HOME/.venvs/moonraker \
MOONRAKER_REBUILD_ENV=y \
MOONRAKER_FORCE_DEFAULTS=n \
MOONRAKER_DISABLE_SYSTEMCTL=n \
MOONRAKER_CONFIG_PATH=$HOME/printer/moonraker.conf \
MOONRAKER_LOG_PATH=/tmp/moonraker.log \
./scripts/install-moonraker.sh
```

Personally, I set `MOONRAKER_VENV` and `MOONRAKER_CONFIG_PATH` in my .profile

Signed-off-by: Franklyn Tackitt <git@frank.af>