### PR TITLE
Enable CORS Private Network access

### DIFF
--- a/moonraker/components/authorization.py
+++ b/moonraker/components/authorization.py
@@ -799,6 +799,11 @@ class Authorization:
                 "Origin, Accept, Content-Type, X-Requested-With, "
                 "X-CRSF-Token, Authorization, X-Access-Token, "
                 "X-Api-Key")
+            if req_hdlr.request.headers.get(
+                'Access-Control-Request-Private-Network', None) == 'true':
+                req_hdlr.set_header(
+                    "Access-Control-Allow-Private-Network",
+                    "true")
 
     def cors_enabled(self) -> bool:
         return self.cors_domains is not None

--- a/moonraker/components/authorization.py
+++ b/moonraker/components/authorization.py
@@ -800,7 +800,7 @@ class Authorization:
                 "X-CRSF-Token, Authorization, X-Access-Token, "
                 "X-Api-Key")
             if req_hdlr.request.headers.get(
-                'Access-Control-Request-Private-Network', None) == 'true':
+                    "Access-Control-Request-Private-Network", None) == "true":
                 req_hdlr.set_header(
                     "Access-Control-Allow-Private-Network",
                     "true")


### PR DESCRIPTION
This might be best configurable, but browsers are blocking requests from public to
 private networks (e.g. public IP address spaces to 192.168.x-like private spaces)

In the future, an `Access-Control-Request-Private-Network` header will be sent with
 these requests, and servers must respond with `Access-Control-Allow-Private-Network`.

This PR adds basic support for this response header. To test this feature, you will
 need to set the following options in chrome://flags:

chrome://flags/#block-insecure-private-network-requests - Disabled
chrome://flags/#private-network-access-send-preflights - Enabled
chrome://flags/#private-network-access-respect-preflight-results - Enabled

This will start with the next Chrome version (104), and Mozilla has marked the
 standard as "worth prototyping", which often leads to final implementation.

Signed-off-by: Franklyn Tackitt <git@frank.af>