### PR TITLE
Skip dbus_manager init without /proc

### DIFF
--- a/moonraker/components/dbus_manager.py
+++ b/moonraker/components/dbus_manager.py
@@ -34,15 +34,18 @@ class DbusManager:
         self.bus: Optional[MessageBus] = None
         self.polkit: Optional[ProxyInterface] = None
         self.warned: bool = False
-        proc_data = pathlib.Path(f"/proc/self/stat").read_text()
-        start_clk_ticks = int(proc_data.split()[21])
-        self.polkit_subject = [
-            "unix-process",
-            {
-                "pid": dbus_next.Variant("u", os.getpid()),
-                "start-time": dbus_next.Variant("t", start_clk_ticks)
-            }
-        ]
+        try:
+            proc_data = pathlib.Path(f"/proc/self/stat").read_text()
+            start_clk_ticks = int(proc_data.split()[21])
+            self.polkit_subject = [
+                "unix-process",
+                {
+                    "pid": dbus_next.Variant("u", os.getpid()),
+                    "start-time": dbus_next.Variant("t", start_clk_ticks)
+                }
+            ]
+        except FileNotFoundError:
+            pass
 
     def is_connected(self) -> bool:
         return self.bus is not None and self.bus.connected


### PR DESCRIPTION
(without /proc/self/stat)

dbus_manager: Skip init if /proc/self/stat isn't readable to prevent FileNotFoundError crash on iOS (and probably other non-Linux environments?)

Signed-off-by: Gianni S (lotuspar0@gmail.com)
