### PR TITLE
Rework file path organization and configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 .devel
-.venv
 
+.venv
+venv
+start_moonraker
+*.env

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,12 +51,6 @@ ssl_port: 7130
 #   The port to listen on for SSL (HTTPS) connections.  Note that the HTTPS
 #   server will only be started of the certificate and key options outlined
 #   below are provided.  The default is 7130.
-ssl_certificate_path:
-#   The path to a self signed ssl certificate.  The default is no path, which
-#   disables HTTPS.
-ssl_key_path:
-#   The path to the private key used to signed the certificate.  The default
-#   is no path, which disables HTTPS.
 klippy_uds_address: /tmp/klippy_uds
 #   The address of Unix Domain Socket used to communicate with Klippy. Default
 #   is /tmp/klippy_uds
@@ -67,6 +61,15 @@ enable_debug_logging: False
 #   of development the default is False.
 ```
 
+!!! Note:
+    Previously the `[server]` section contained `ssl_certificate_path` and
+    `ssl_key_path` options. These options are now deprecated, as both locations
+    are determined by the `data path` and `alias` configured on the command
+    line, ie `<data_file_path>/certs/<alias>.cert`.  By default the certificate
+    path resolves to `$HOME/moonraker_data/certs/moonraker.cert` and the key
+    path resolves to `$HOME/moonraker_data/certs/moonraker.key`.  Both files
+    may be symbolic links.
+
 ### `[file_manager]`
 
 The `file_manager` section provides configuration for Moonraker's file
@@ -74,18 +77,6 @@ management functionality.  If omitted defaults will be used.
 
 ```ini
 # moonraker.conf
-
-config_path:
-#   The path to a directory where configuration files are located. This
-#   directory may contain Klipper config files (printer.cfg) or Moonraker
-#   config files (moonraker.conf).  Clients may also write their own config
-#   files to this directory.  Note that this may not be the system root
-#   (ie: "/") and moonraker must have read and write access permissions
-#   for this directory.
-log_path:
-#   An optional path to a directory where log files are located.  Users may
-#   configure various applications to store logs here and Moonraker will serve
-#   them at "/server/files/logs/*".  The default is no log paths.
 queue_gcode_uploads: False
 #   When set to True the file manager will add uploads to the job_queue when
 #   the `start_print` flag has been set.  The default if False.
@@ -96,17 +87,17 @@ enable_object_processing: False
 #   "cancel object" functionality.  Note that this process is file I/O intensive,
 #   it is not recommended for usage on low resource SBCs such as a Pi Zero.
 #   The default is False.
+enable_inotify_warnings: True
+#   When set to True Moonraker will generate warnings when inotify attempts
+#   to add a duplicate watch or when inotify encounters an error.  On some
+#   file systems inotify may not work as expected, this gives users the
+#   option to suppress warnings when necessary.  The default is True.
 ```
 
-!!! Warning
-    Moonraker currently supports two paths with read/write access, the
-    `config_path` configured in the `file_manager` and the `virtual_sdcard` path
-    configured through Klipper in `printer.cfg`. These paths are monitored for
-    changes, thus they must not overlap. Likewise, these paths may not be a
-    parent or child of folders containing sensitive files such as the `database`,
-    Moonraker's source, or Klipper's source.  If either of the above conditions
-    are present Moonraker will generate a warning and revoke access to the
-    offending path.
+!!! Note:
+    Previously the `[file_manager]` section contained `config_path` and
+    `log_path` options. These options are now deprecated, as both locations
+    are determined by the `data path` configured on the command line.
 
 !!! Tip
     It is also possible to enable object processing directly in the slicer.
@@ -169,24 +160,11 @@ gcode:
 
 ### `[database]`
 
-The `database` section provides configuration for Moonraker's lmdb database.
-If omitted defaults will be used.
-
-```ini
-moonraker.conf
-
-database_path: ~/.moonraker_database
-#   The path to the folder that stores Moonraker's lmdb database files.
-#   It is NOT recommended to place this file in a location that is served by
-#   Moonraker (such as the "config_path" or the location where gcode
-#   files are stored).  If the folder does not exist an attempt will be made
-#   to create it.  The default is ~/.moonraker_database.
-```
-
-!!! Note
-    Previously the `enable_database_debug` option was available for internal
-    development to test changes to write protected namespaces.  This option
-    been deprecated and disabled.
+!!! Note:
+    This section no long has configuration options.  Previously the
+    `database_path` option was used to determine the locatation of
+    the database folder, it is now determined by the `data path`
+    configured on the command line.
 
 ### `[data_store]`
 
@@ -1804,23 +1782,15 @@ separate from `moonraker.conf`.  This allows users to safely distribute
 their configuration and log files without revealing credentials and
 other sensitive information.
 
-```ini
-# moonraker.conf
+!!! Note:
+    This section no long has configuration options.  Previously the
+    `secrets_path` option was used to specify the location of the file.
+    The secrets file name and location is now determined by the `data path`
+    and `alias` command line options, ie: `<data_base_path>/<alias>.secrets`.
+    By default this resolves to `$HOME/moonraker_data/moonraker.secrets`.
+    This may be a symbolic link.
 
-[secrets]
-secrets_path:
-#   A valid path to the "secrets" file.  A secrets file should either be
-#   in "ini" format (ie: the same format as moonraker.conf) or "json"
-#   format.  If the file is a "json" file, the top level item must be
-#   an Object.  When this parameter is not specified no file will be
-#   loaded.
-```
-
-!!! Warning
-    For maximum security the secrets file should be located in a folder
-    not served by Moonraker.
-
-Example ini file:
+Example ini secrets file:
 
 ```ini
 # moonraker_secrets.ini
@@ -1834,7 +1804,7 @@ token: long_token_string
 
 ```
 
-Example json file:
+Example json secrets file:
 
 ```json
 {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,6 +124,18 @@ sudo_password:
 #   see the [secrets] section for details.  It is strongly recommended to only
 #   set this option when required and to use the aforementioned secrets module
 #   when doing so.  The default is no sudo password is set.
+validate_service:
+#   Enables validation of Moonraker's systemd service unit.  If Moonraker
+#   detects that a change is necessary it will attempt to do so.  Custom
+#   installations and installations that do systemd should set this to False.
+#   The default is True.
+validate_config:
+#   Enables validation of Moonraker's configuration.  If Moonraker detects
+#   deprecated options it will attempt to correct them.  The default is True.
+force_validation:
+#   By default Moonraker will not attempt to revalidate if a previous attempt
+#   at validation successfully completed. Setting this value to True will force
+#   Moonraker to perform validation.  The default is False.
 ```
 
 !!! Note

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,8 +57,8 @@ klippy_uds_address: /tmp/klippy_uds
 max_upload_size: 1024
 #   The maximum size allowed for a file upload (in MiB).  Default is 1024 MiB.
 enable_debug_logging: False
-#   When set to True Moonraker will log in verbose mode.  During this stage
-#   of development the default is False.
+#   ***DEPRECATED***
+#   Verbose logging is enabled by the '-v' command line option.
 ```
 
 !!! Note:
@@ -1201,11 +1201,8 @@ disk or cloned from unofficial sources are not supported.
 
 [update_manager]
 enable_repo_debug: False
-#   When set to True moonraker will bypass repo validation and allow
-#   updates from unofficial remotes and/or branches.  Updates on
-#   detached repos are also allowed.  This option is intended for
-#   developers and should not be used on production machines.  The
-#   default is False.
+#  ***DEPRECATED***
+#   Debug features are now enabled by the '-g' command line option
 enable_auto_refresh: False
 #   When set to True Moonraker will attempt to fetch status about
 #   available updates roughly every 24 hours, between 12am-4am.
@@ -2105,12 +2102,10 @@ for core component configuration if no section was present.
 
 On April 6th 2022 the fallback was deprecated.  Moonraker will still function
 normally if `core components` are configured in the `[server]` section,
-however Moonraker now generates warnings when it detected this condition,
+however Moonraker now generates warnings when it detects this condition,
 such as:
 
 ```
-[server]: Option 'config_path' has been moved to section [file_manager]. Please correct your configuration, see https://moonraker.readthedocs.io/en/latest/configuration for detailed documentation.
-[server]: Option 'log_path' has been moved to section [file_manager]. Please correct your configuration, see https://moonraker.readthedocs.io/en/latest/configuration for detailed documentation.
 [server]: Option 'temperature_store_size' has been moved to section [data_store]. Please correct your configuration, see https://moonraker.readthedocs.io/en/latest/configuration for detailed documentation.
 [server]: Option 'gcode_store_size' has been moved to section [data_store]. Please correct your configuration, see https://moonraker.readthedocs.io/en/latest/configuration for detailed documentation
 ```
@@ -2126,8 +2121,6 @@ host: 0.0.0.0
 port: 7125
 temperature_store_size: 600
 gcode_store_size: 1000
-config_path: ~/klipper_config
-log_path: ~/klipper_logs
 
 ```
 
@@ -2139,10 +2132,6 @@ You will need to change it to the following;
 [server]
 host: 0.0.0.0
 port: 7125
-
-[file_manager]
-config_path: ~/klipper_config
-log_path: ~/klipper_logs
 
 [data_store]
 temperature_store_size: 600
@@ -2159,8 +2148,3 @@ make the changes.
 
 Once the changes are complete you may use the UI to restart Moonraker and
 the warnings should clear.
-
-!!! Note
-    Some users have asked why Moonraker does not automate these changes.
-    Currently Moonraker has no mechanism to modify the configuration directly,
-    however this functionality will be added in the future.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,7 +31,7 @@ missing one or both, you can simply add the bare sections to `printer.cfg`:
 [display_status]
 
 [virtual_sdcard]
-path: ~/moonraker_data/gcodes
+path: ~/printer_data/gcodes
 ```
 
 ### Enabling the Unix Socket
@@ -79,17 +79,17 @@ KLIPPY_USER=pi
 
 KLIPPY_EXEC=/home/pi/klippy-env/bin/python
 
-KLIPPY_ARGS="/home/pi/klipper/klippy/klippy.py /home/pi/moonraker_data/config/printer.cfg -l /home/pi/moonraker_data/logs/klippy.log -a /tmp/klippy_uds"
+KLIPPY_ARGS="/home/pi/klipper/klippy/klippy.py /home/pi/printer_data/config/printer.cfg -l /home/pi/printer_data/logs/klippy.log -a /tmp/klippy_uds"
 ```
 
 Moonraker's install script will create the data folder, however you
 may wish to create it now and move `printer.cfg` to the correct
 location, ie:
 ```
-mkdir ~/moonraker_data
-mkdir ~/moonraker_data/logs
-mkdir ~/moonraker_data/config
-mv printer.cfg ~/moonraker_data/config
+mkdir ~/printer_data
+mkdir ~/printer_data/logs
+mkdir ~/printer_data/config
+mv printer.cfg ~/printer_data/config
 ```
 
 ### Installing Moonraker
@@ -105,7 +105,7 @@ The install script will attempt to create a basic configuration if
 `moonraker.conf` does not exist at the expected location, however if you
 prefer to have Moonraker start with a robust configuration you may create
 it now.  By default the configuration file should be located at
-`$HOME/moonraker_data/config/moonraker.conf`, however the location of the
+`$HOME/printer_data/config/moonraker.conf`, however the location of the
 data path may be configured using the script's command line options.
 The [sample moonraker.conf](./moonraker.conf) may be used as a starting
 point, full details can be found in the
@@ -124,23 +124,22 @@ particularly for those upgrading:
   Force an overwrite of Moonraker's systemd script. By default the
   the systemd script will not be modified if it exists.
 - `-a <alias>`:
-  The alias used for this instance of Moonraker.  Moonraker uses this option
-  when determining the file names for the configuration file, log file,
-  secrets file, etc.  This option is also used to name Moonraker's systemd
-  service unit and enviroment file.  If omitted this defaults to `moonraker`.
+  The installer uses this option to determine the name of the service
+  to install.  If `-d` is not provided then this options will also be
+  used to determine the name of the data path folder. If omitted this
+  defaults to `moonraker`.
 - `-d <path to data folder>`:
   Specifies the path to Moonraker's data folder.  This folder organizes
   files and directories used by moonraker.  See the `Data Folder Structure`
-  section for details.  If omitted this defaults to `$HOME/<alias>_data`,
-  ie: `/home/pi/moonraker_data`.
+  section for details.  If omitted this defaults to `$HOME/printer_data`.
 - `-c <path to configuration file>`
   Specifies the path to Moonraker's configuation file.  By default the
-  configuration is expected at `<data_folder>/config/<alias>.conf`. ie:
-  `/home/pi/moonraker_data/config/moonraker.conf`.
+  configuration is expected at `<data_folder>/config/moonraker.conf`. ie:
+  `/home/pi/printer_data/config/moonraker.conf`.
 - `-l <path to log file>`
    Specifies the path to Moonraker's log file.  By default Moonraker logs
-   to `<data_folder>/logs/<alias>.log`. ie:
-  `/home/pi/moonraker_data/logs/moonraker.log`.
+   to `<data_folder>/logs/moonraker.log`. ie:
+  `/home/pi/printer_data/logs/moonraker.log`.
 - `-z`:
   Disables `systemctl` commands during install (ie: daemon-reload, restart).
   This is useful for installations that occur outside of a standard environment
@@ -182,11 +181,10 @@ Now you may install a client, such as
 
 As mentioned previously, files and folders used by Moonraker are organized
 in a primary data folder.  The example below illustrates the folder
-structure using the default data path of `$HOME/moonraker_data` and the
-default alias of `moonraker`:
+structure using the default data path of `$HOME/printer_data`.
 
 ```
-/home/pi/moonraker_data
+/home/pi/printer_data
 ├── backup
 │   └── 20220822T202419Z
 │       ├── config
@@ -208,36 +206,9 @@ default alias of `moonraker`:
 ├── logs
 │   ├── klippy.log
 │   └── moonraker.log
+├── systemd
+│   └── moonraker.env
 └── moonraker.secrets (optional)
-```
-
-The next example illustrates how the `<data file path>` and `<alias>`
-command line options are used to populate the folder:
-
-```
-<data file path>
-├── backup
-│   └── <ISO8601_DATE>
-│       ├── config
-│       │   └── <full configuration backup>
-│       └── service
-│           └── <systemd service backup>
-├── certs
-│   ├── <alias>.cert (optional)
-│   └── <alias>.key (optional)
-├── config
-│   ├── <alias>.conf
-│   └── printer.cfg
-├── database
-│   ├── data.mdb
-│   └── lock.mdb
-├── gcodes
-│   ├── test_gcode_one.gcode
-│   └── test_gcode_two.gcode
-├── logs
-│   ├── klippy.log
-│   └── <alias>.log
-└── <alias>.secrets (optional)
 ```
 
 If it is not desirible for the files and folders to exist in these specific
@@ -248,8 +219,8 @@ reconfigure Klipper's `virtual_sdcard` it may be desirable to create a
 
 !!! Note
     It is still possible to directly configure the paths to the configuration
-    and log files if you do not wish to use the default `<alias>` naming
-    scheme or if you wish for them to exist outside of the data folder.
+    and log files if you do not wish to use the default file names of
+    `moonraker.conf` and `moonraker.log`
 
 When Moonraker attempts to update legacy installations symbolic links
 are used to avoid an unrecoverable error.  Additionally a `backup`
@@ -257,7 +228,7 @@ folder is created which contains the prior configuration and/or
 systemd service unit, ie:
 
 ```
-/home/pi/moonraker_data
+/home/pi/printer_data
 ├── backup
 │   └── 20220822T202419Z
 │       ├── config
@@ -275,6 +246,8 @@ systemd service unit, ie:
 ├── database -> /home/pi/.moonraker_database
 ├── gcodes -> /home/pi/gcode_files
 ├── logs -> /home/pi/logs
+├── systemd
+│   └── moonraker.env
 └── moonraker.secrets -> /home/pi/moonraker_secrets.ini
 ```
 
@@ -306,7 +279,7 @@ User=pi
 SupplementaryGroups=moonraker-admin
 RemainAfterExit=yes
 WorkingDirectory=/home/pi/moonraker
-EnvironmentFile=/home/pi/moonraker/moonraker.env
+EnvironmentFile=/home/pi/printer_data/systemd/moonraker.env
 ExecStart=/home/pi/moonraker-env/bin/python $MOONRAKER_ARGS
 Restart=always
 RestartSec=10
@@ -327,31 +300,24 @@ Following are some items to take note of:
 
 #### The Enivirorment File
 
-The environment file is created in Moonraker's source directory during
-installation.  By default the enviroment file is named `moonraker.env`.
-A default installation's enviroment file will contain the path
-to `moonraker.py` and the alias option, ie:
+The environment file, `moonraker.env`. is created in the data path during
+installation. A default installation's enviroment file will contain the path
+to `moonraker.py` and the data path option, ie:
 
 ```
-MOONRAKER_ARGS="/home/pi/moonraker/moonraker/moonraker.py -a moonraker"
+MOONRAKER_ARGS="/home/pi/moonraker/moonraker/moonraker.py -d /home/pi/printer_data"
 ```
 
 A legacy installation converted to the updated flexible service unit
 might contain the following:
 
 ```
-MOONRAKER_ARGS="/home/pi/moonraker/moonraker/moonraker.py -a moonraker -d /home/pi/moonraker_data -c /home/pi/klipper_config/moonraker.conf -l /home/pi/klipper_logs/moonraker.log"
+MOONRAKER_ARGS="/home/pi/moonraker/moonraker/moonraker.py -d /home/pi/printer_data -c /home/pi/klipper_config/moonraker.conf -l /home/pi/klipper_logs/moonraker.log"
 ```
 
 Post installation it is simple to customize the [arguments](#command-line-usage)
 supplied to Moonraker by editing this file and restarting the service.
 
-!!! Note
-    The service unit and enviroment file are named based on the `alias`
-    option supplied to the install script, which is `moonraker` by default.
-    Supplying `-a moonraker_1` to the install script will result in a
-    service file named `moonraker_1.service` and an environment file
-    named `moonraker_1.env`.
 
 ### Command line usage
 
@@ -359,14 +325,12 @@ This section is intended for users that need to write their own
 installation script.  Detailed are the command line arguments
 available to Moonraker:
 ```
-usage: moonraker.py [-h] [-a <alias>] [-d <data path>] [-c <configfile>] [-l <logfile>] [-n]
+usage: moonraker.py [-h]p [-d <data path>] [-c <configfile>] [-l <logfile>] [-n]
 
 Moonraker - Klipper API Server
 
 options:
   -h, --help            show this help message and exit
-  -a <alias>, --alias <alias>
-                        Alternate name of instance
   -d <data path>, --datapath <data path>
                         Location of Moonraker Data File Path
   -c <configfile>, --configfile <configfile>
@@ -377,14 +341,13 @@ options:
 ```
 
 The default configuration is:
-- `data path`: `$HOME/moonraker_data`
-- `alias`: `moonraker`
-- `config file`: `$HOME/moonraker_data/config/moonraker.conf`
-- `log file`: `$HOME/moonraker_data/logs/moonraker.log`
+- `data path`: `$HOME/printer_data`
+- `config file`: `$HOME/printer_data/config/moonraker.conf`
+- `log file`: `$HOME/printer_data/logs/moonraker.log`
 - logging to a file is enabled
 
 !!! Tip
-    While the `alias` option may be omitted it is recommended that it
+    While the `data path` option may be omitted it is recommended that it
     always be included for new installations.  This allows Moonraker
     to differentiate between new and legacy installations.
 

--- a/docs/moonraker.conf
+++ b/docs/moonraker.conf
@@ -6,8 +6,7 @@
 
 [server]
 # Bind server defaults of 0.0.0.0, port 7125
-enable_debug_logging: True
-config_path: ~/printer_config
+enable_debug_logging: False
 
 [authorization]
 enabled: True

--- a/docs/user_changes.md
+++ b/docs/user_changes.md
@@ -2,6 +2,30 @@
 This file will track changes that require user intervention,
 such as a configuration change or a reinstallation.
 
+### October 14th 2022
+- The systemd service file is now versioned.  Moonraker can now detect when
+  the file is out of date and automate corrections as necessary.
+- Moonraker's command line options are now specified in an environment file,
+  making it possible to change these options without modifying the service file
+  and reloading the systemd daemon.  The default location of the environment
+  file is `~/printer_data/systemd/moonraker.env`.
+- Moonraker now manages files and folders in a primary data folder supplied
+  by the `-d` (`--data-path`) command line option.  As a result, the following
+  options have been deprecated:
+    - `ssl_certificate_path` in `[server]`
+    - `ssl_key_path` in `[server]`
+    - `database_path` in `[database]`
+    - `config_path` in `[file_manager]`
+    - `log_path` in `[file_manager]`
+    - `secrets_path` in `[secrets]`
+- Debugging options are now supplied to Moonraker via the command line.
+  The `-v` (`--verbose`) option enables verbose logging, while the `-g`
+  (`--debug`) option enables debug features, including access to debug
+  endpoints and the repo debug feature in `update_manager`.  As a result,
+  the following options are deprecated:
+    - `enable_debug_logging` in `[server]`
+    - `enable_repo_debug` in `[update_manager]`
+
 ### July 27th 2022
 - The behavior of `[include]` directives has changed.  Included files
   are now parsed as they are encountered.  If sections are duplicated

--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -1071,6 +1071,10 @@ Returns: Information about the host system in the following format:
             "klipper_mcu",
             "moonraker"
         ],
+        "instance_ids": {
+            "moonraker": "moonraker",
+            "klipper": "klipper"
+        },
         "service_state": {
             "klipper": {
                 "active_state": "active",

--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -2333,6 +2333,7 @@ HTTP request:
 ```http
 GET /server/database/list
 ```
+
 JSON-RPC request:
 ```json
 {
@@ -4935,6 +4936,133 @@ Returns:
 `ok` if an `id` was present in the request, otherwise no response is
 returned.  Once received, Moonraker will broadcast this event via
 the [agent event notification](#agent-events) to all other connections.
+
+### Debug APIs
+
+The APIs in this section are available when Moonraker the debug argument
+(`-g`) has been supplied via the command line.  Some API may also depend
+on Moonraker's configuration, ie: an optional component may choose to
+register a debug API.
+
+!!! Warning
+    Debug APIs may expose security vulnerabilities.  They should only be
+    enabled by developers on secured machines.
+
+#### List Database Namespaces (debug)
+
+Debug version of [List Namespaces](#list-namespaces). Return value includes
+namespaces exlusively reserved for Moonraker. Only availble when Moonraker's
+debug features are enabled.
+
+
+HTTP request:
+```http
+GET /debug/database/list
+```
+
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "debug.database.list",
+    "id": 8694
+}
+```
+
+#### Get Database Item (debug)
+
+Debug version of [Get Database Item](#get-database-item).  Keys within
+protected and forbidden namespaces are accessible. Only availble when
+Moonraker's debug features are enabled.
+
+!!! Warning
+    Moonraker's forbidden namespaces include items such as user credentials.
+    This endpoint should NOT be implemented in front ends directly.
+
+HTTP request:
+```http
+GET /debug/database/item?namespace={namespace}&key={key}
+```
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "debug.database.get_item",
+    "params": {
+        "namespace": "{namespace}",
+        "key": "{key}"
+    },
+    "id": 5644
+}
+```
+
+#### Add Database Item (debug)
+
+Debug version of [Add Database Item](#add-database-item).  Keys within
+protected and forbidden namespaces may be added. Only availble when
+Moonraker's debug features are enabled.
+
+!!! Warning
+    This endpoint should be used for testing/debugging purposes only.
+    Modifying protected namespaces outside of Moonraker can result in
+    broken functionality and is not supported for production environments.
+    Issues opened with reports/queries related to this endpoint will be
+    redirected to this documentation and closed.
+
+```http
+POST /debug/database/item
+Content-Type: application/json
+
+{
+    "namespace": "my_client",
+    "key": "settings.some_count",
+    "value": 100
+}
+```
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "debug.database.post_item",
+    "params": {
+        "namespace": "{namespace}",
+        "key": "{key}",
+        "value": 100
+    },
+    "id": 4654
+}
+```
+
+#### Delete Database Item (debug)
+
+Debug version of [Delete Database Item](#delete-database-item).  Keys within
+protected and forbidden namespaces may be removed. Only availble when
+Moonraker's debug features are enabled.
+
+!!! Warning
+    This endpoint should be used for testing/debugging purposes only.
+    Modifying protected namespaces outside of Moonraker can result in
+    broken functionality and is not supported for production environments.
+    Issues opened with reports/queries related to this endpoint will be
+    redirected to this documentation and closed.
+
+HTTP request:
+```http
+DELETE /debug/database/item?namespace={namespace}&key={key}
+```
+
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "debug.database.delete_item",
+    "params": {
+        "namespace": "{namespace}",
+        "key": "{key}"
+    },
+    "id": 4654
+}
+```
 
 ### Websocket notifications
 Printer generated events are sent over the websocket as JSON-RPC 2.0

--- a/moonraker/app.py
+++ b/moonraker/app.py
@@ -238,7 +238,6 @@ class MoonrakerApp:
         path: Optional[str] = config.get(option, None, deprecate=True)
         app_args = self.server.get_app_args()
         data_path = app_args["data_path"]
-        alias = app_args["alias"]
         certs_path = pathlib.Path(data_path).joinpath("certs")
         if not certs_path.exists():
             try:
@@ -246,7 +245,7 @@ class MoonrakerApp:
             except Exception:
                 pass
         ext = "key" if "key" in option else "cert"
-        item = certs_path.joinpath(f"{alias}.{ext}")
+        item = certs_path.joinpath(f"moonraker.{ext}")
         if item.exists() or path is None:
             return item
         item = pathlib.Path(path).expanduser().resolve()

--- a/moonraker/app.py
+++ b/moonraker/app.py
@@ -262,7 +262,7 @@ class MoonrakerApp:
         self.http_server = self.app.listen(
             port, address=host, max_body_size=MAX_BODY_SIZE,
             xheaders=True)
-        if self.cert_path.exists() and self.key_path.exists():
+        if self.https_enabled():
             logging.info(f"Starting secure server on port {ssl_port}")
             ssl_ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
             ssl_ctx.load_cert_chain(self.cert_path, self.key_path)
@@ -298,6 +298,9 @@ class MoonrakerApp:
 
     def get_asset_path(self) -> pathlib.Path:
         return ASSET_PATH
+
+    def https_enabled(self) -> bool:
+        return self.cert_path.exists() and self.key_path.exists()
 
     async def close(self) -> None:
         if self.http_server is not None:

--- a/moonraker/app.py
+++ b/moonraker/app.py
@@ -395,6 +395,24 @@ class MoonrakerApp:
             params['location_prefix'] = location_prefix
         self.mutable_router.add_handler(pattern, FileUploadHandler, params)
 
+    def register_debug_handler(
+        self,
+        uri: str,
+        request_methods: List[str],
+        callback: APICallback,
+        transports: List[str] = ALL_TRANSPORTS,
+        wrap_result: bool = True
+    ) -> None:
+        if not self.server.is_debug_enabled():
+            return
+        if not uri.startswith("/debug"):
+            raise self.server.error(
+                "Debug Endpoints must be registerd in the '/debug' path"
+            )
+        self.register_local_handler(
+            uri, request_methods, callback, transports, wrap_result
+        )
+
     def remove_handler(self, endpoint: str) -> None:
         api_def = self.api_cache.pop(endpoint, None)
         if api_def is not None:

--- a/moonraker/app.py
+++ b/moonraker/app.py
@@ -194,9 +194,8 @@ class MoonrakerApp:
         mimetypes.add_type('text/plain', '.gcode')
         mimetypes.add_type('text/plain', '.cfg')
 
-        self.debug = self.server.is_debug_enabled()
         app_args: Dict[str, Any] = {
-            'serve_traceback': self.debug,
+            'serve_traceback': self.server.is_verbose_enabled(),
             'websocket_ping_interval': 10,
             'websocket_ping_timeout': 30,
             'server': self.server,
@@ -275,7 +274,10 @@ class MoonrakerApp:
 
     def log_request(self, handler: tornado.web.RequestHandler) -> None:
         status_code = handler.get_status()
-        if not self.debug and status_code in [200, 204, 206, 304]:
+        if (
+            not self.server.is_verbose_enabled()
+            and status_code in [200, 204, 206, 304]
+        ):
             # don't log successful requests in release mode
             return
         if status_code < 400:
@@ -620,7 +622,7 @@ class DynamicRequestHandler(AuthorizedRequestHandler):
         return args
 
     def _log_debug(self, header: str, args: Any) -> None:
-        if self.server.is_debug_enabled():
+        if self.server.is_verbose_enabled():
             resp = args
             if isinstance(args, dict):
                 if (

--- a/moonraker/assets/welcome.html
+++ b/moonraker/assets/welcome.html
@@ -123,6 +123,137 @@
                     background-color: rgb(160, 64, 8);
                 }
             }
+
+            .modal {
+                display: none;
+                position: fixed;
+                z-index: 1;
+                left: 0;
+                top: 0;
+                width: 100%;
+                height: 100%;
+                overflow: auto;
+                background-color: rgb(0,0,0);
+                background-color: rgba(0,0,0,0.4);
+            }
+
+            .modal-card {
+                background: none;
+                position: relative;
+                border: 0px;
+                border-radius: 1rem;
+                background-color: #1a1a1a;
+                margin: 20% auto 2rem auto;
+                padding: 0rem;
+                border: 0px;
+                width: 50%;
+                animation-name: fadein;
+                animation-duration: .5s;
+            }
+
+            .modal-card h1 {
+                background-color: #006f7e;
+                text-align: center;
+                line-height: 3rem;
+                font-size: 1.1rem;
+                height: 3rem;
+                margin: 0;
+                border-top-left-radius: 1rem;
+                border-top-right-radius: 1rem;
+            }
+
+            .modal-content {
+                background-color: #3e3e3e;
+                padding: 1rem;
+                margin: 0;
+                height: auto
+            }
+
+            .modal-content .entry {
+                display: inline-block;
+                width: 100%;
+            }
+            .modal-content .entry:not(:last-child) {
+                margin-bottom: .5rem;
+            }
+            .modal-content .value {
+                float: right;
+                display: inline;
+            }
+            .modal-content input {
+                width: 100%;
+                padding: 8px;
+                border-radius: 4px;
+                -moz-border-radius: 4px;
+                -webkit-border-radius: 4px;
+                font-size: 1rem; color: #222;
+                background: #F7F7F7;
+
+            }
+
+            .modal-footer {
+                display: inline-block;
+                background-color: #3e3e3e;
+                margin: 0;
+                height: auto;
+                width: 100%;
+                border-bottom-left-radius: 1rem;
+                border-bottom-right-radius: 1rem;
+            }
+
+            .modal-button {
+                float: right;
+                background: #cecece;
+                border: none;
+                width: auto;
+                overflow: visible;
+                font-size: 1rem;
+                font-weight: bold;
+                color: rgb(0, 0, 0);
+                padding: .4rem .5rem;
+                margin: 0rem .5rem .5rem 0rem;
+                border-radius: .5rem;
+                -webkit-border-radius: .5rem;
+                -moz-border-radius: .5rem;
+            }
+
+            .modal-button:hover {
+                color: rgb(8, 154, 45);
+                text-decoration: none;
+                cursor: pointer;
+            }
+
+            .modal-status {
+                display: none;
+                position: relative;
+                border: 0;
+                border-radius: 1rem;
+                background-color: #3e3e3e;
+                margin: auto;
+                padding: 0rem;
+                width: 50%;
+                animation-name: fadebottom;
+                animation-duration: .5s;
+            }
+
+            .modal-status:hover {
+                cursor: pointer;
+            }
+
+            .modal-status .content {
+                display: inline-block;
+                margin: 1rem;
+            }
+
+            @keyframes fadebottom {
+                from {top: 10em; opacity: 0}
+                to {top: 0em; opacity: 1}
+            }
+
+            @keyframes fadein {
+                from {opacity: 0}
+                to {opacity: 1}
+            }
         </style>
         <script>
             function setClickable(id) {
@@ -162,11 +293,11 @@
                     <div class="content">
                         <div class="entry">
                             Request IP:
-                            <div class="value">{{ ip_address }}</div>
+                            <div class="value">{{ remote_ip }}</div>
                         </div>
                         <div class="entry">
-                            Trusted:
-                            <div class="value">{{ authorized}}</div>
+                            Authorized:
+                            <div class="value">{{ authorized }}</div>
                         </div>
                         <div class="entry">
                             CORS Enabled:
@@ -230,6 +361,140 @@
                     </article>
                 {% end %}
             </div>
+            <div id="update_modal" class="modal">
+                <div class="modal-card">
+                    <h1 id="modal_header_msg">
+                        Moonraker Root Request
+                    </h1>
+                    <div id="modal_body" class="modal-content">
+                        <div id="main_form">
+                            <div class="entry">
+                                Service Name:
+                                <div class="value">
+                                    {{ service_name }}
+                                </div>
+                            </div>
+                            <div class="entry">
+                                Host Name:
+                                <div class="value">
+                                    {{ hostname }}
+                                </div>
+                            </div>
+                            <div class="entry">
+                                Host IP Address:
+                                <div class="value">
+                                    {{ local_ip }}
+                                </div>
+                            </div>
+                            <div class="entry">
+                                {{ sudo_request_message }}
+                                Please enter the password for linux user <b>{{ linux_user }}</b>:
+                            </div>
+                            <div class="entry">
+                                <input id="sudo_passwd" name="sudo_passwd" type="password" />
+                            </div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" id="modal_close" class="modal-button">Cancel</button>
+                        <button type="button" id="modal_submit" class="modal-button">Submit</button>
+                    </div>
+                </div>
+                <div id="modal_status" class="modal-status">
+                    <div id="status_msg" class="content">
+                        Status Text
+                    </div>
+                </div>
+            </div>
+            <script>
+                const modal = document.getElementById("update_modal");
+                {% if sudo_requested %}
+                    modal.style.display = "block";
+                {% end %}
+                const main_form = document.getElementById("main_form")
+                const status_item = document.getElementById("modal_status");
+                const status_div = document.getElementById("status_msg");
+
+                function update_modal(status_msg) {
+                    status_div.innerHTML = status_msg
+                    status_item.style.display = "block";
+                }
+
+                function dismiss_status() {
+                    status_item.style.display = "none";
+                }
+
+                function check_success(req) {
+                    return (req.status < 205 || req.status == 304);
+                }
+
+                function post_machine_password(passwd) {
+                    let pwd_req = new XMLHttpRequest();
+                    pwd_req.onload = () => {
+                        if (check_success(pwd_req)) {
+                            console.log("Successfully Set Sudo Password");
+                            let resp = JSON.parse(pwd_req.responseText)
+                            let msg = resp.result.sudo_responses.join("<br/>")
+                            msg += "<br/><br/>You may close this window and return to the front end.";
+                            update_modal(msg);
+                        } else {
+                            console.log("Password Request Error");
+                            let err_msg = `Code ${pwd_req.status}: `;
+                            let response = pwd_req.responseText;
+                            try {
+                                let json_resp = JSON.parse(response);
+                                err_msg = json_resp.error.message;
+                            } catch (error) {}
+                            update_modal(
+                                "Request failed with error:<br/><br/>" + err_msg +
+                                "<br/><br/>You may need to manually update your installation."
+                            );
+                        }
+                    };
+                    pwd_req.onerror = () => {
+                        console.log("Error setting password");
+                        update_modal(
+                            "Request to set root password failed with " +
+                            "a network error."
+                        )
+                    };
+                    pwd_req.open("POST", "/machine/sudo/password");
+                    pwd_req.setRequestHeader("Content-Type", "application/json");
+                    pwd_req.send(JSON.stringify({"password": passwd}));
+                }
+
+                const modal_submit = document.getElementById("modal_submit");
+                const pwd_input = document.getElementById("sudo_passwd");
+                const modal_close = document.getElementById("modal_close");
+
+                modal_submit.onclick = () => {
+                    let val = pwd_input.value;
+                    pwd_input.value = "";
+                    dismiss_status();
+                    post_machine_password(val);
+                };
+
+                pwd_input.addEventListener("keypress", (event) => {
+                    if (event.key === "Enter") {
+                        event.preventDefault();
+                        modal_submit.click();
+                    }
+                });
+
+                modal_close.onclick = () => {
+                    modal.style.display = "none";
+                };
+
+                status_item.onclick = () => {
+                    dismiss_status();
+                }
+
+                window.onclick = (event) => {
+                    if (event.target == modal) {
+                        modal.style.display = "none";
+                    }
+                };
+            </script>
        </main>
    </body>
  </html>

--- a/moonraker/components/database.py
+++ b/moonraker/components/database.py
@@ -82,7 +82,6 @@ class MoonrakerDatabase:
         dep_path = config.get("database_path", None, deprecate=True)
         db_path = pathlib.Path(app_args["data_path"]).joinpath("database")
         if (
-            app_args["is_default_alias"] and
             app_args["is_default_data_path"] and
             not (dep_path is None and db_path.exists())
         ):

--- a/moonraker/components/file_manager/file_manager.py
+++ b/moonraker/components/file_manager/file_manager.py
@@ -1162,7 +1162,6 @@ class INotifyHandler:
                  ) -> None:
         self.server = config.get_server()
         self.event_loop = self.server.get_event_loop()
-        self.debug_enabled = self.server.is_debug_enabled()
         self.enable_warn = config.getboolean("enable_inotify_warnings", True)
         self.file_manager = file_manager
         self.gcode_metadata = gcode_metadata
@@ -1306,7 +1305,7 @@ class INotifyHandler:
         return True
 
     def log_nodes(self) -> None:
-        if self.debug_enabled:
+        if self.server.is_verbose_enabled():
             debug_msg = f"Inotify Watches After Scan:"
             for wdesc, node in self.watched_nodes.items():
                 wdir = node.get_path()

--- a/moonraker/components/file_manager/file_manager.py
+++ b/moonraker/components/file_manager/file_manager.py
@@ -59,15 +59,16 @@ class FileManager:
     def __init__(self, config: ConfigHelper) -> None:
         self.server = config.get_server()
         self.event_loop = self.server.get_event_loop()
-        self.reserved_paths: Dict[str, pathlib.Path] = {}
+        self.reserved_paths: Dict[str, Tuple[pathlib.Path, bool]] = {}
         self.full_access_roots: Set[str] = set()
         self.file_paths: Dict[str, str] = {}
-        self.add_reserved_path("moonraker", MOONRAKER_PATH)
-        db: DBComp = self.server.load_component(config, "database")
-        db_path = db.get_database_path()
-        self.add_reserved_path("database", db_path)
         app_args = self.server.get_app_args()
         self.datapath = pathlib.Path(app_args["data_path"])
+        self.add_reserved_path("moonraker", MOONRAKER_PATH, False)
+        db: DBComp = self.server.load_component(config, "database")
+        db_path = db.get_database_path()
+        self.add_reserved_path("database", db_path, False)
+        self.add_reserved_path("certs", self.datapath.joinpath("certs"), False)
         self.gcode_metadata = MetadataStorage(config, db)
         self.inotify_handler = INotifyHandler(config, self,
                                               self.gcode_metadata)
@@ -144,6 +145,7 @@ class FileManager:
         # Register path for example configs
         klipper_path = paths.get('klipper_path', None)
         if klipper_path is not None:
+            self.reserved_paths.pop("klipper", None)
             self.add_reserved_path("klipper", klipper_path)
             example_cfg_path = os.path.join(klipper_path, "config")
             self.register_directory("config_examples", example_cfg_path)
@@ -205,8 +207,6 @@ class FileManager:
             return False
         permissions = os.R_OK
         if full_access:
-            if not self._check_root_safe(root, path):
-                return False
             permissions |= os.W_OK
             self.full_access_roots.add(root)
         if not os.access(path, permissions):
@@ -229,70 +229,38 @@ class FileManager:
                     "root_update", root, path)
         return True
 
-    def _paths_overlap(self,
-                       path_one: StrOrPath,
-                       path_two: StrOrPath
-                       ) -> bool:
-        if isinstance(path_one, str):
-            path_one = pathlib.Path(path_one)
-        path_one = path_one.expanduser().resolve()
-        if isinstance(path_two, str):
-            path_two = pathlib.Path(path_two)
-        path_two = path_two.expanduser().resolve()
-        return (
-            path_one == path_two or
-            path_one in path_two.parents or
-            path_two in path_one.parents
-        )
-
-    def _check_root_safe(self, new_root: str, new_path: StrOrPath) -> bool:
-        # Make sure that registered full access paths
-        # do no overlap one another, nor a reserved path
-        if isinstance(new_path, str):
-            new_path = pathlib.Path(new_path)
-        new_path = new_path.expanduser().resolve()
-        for reg_root, reg_path in self.file_paths.items():
-            exp_reg_path = pathlib.Path(reg_path).expanduser().resolve()
+    def check_reserved_path(
+        self,
+        req_path: StrOrPath,
+        need_write: bool,
+        raise_error: bool = True
+    ) -> bool:
+        if isinstance(req_path, str):
+            req_path = pathlib.Path(req_path)
+        req_path = req_path.expanduser().resolve()
+        for name, (res_path, can_read) in self.reserved_paths.items():
             if (
-                reg_root not in self.full_access_roots or
-                (reg_root == new_root and new_path == exp_reg_path)
+                (res_path == req_path or res_path in req_path.parents) and
+                (need_write or not can_read)
             ):
-                continue
-            if self._paths_overlap(new_path, exp_reg_path):
-                self.server.add_warning(
-                    f"Failed to register '{new_root}': '{new_path}', path "
-                    f"overlaps registered root '{reg_root}': '{exp_reg_path}'")
-                return False
-        for res_name, res_path in self.reserved_paths.items():
-            if self._paths_overlap(new_path, res_path):
-                self.server.add_warning(
-                    f"Failed to register '{new_root}': '{new_path}', path "
-                    f"overlaps reserved path '{res_name}': '{res_path}'")
-                return False
-        return True
+                if not raise_error:
+                    return True
+                raise self.server.error(
+                    f"Access to file {req_path.name} forbidden by reserved "
+                    f"path '{name}'", 403
+                )
+        return False
 
-    def add_reserved_path(self, name: str, res_path: StrOrPath) -> bool:
+    def add_reserved_path(
+        self, name: str, res_path: StrOrPath, read_access: bool = True
+    ) -> bool:
+        if name in self.reserved_paths:
+            return False
         if isinstance(res_path, str):
             res_path = pathlib.Path(res_path)
         res_path = res_path.expanduser().resolve()
-        if (
-            name in self.reserved_paths and
-            res_path == self.reserved_paths[name]
-        ):
-            return True
-        self.reserved_paths[name] = res_path
-        check_passed = True
-        for reg_root, reg_path in list(self.file_paths.items()):
-            if reg_root not in self.full_access_roots:
-                continue
-            exp_reg_path = pathlib.Path(reg_path).expanduser().resolve()
-            if self._paths_overlap(res_path, exp_reg_path):
-                self.server.add_warning(
-                    f"Full access root '{reg_root}' overlaps reserved path "
-                    f"'{name}', removing access")
-                self.file_paths.pop(reg_root, None)
-                check_passed = False
-        return check_passed
+        self.reserved_paths[name] = (res_path, read_access)
+        return True
 
     def get_directory(self, root: str = "gcodes") -> str:
         return self.file_paths.get(root, "")
@@ -367,6 +335,7 @@ class FileManager:
             dir_info = self._list_directory(dir_path, root, is_extended)
             return dir_info
         async with self.write_mutex:
+            self.check_reserved_path(dir_path, True)
             result = {
                 'item': {'path': directory, 'root': root},
                 'action': "create_dir"}
@@ -460,6 +429,8 @@ class FileManager:
         if dest_root not in self.full_access_roots:
             raise self.server.error(
                 f"Destination path is read-only: {dest_root}")
+        self.check_reserved_path(source_path, False)
+        self.check_reserved_path(dest_path, True)
         async with self.write_mutex:
             result: Dict[str, Any] = {'item': {'root': dest_root}}
             if not os.path.exists(source_path):
@@ -540,16 +511,19 @@ class FileManager:
         }
         return flist
 
-    def get_path_info(self, path: str, root: str) -> Dict[str, Any]:
-        fstat = os.stat(path)
-        real_path = os.path.realpath(path)
+    def get_path_info(self, path: StrOrPath, root: str) -> Dict[str, Any]:
+        if isinstance(path, str):
+            path = pathlib.Path(path)
+        real_path = path.resolve()
+        fstat = path.stat()
         permissions = "rw"
         if (
-            (os.path.islink(path) and os.path.isfile(real_path)) or
-            not os.access(real_path, os.R_OK | os.W_OK) or
-            root not in self.full_access_roots
+            root not in self.full_access_roots or
+            (path.is_symlink() and path.is_file())
         ):
             permissions = "r"
+        if self.check_reserved_path(real_path, permissions == "rw", False):
+            permissions = ""
         return {
             'modified': fstat.st_mtime,
             'size': fstat.st_size,
@@ -569,6 +543,7 @@ class FileManager:
         async with self.write_mutex:
             try:
                 upload_info = self._parse_upload_args(form_args)
+                self.check_reserved_path(upload_info["dest_path"], True)
                 root = upload_info['root']
                 if root == "gcodes" and upload_info['ext'] in VALID_GCODE_EXTS:
                     result = await self._finish_gcode_upload(upload_info)
@@ -820,6 +795,7 @@ class FileManager:
     async def delete_file(self, path: str) -> Dict[str, Any]:
         async with self.write_mutex:
             root, full_path = self._convert_request_path(path)
+            self.check_reserved_path(full_path, True)
             filename = self.get_relative_path(root, full_path)
             if root not in self.full_access_roots:
                 raise self.server.error(

--- a/moonraker/components/file_manager/file_manager.py
+++ b/moonraker/components/file_manager/file_manager.py
@@ -69,6 +69,9 @@ class FileManager:
         db_path = db.get_database_path()
         self.add_reserved_path("database", db_path, False)
         self.add_reserved_path("certs", self.datapath.joinpath("certs"), False)
+        self.add_reserved_path(
+            "systemd", self.datapath.joinpath("systemd"), False
+        )
         self.gcode_metadata = MetadataStorage(config, db)
         self.inotify_handler = INotifyHandler(config, self,
                                               self.gcode_metadata)

--- a/moonraker/components/machine.py
+++ b/moonraker/components/machine.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     from confighelper import ConfigHelper
     from websockets import WebRequest
     from app import MoonrakerApp
+    from klippy_connection import KlippyConnection
     from .shell_command import ShellCommandFactory as SCMDComp
     from .database import MoonrakerDatabase
     from .file_manager.file_manager import FileManager
@@ -269,7 +270,14 @@ class Machine:
     async def _handle_sysinfo_request(self,
                                       web_request: WebRequest
                                       ) -> Dict[str, Any]:
-        return {"system_info": self.system_info}
+        kconn: KlippyConnection
+        kconn = self.server.lookup_component("klippy_connection")
+        sys_info = self.system_info.copy()
+        sys_info["instance_ids"] = {
+            "moonraker": self.unit_name,
+            "klipper": kconn.unit_name
+        }
+        return {"system_info": sys_info}
 
     async def _set_sudo_password(
         self, web_request: WebRequest

--- a/moonraker/components/machine.py
+++ b/moonraker/components/machine.py
@@ -1522,9 +1522,12 @@ class InstallValidator:
                 self._link_data_file(key_dest, ssl_key)
                 cfg_source.remove_option("server", "ssl_key_path")
 
-            # Remove deprecated debug option
+            # Remove deprecated debug options
             if server_cfg.has_option("enable_debug_logging"):
                 cfg_source.remove_option("server", "enable_debug_logging")
+            um_cfg = server_cfg["update_manager"]
+            if um_cfg.has_option("enable_repo_debug"):
+                cfg_source.remove_option("update_manager", "enable_repo_debug")
         except Exception:
             cfg_source.cancel()
             raise

--- a/moonraker/components/machine.py
+++ b/moonraker/components/machine.py
@@ -1521,6 +1521,10 @@ class InstallValidator:
                 key_dest = certs_path.joinpath("moonraker.key")
                 self._link_data_file(key_dest, ssl_key)
                 cfg_source.remove_option("server", "ssl_key_path")
+
+            # Remove deprecated debug option
+            if server_cfg.has_option("enable_debug_logging"):
+                cfg_source.remove_option("server", "enable_debug_logging")
         except Exception:
             cfg_source.cancel()
             raise

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -321,11 +321,12 @@ class PowerDevice:
     def _setup_bound_service(self) -> None:
         if self.bound_service is None:
             return
-        if self.bound_service.startswith("moonraker"):
-            raise self.server.error(
-                f"Cannot bind to '{self.bound_service}' "
-                "service")
         machine_cmp: Machine = self.server.lookup_component("machine")
+        if machine_cmp.unit_name == self.bound_service.split(".", 1)[0]:
+            raise self.server.error(
+                f"Power Device {self.name}: Cannot bind to Moonraker "
+                f"service, {self.bound_service}."
+            )
         sys_info = machine_cmp.get_system_info()
         avail_svcs: List[str] = sys_info.get('available_services', [])
         if self.bound_service not in avail_svcs:

--- a/moonraker/components/secrets.py
+++ b/moonraker/components/secrets.py
@@ -21,16 +21,17 @@ class Secrets:
     def __init__(self, config: ConfigHelper) -> None:
         server = config.get_server()
         self.secrets_file: Optional[pathlib.Path] = None
-        path: Optional[str] = config.get('secrets_path', None)
+        path: Optional[str] = config.get("secrets_path", None, deprecate=True)
+        app_args = server.get_app_args()
+        alias = app_args["alias"]
+        data_path = app_args["data_path"]
+        fpath = pathlib.Path(data_path).joinpath(f"{alias}.secrets")
+        if not fpath.is_file() and path is not None:
+            fpath = pathlib.Path(path).expanduser().resolve()
         self.type = "invalid"
         self.values: Dict[str, Any] = {}
-        if path is not None:
-            self.secrets_file = pathlib.Path(path).expanduser().resolve()
-            if not self.secrets_file.is_file():
-                server.add_warning(
-                    "[secrets]: option 'secrets_path', file does not exist: "
-                    f"'{self.secrets_file}'")
-                return
+        if fpath.is_file():
+            self.secrets_file = fpath
             data = self.secrets_file.read_text()
             vals = self._parse_json(data)
             if vals is not None:
@@ -52,6 +53,10 @@ class Secrets:
                 self.type = "ini"
             logging.debug(f"[secrets]: Loaded {self.type} file: "
                           f"{self.secrets_file}")
+        elif path is not None:
+            server.add_warning(
+                "[secrets]: option 'secrets_path', file does not exist: "
+                f"'{self.secrets_file}'")
         else:
             logging.debug(
                 "[secrets]: Option `secrets_path` not supplied")

--- a/moonraker/components/secrets.py
+++ b/moonraker/components/secrets.py
@@ -16,6 +16,7 @@ from typing import (
 )
 if TYPE_CHECKING:
     from confighelper import ConfigHelper
+    from .file_manager.file_manager import FileManager
 
 class Secrets:
     def __init__(self, config: ConfigHelper) -> None:
@@ -30,6 +31,8 @@ class Secrets:
             fpath = pathlib.Path(path).expanduser().resolve()
         self.type = "invalid"
         self.values: Dict[str, Any] = {}
+        fm: FileManager = server.lookup_component("file_manager")
+        fm.add_reserved_path("secrets", fpath, False)
         if fpath.is_file():
             self.secrets_file = fpath
             data = self.secrets_file.read_text()

--- a/moonraker/components/secrets.py
+++ b/moonraker/components/secrets.py
@@ -24,9 +24,8 @@ class Secrets:
         self.secrets_file: Optional[pathlib.Path] = None
         path: Optional[str] = config.get("secrets_path", None, deprecate=True)
         app_args = server.get_app_args()
-        alias = app_args["alias"]
         data_path = app_args["data_path"]
-        fpath = pathlib.Path(data_path).joinpath(f"{alias}.secrets")
+        fpath = pathlib.Path(data_path).joinpath("moonraker.secrets")
         if not fpath.is_file() and path is not None:
             fpath = pathlib.Path(path).expanduser().resolve()
         self.type = "invalid"

--- a/moonraker/components/simplyprint.py
+++ b/moonraker/components/simplyprint.py
@@ -1404,7 +1404,7 @@ class WebcamStream:
         except asyncio.CancelledError:
             raise
         except Exception as e:
-            if not self.server.is_debug_enabled():
+            if not self.server.is_verbose_enabled():
                 return
             logging.exception("SimplyPrint WebCam Stream Error")
 
@@ -1628,7 +1628,7 @@ class ProtoLogger:
     def __init__(self, config: ConfigHelper) -> None:
         server = config.get_server()
         self._logger: Optional[logging.Logger] = None
-        if not config["server"].getboolean("enable_debug_logging", False):
+        if not server.is_verbose_enabled():
             return
         fm: FileManager = server.lookup_component("file_manager")
         log_root = fm.get_directory("logs")

--- a/moonraker/components/update_manager/app_deploy.py
+++ b/moonraker/components/update_manager/app_deploy.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from confighelper import ConfigHelper
     from .update_manager import CommandHelper
     from ..machine import Machine
+    from ..file_manager.file_manager import FileManager
 
 SUPPORTED_CHANNELS = {
     "zip": ["stable", "beta"],
@@ -60,6 +61,12 @@ class AppDeploy(BaseDeploy):
             self.type = "zip"
         self.path = pathlib.Path(
             config.get('path')).expanduser().resolve()
+        if (
+            self.name not in ["moonraker", "klipper"]
+            and not self.path.joinpath(".writeable").is_file()
+        ):
+            fm: FileManager = self.server.lookup_component("file_manager")
+            fm.add_reserved_path(f"update_manager {self.name}", self.path)
         executable = config.get('env', None)
         if self.channel not in SUPPORTED_CHANNELS[self.type]:
             raise config.error(

--- a/moonraker/components/update_manager/app_deploy.py
+++ b/moonraker/components/update_manager/app_deploy.py
@@ -41,7 +41,6 @@ class AppDeploy(BaseDeploy):
     def __init__(self, config: ConfigHelper, cmd_helper: CommandHelper) -> None:
         super().__init__(config, cmd_helper, prefix="Application")
         self.config = config
-        self.debug = self.cmd_helper.is_debug_enabled()
         type_choices = list(TYPE_TO_CHANNEL.keys())
         self.type = config.get('type').lower()
         if self.type not in type_choices:
@@ -224,7 +223,7 @@ class AppDeploy(BaseDeploy):
     def get_update_status(self) -> Dict[str, Any]:
         return {
             'channel': self.channel,
-            'debug_enabled': self.debug,
+            'debug_enabled': self.server.is_debug_enabled(),
             'need_channel_update': self.need_channel_update,
             'is_valid': self._is_valid,
             'configured_type': self.type,

--- a/moonraker/components/update_manager/base_config.py
+++ b/moonraker/components/update_manager/base_config.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import os
 import sys
 import copy
+from utils import MOONRAKER_PATH
 from typing import (
     TYPE_CHECKING,
     Dict
@@ -17,8 +18,6 @@ if TYPE_CHECKING:
     from confighelper import ConfigHelper
     from components.database import MoonrakerDatabase
 
-MOONRAKER_PATH = os.path.normpath(os.path.join(
-    os.path.dirname(__file__), "../../.."))
 KLIPPER_DEFAULT_PATH = os.path.expanduser("~/klipper")
 KLIPPER_DEFAULT_EXEC = os.path.expanduser("~/klippy-env/bin/python")
 

--- a/moonraker/components/update_manager/base_deploy.py
+++ b/moonraker/components/update_manager/base_deploy.py
@@ -23,7 +23,7 @@ class BaseDeploy:
                  cfg_hash: Optional[str] = None
                  ) -> None:
         if name is None:
-            name = config.get_name().split()[-1]
+            name = config.get_name().split(maxsplit=1)[-1]
         self.name = name
         if prefix:
             prefix = f"{prefix} {self.name}: "

--- a/moonraker/components/update_manager/git_deploy.py
+++ b/moonraker/components/update_manager/git_deploy.py
@@ -67,7 +67,7 @@ class GitDeploy(AppDeploy):
             msgs = '\n'.join(invalids)
             self.log_info(
                 f"Repo validation checks failed:\n{msgs}")
-            if self.debug:
+            if self.server.is_debug_enabled():
                 self._is_valid = True
                 self.log_info(
                     "Repo debug enabled, overriding validity checks")
@@ -402,7 +402,7 @@ class GitRepo:
         if not detected_origin.endswith(".git"):
             detected_origin += ".git"
         if (
-            self.cmd_helper.is_debug_enabled() or
+            self.server.is_debug_enabled() or
             not detected_origin.startswith("http") or
             detected_origin == self.origin_url.lower()
         ):
@@ -703,7 +703,7 @@ class GitRepo:
                 f"Git Repo {self.alias}: Cannot perform pull on a "
                 "detached HEAD")
         cmd = "pull --progress"
-        if self.cmd_helper.is_debug_enabled():
+        if self.server.is_debug_enabled():
             cmd = f"{cmd} --rebase"
         if self.is_beta:
             cmd = f"{cmd} {self.git_remote} {self.upstream_commit}"

--- a/moonraker/components/update_manager/update_manager.py
+++ b/moonraker/components/update_manager/update_manager.py
@@ -464,8 +464,8 @@ class CommandHelper:
         self.server = config.get_server()
         self.http_client: HttpClient
         self.http_client = self.server.lookup_component("http_client")
-        self.debug_enabled = config.getboolean('enable_repo_debug', False)
-        if self.debug_enabled:
+        config.getboolean('enable_repo_debug', False, deprecate=True)
+        if self.server.is_debug_enabled():
             logging.warning("UPDATE MANAGER: REPO DEBUG ENABLED")
         shell_cmd: SCMDComp = self.server.lookup_component('shell_command')
         self.scmd_error = shell_cmd.error

--- a/moonraker/components/update_manager/update_manager.py
+++ b/moonraker/components/update_manager/update_manager.py
@@ -506,9 +506,6 @@ class CommandHelper:
     def get_umdb(self) -> NamespaceWrapper:
         return self.umdb
 
-    def is_debug_enabled(self) -> bool:
-        return self.debug_enabled
-
     def set_update_info(self, app: str, uid: int) -> None:
         self.cur_update_app = app
         self.cur_update_id = uid

--- a/moonraker/components/update_manager/update_manager.py
+++ b/moonraker/components/update_manager/update_manager.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
     from components.dbus_manager import DbusManager
     from components.machine import Machine
     from components.http_client import HttpClient
+    from components.file_manager.file_manager import FileManager
     from eventloop import FlexTimer
     from dbus_next import Variant
     from dbus_next.aio import ProxyInterface
@@ -1133,6 +1134,8 @@ class WebClientDeploy(BaseDeploy):
         self.repo = config.get('repo').strip().strip("/")
         self.owner = self.repo.split("/", 1)[0]
         self.path = pathlib.Path(config.get("path")).expanduser().resolve()
+        fm: FileManager = self.server.lookup_component("file_manager")
+        fm.add_reserved_path(f"update_manager {self.name}", self.path)
         self.type = config.get('type')
         def_channel = "stable"
         if self.type == "web_beta":

--- a/moonraker/klippy_connection.py
+++ b/moonraker/klippy_connection.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from websockets import WebRequest, Subscribable
     from components.klippy_apis import KlippyAPI
     from components.file_manager.file_manager import FileManager
+    from components.machine import Machine
     from asyncio.trsock import TransportSocket
     FlexCallback = Callable[..., Optional[Coroutine]]
 
@@ -59,6 +60,7 @@ class KlippyConnection:
         self._klipper_version: str = ""
         self._missing_reqs: Set[str] = set()
         self._peer_cred: Dict[str, int] = {}
+        self._service_info: Dict[str, Any] = {}
         self.init_attempts: int = 0
         self._state: str = "disconnected"
         self._state_message: str = "Klippy Disconnected"
@@ -100,6 +102,16 @@ class KlippyConnection:
     @property
     def peer_credentials(self) -> Dict[str, int]:
         return dict(self._peer_cred)
+
+    @property
+    def service_info(self) -> Dict[str, Any]:
+        return self._service_info
+
+    @property
+    def unit_name(self) -> str:
+        svc_info = self._service_info
+        unit_name = svc_info.get("unit_name", "klipper.service")
+        return unit_name.split(".", 1)[0]
 
     async def wait_connected(self) -> bool:
         if (
@@ -226,18 +238,27 @@ class KlippyConnection:
                     continue
                 logging.info("Klippy Connection Established")
                 self.writer = writer
-                self._get_peer_credentials(writer)
+                if self._get_peer_credentials(writer):
+                    machine: Machine = self.server.lookup_component("machine")
+                    provider = machine.get_system_provider()
+                    props = ["Description", "ExecStart", "FragmentPath"]
+                    svc_info = await provider.extract_service_info(
+                        "klipper", self._peer_cred["process_id"], props
+                    )
+                    if svc_info != self._service_info:
+                        self._service_info = svc_info
+                        machine.log_service_info(svc_info)
             self.event_loop.create_task(self._read_stream(reader))
             return await self._init_klippy_connection()
 
-    def _get_peer_credentials(self, writer: asyncio.StreamWriter) -> None:
+    def _get_peer_credentials(self, writer: asyncio.StreamWriter) -> bool:
         sock: TransportSocket
         sock = writer.get_extra_info("socket", None)
         if sock is None:
             logging.debug(
                 "Unable to get Unix Socket, cant fetch peer credentials"
             )
-            return
+            return False
         data: bytes = b""
         try:
             size = struct.calcsize("3I")
@@ -249,7 +270,7 @@ class KlippyConnection:
             logging.exception(
                 f"Failed to get Klippy Peer Credentials, raw: 0x{data.hex()}"
             )
-            return
+            return False
         self._peer_cred = {
             "process_id": pid,
             "user_id": uid,
@@ -258,6 +279,7 @@ class KlippyConnection:
         logging.debug(
             f"Klippy Connection: Received Peer Credentials: {self._peer_cred}"
         )
+        return True
 
     async def _init_klippy_connection(self) -> bool:
         self.init_list = []

--- a/moonraker/klippy_connection.py
+++ b/moonraker/klippy_connection.py
@@ -390,8 +390,7 @@ class KlippyConnection:
                 if vsd_path is not None:
                     file_manager: FileManager = self.server.lookup_component(
                         'file_manager')
-                    file_manager.register_directory('gcodes', vsd_path,
-                                                    full_access=True)
+                    file_manager.validate_gcode_path(vsd_path)
                 else:
                     logging.info(
                         "Configuration for [virtual_sdcard] not found,"

--- a/moonraker/moonraker.py
+++ b/moonraker/moonraker.py
@@ -438,8 +438,7 @@ class Server:
 
 def main(cmd_line_args: argparse.Namespace) -> None:
     startup_warnings: List[str] = []
-    alias: str = cmd_line_args.alias or "moonraker"
-    dp: str = cmd_line_args.datapath or f"~/{alias}_data"
+    dp: str = cmd_line_args.datapath or "~/printer_data"
     data_path = pathlib.Path(dp).expanduser().resolve()
     if not data_path.exists():
         try:
@@ -451,11 +450,9 @@ def main(cmd_line_args: argparse.Namespace) -> None:
     if cmd_line_args.configfile is not None:
         cfg_file: str = cmd_line_args.configfile
     else:
-        cfg_file = str(data_path.joinpath(f"config/{alias}.conf"))
+        cfg_file = str(data_path.joinpath("config/moonraker.conf"))
     app_args = {
-        "alias": alias,
         "data_path": str(data_path),
-        "is_default_alias": cmd_line_args.alias is None,
         "is_default_data_path": cmd_line_args.datapath is None,
         "config_file": cfg_file,
         "startup_warnings": startup_warnings
@@ -469,7 +466,7 @@ def main(cmd_line_args: argparse.Namespace) -> None:
         app_args["log_file"] = os.path.normpath(
             os.path.expanduser(cmd_line_args.logfile))
     else:
-        app_args["log_file"] = str(data_path.joinpath(f"logs/{alias}.log"))
+        app_args["log_file"] = str(data_path.joinpath("logs/moonraker.log"))
     app_args["software_version"] = version
     app_args["python_version"] = sys.version.replace("\n", " ")
     ql, file_logger, warning = utils.setup_logging(app_args)
@@ -537,10 +534,6 @@ if __name__ == '__main__':
     # Parse start arguments
     parser = argparse.ArgumentParser(
         description="Moonraker - Klipper API Server")
-    parser.add_argument(
-        "-a", "--alias", default=None, metavar="<alias>",
-        help="Alternate name of instance"
-    )
     parser.add_argument(
         "-d", "--datapath", default=None,
         metavar='<data path>',

--- a/moonraker/moonraker.py
+++ b/moonraker/moonraker.py
@@ -40,6 +40,7 @@ from typing import (
 if TYPE_CHECKING:
     from websockets import WebRequest, WebsocketManager
     from components.file_manager.file_manager import FileManager
+    from components.machine import Machine
     FlexCallback = Callable[..., Optional[Coroutine]]
     _T = TypeVar("_T")
 
@@ -161,6 +162,10 @@ class Server:
 
         if not self.warnings:
             await self.event_loop.run_in_thread(self.config.create_backup)
+
+        machine: Machine = self.lookup_component("machine")
+        if await machine.validate_installation():
+            return
 
         if start_server:
             await self.start_server()

--- a/moonraker/moonraker.py
+++ b/moonraker/moonraker.py
@@ -88,6 +88,7 @@ class Server:
         # Tornado Application/Server
         self.moonraker_app = app = MoonrakerApp(config)
         self.register_endpoint = app.register_local_handler
+        self.register_debug_endpoint = app.register_debug_handler
         self.register_static_file_handler = app.register_static_file_handler
         self.register_upload_handler = app.register_upload_handler
         self.register_api_transport = app.register_api_transport

--- a/scripts/finish-upgrade.sh
+++ b/scripts/finish-upgrade.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+#  Helper script for completing service upgrades via ssh
+
+ADDRESS="localhost"
+PORT="7125"
+API_KEY=""
+
+# Python Helper Scripts
+check_sudo_request=$( cat << EOF
+import sys
+import json
+try:
+  ret = json.load(sys.stdin)
+except Exception:
+  exit(0)
+entries = ret.get('result', {}).get('entries', [])
+for item in entries:
+   if item['dismissed'] is False and item['title'] == 'Sudo Password Required':
+     sys.stdout.write('true')
+     exit(0)
+sys.stdout.write('false')
+EOF
+)
+
+check_pw_response=$( cat << EOF
+import sys
+import json
+try:
+  ret = json.load(sys.stdin)
+except Exception:
+  exit(0)
+responses = ret.get('result', {}).get('sudo_responses', [])
+if responses:
+  sys.stdout.write('\n'.join(responses))
+EOF
+)
+
+print_help_message()
+{
+    echo "Utility to complete privileged upgrades for Moonraker"
+    echo
+    echo "usage: finish-upgrade.sh [-h] [-a <address>] [-p <port>] [-k <api_key>]"
+    echo
+    echo "optional arguments:"
+    echo "  -h                show this message"
+    echo "  -a <address>      address for Moonraker instance"
+    echo "  -p <port>         port for Moonraker instance"
+    echo "  -k <api_key>      API Key for authorization"
+}
+
+while getopts "a:p:k:h" arg; do
+    case $arg in
+        a) ADDRESS=${OPTARG};;
+        b) PORT=${OPTARG};;
+        k) API_KEY=${OPTARG};;
+        h)
+          print_help_message
+          exit 0
+          ;;
+    esac
+done
+
+base_url="http://${ADDRESS}:${PORT}"
+
+echo "Completing Upgrade for Moonraker at ${base_url}"
+echo "Requesting Announcements..."
+ann_url="${base_url}/server/announcements/list"
+curl_cmd=(curl -f -s -S "${ann_url}")
+[ -n "${API_KEY}" ] && curl_cmd+=(-H "X-Api-Key: ${API_KEY}")
+result="$( "${curl_cmd[@]}" 2>&1 )"
+if [ $? -ne 0 ]; then
+    echo "Moonraker announcement request failed with error: ${result}"
+    echo "Make sure the address and port are correct.  If authorization"
+    echo "is required supply the API Key with the -k option."
+    exit -1
+fi
+has_req="$( echo "$result" | python3 -c "${check_sudo_request}" )"
+if [ "$has_req" != "true" ]; then
+    echo "No sudo request detected, aborting"
+    exit -1
+fi
+
+# Request Password, send to Moonraker
+echo "Sudo request announcement found, please enter your password"
+read -sp "Password: " passvar
+echo -e "\n"
+sudo_url="${base_url}/machine/sudo/password"
+curl_cmd=(curl -f -s -S -X POST "${sudo_url}")
+curl_cmd+=(-d "{\"password\": \"${passvar}\"}")
+curl_cmd+=(-H "Content-Type: application/json")
+[ -n "$API_KEY" ] && curl_cmd+=(-H "X-Api-Key: ${API_KEY}")
+
+result="$( "${curl_cmd[@]}" 2>&1)"
+if [ $? -ne 0 ]; then
+    echo "Moonraker password request failed with error: ${result}"
+    echo "Make sure you entered the correct password."
+    exit -1
+fi
+response="$( echo "$result" | python3 -c "${check_pw_response}" )"
+if [ -n "${response}" ]; then
+    echo "${response}"
+else
+    echo "Invalid response received from Moonraker.  Raw result: ${result}"
+fi

--- a/scripts/install-moonraker.sh
+++ b/scripts/install-moonraker.sh
@@ -80,7 +80,8 @@ init_data_path()
     [ ! -e "${logs_dir}" ] && mkdir ${logs_dir}
     [ ! -e "${env_dir}" ] && mkdir ${env_dir}
     [ -n "${CONFIG_PATH}" ] && config_file=${CONFIG_PATH}
-    if [ ! -e "${config_file}" ]; then
+    # Write initial configuration for first time installs
+    if [ ! -f $SERVICE_FILE ] && [ ! -e "${config_file}" ]; then
         report_status "Writing Config File ${config_file}:\n"
         /bin/sh -c "cat > ${config_file}" << EOF
 # Moonraker Configuration File
@@ -105,7 +106,6 @@ install_script()
 {
     # Create systemd service file
     ENV_FILE="${DATA_PATH}/systemd/moonraker.env"
-    SERVICE_FILE="${SYSTEMDDIR}/${INSTANCE_ALIAS}.service"
     if [ ! -f $ENV_FILE ] || [ $FORCE_DEFAULTS = "y" ]; then
         rm -f $ENV_FILE
         args="MOONRAKER_ARGS=\"${SRCDIR}/moonraker/moonraker.py"
@@ -236,6 +236,9 @@ if [ -z "${DATA_PATH}" ]; then
         fi
     fi
 fi
+
+SERVICE_FILE="${SYSTEMDDIR}/${INSTANCE_ALIAS}.service"
+
 # Run installation steps defined above
 verify_ready
 cleanup_legacy

--- a/scripts/install-moonraker.sh
+++ b/scripts/install-moonraker.sh
@@ -7,8 +7,13 @@ SYSTEMDDIR="/etc/systemd/system"
 REBUILD_ENV="${MOONRAKER_REBUILD_ENV:-n}"
 FORCE_DEFAULTS="${MOONRAKER_FORCE_DEFAULTS:-n}"
 DISABLE_SYSTEMCTL="${MOONRAKER_DISABLE_SYSTEMCTL:-n}"
-CONFIG_PATH="${MOONRAKER_CONFIG_PATH:-${HOME}/moonraker.conf}"
-LOG_PATH="${MOONRAKER_LOG_PATH:-/tmp/moonraker.log}"
+SKIP_POLKIT="${MOONRAKER_SKIP_POLKIT:-n}"
+CONFIG_PATH="${MOONRAKER_CONFIG_PATH}"
+LOG_PATH="${MOONRAKER_LOG_PATH}"
+DATA_PATH="${MOONRAKER_DATA_PATH}"
+INSTANCE_ALIAS="${MOONRAKER_ALIAS:-moonraker}"
+SERVICE_VERSION="1"
+MACHINE_PROVIDER="systemd_cli"
 
 # Step 2: Clean up legacy installation
 cleanup_legacy() {
@@ -51,11 +56,11 @@ create_virtualenv()
     fi
 
     if [ ! -d ${PYTHONDIR} ]; then
-        GET_PIP="${HOME}/get-pip.py"
-        virtualenv --no-pip -p /usr/bin/python3 ${PYTHONDIR}
-        curl https://bootstrap.pypa.io/pip/3.6/get-pip.py -o ${GET_PIP}
-        ${PYTHONDIR}/bin/python ${GET_PIP}
-        rm ${GET_PIP}
+        virtualenv -p /usr/bin/python3 ${PYTHONDIR}
+        #GET_PIP="${HOME}/get-pip.py"
+        #curl https://bootstrap.pypa.io/pip/3.6/get-pip.py -o ${GET_PIP}
+        #${PYTHONDIR}/bin/python ${GET_PIP}
+        #rm ${GET_PIP}
     fi
 
     # Install/update dependencies
@@ -66,14 +71,25 @@ create_virtualenv()
 install_script()
 {
     # Create systemd service file
-    SERVICE_FILE="${SYSTEMDDIR}/moonraker.service"
+    ENV_FILE="${SRCDIR}/${INSTANCE_ALIAS}.env"
+    SERVICE_FILE="${SYSTEMDDIR}/${INSTANCE_ALIAS}.service"
+    if [ ! -f $ENV_FILE ] || [ $FORCE_DEFAULTS = "y" ]; then
+        rm -f $ENV_FILE
+        args="MOONRAKER_ARGS=\"${SRCDIR}/moonraker/moonraker.py"
+        args="${args} -a ${INSTANCE_ALIAS}"
+        [ -n "${CONFIG_PATH}" ] && args="${args} -c ${CONFIG_PATH}"
+        [ -n "${LOG_PATH}" ] && args="${args} -l ${LOG_PATH}"
+        [ -n "${DATA_PATH}" ] && args="${args} -d ${DATA_PATH}"
+        args="${args}\""
+        echo $args > $ENV_FILE
+    fi
     [ -f $SERVICE_FILE ] && [ $FORCE_DEFAULTS = "n" ] && return
     report_status "Installing system start script..."
     sudo groupadd -f moonraker-admin
     sudo /bin/sh -c "cat > ${SERVICE_FILE}" << EOF
-#Systemd service file for moonraker
+# systemd service file for moonraker
 [Unit]
-Description=API Server for Klipper
+Description=API Server for Klipper SV${SERVICE_VERSION}
 Requires=network-online.target
 After=network-online.target
 
@@ -86,13 +102,14 @@ User=$USER
 SupplementaryGroups=moonraker-admin
 RemainAfterExit=yes
 WorkingDirectory=${SRCDIR}
-ExecStart=${LAUNCH_CMD} -c ${CONFIG_PATH} -l ${LOG_PATH}
+EnvironmentFile=${ENV_FILE}
+ExecStart=${PYTHONDIR}/bin/python \$MOONRAKER_ARGS
 Restart=always
 RestartSec=10
 EOF
 # Use systemctl to enable the klipper systemd service script
     if [ $DISABLE_SYSTEMCTL = "n" ]; then
-        sudo systemctl enable moonraker.service
+        sudo systemctl enable "${INSTANCE_ALIAS}.service"
         sudo systemctl daemon-reload
     fi
 }
@@ -102,33 +119,74 @@ check_polkit_rules()
     if [ ! -x "$(command -v pkaction)" ]; then
         return
     fi
-    POLKIT_VERSION="$( pkaction --version | grep -Po "(\d?\.\d+)" )"
+    POLKIT_VERSION="$( pkaction --version | grep -Po "(\d+\.?\d*)" )"
+    NEED_POLKIT_INSTALL="n"
     if [ "$POLKIT_VERSION" = "0.105" ]; then
         POLKIT_LEGACY_FILE="/etc/polkit-1/localauthority/50-local.d/10-moonraker.pkla"
         # legacy policykit rules don't give users other than root read access
         if sudo [ ! -f $POLKIT_LEGACY_FILE ]; then
-            echo -e "\n*** No PolicyKit Rules detected, run 'set-policykit-rules.sh'"
-            echo "*** if you wish to grant Moonraker authorization to manage"
-            echo "*** system services, reboot/shutdown the system, and update"
-            echo "*** packages."
+            NEED_POLKIT_INSTALL="y"
         fi
     else
         POLKIT_FILE="/etc/polkit-1/rules.d/moonraker.rules"
         POLKIT_USR_FILE="/usr/share/polkit-1/rules.d/moonraker.rules"
         if [ ! -f $POLKIT_FILE ] && [ ! -f $POLKIT_USR_FILE ]; then
+            NEED_POLKIT_INSTALL="y"
+        fi
+    fi
+    if [ "${NEED_POLKIT_INSTALL}" = "y" ]; then
+        if [ "${SKIP_POLKIT}" = "y" ]; then
             echo -e "\n*** No PolicyKit Rules detected, run 'set-policykit-rules.sh'"
             echo "*** if you wish to grant Moonraker authorization to manage"
             echo "*** system services, reboot/shutdown the system, and update"
             echo "*** packages."
+        else
+            report_status "Installing PolKit Rules"
+            ${SRCDIR}/scripts/set-policykit-rules.sh -z
+            MACHINE_PROVIDER="systemd_dbus"
         fi
+    else
+        MACHINE_PROVIDER="systemd_dbus"
     fi
 }
 
-# Step 6: Start server
+# Step 6: Initialize data folder
+init_data_path()
+{
+    dpath="${DATA_PATH:-${HOME}/${INSTANCE_ALIAS}_data}"
+    report_status "Initializing Moonraker Data Path at ${dpath}"
+    config_dir="${dpath}/config"
+    logs_dir="${dpath}/logs"
+    config_file="${dpath}/config/${INSTANCE_ALIAS}.conf"
+    [ ! -e "${dpath}" ] && mkdir ${dpath}
+    [ ! -e "${config_dir}" ] && mkdir ${config_dir}
+    [ ! -e "${logs_dir}" ] && mkdir ${logs_dir}
+    [ -n "${CONFIG_PATH}" ] && config_file=${CONFIG_PATH}
+    if [ ! -e "${config_file}" ]; then
+        report_status "Writing Config File ${config_file}:\n"
+        /bin/sh -c "cat > ${config_file}" << EOF
+# Moonraker Configuration File
+
+[server]
+host: 0.0.0.0
+port: 7125
+# Make sure the klippy_uds_address is correct.  It is initialized
+# to the default address.
+klippy_uds_address: /tmp/klippy_uds
+
+[machine]
+provider: ${MACHINE_PROVIDER}
+
+EOF
+        cat ${config_file}
+    fi
+}
+
+# Step 7: Start server
 start_software()
 {
     report_status "Launching Moonraker API Server..."
-    sudo systemctl restart moonraker
+    sudo systemctl restart ${INSTANCE_ALIAS}
 }
 
 # Helper functions
@@ -150,16 +208,18 @@ set -e
 
 # Find SRCDIR from the pathname of this script
 SRCDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
-LAUNCH_CMD="${PYTHONDIR}/bin/python ${SRCDIR}/moonraker/moonraker.py"
 
 # Parse command line arguments
-while getopts "rfzc:l:" arg; do
+while getopts "rfzxc:l:d:a:" arg; do
     case $arg in
         r) REBUILD_ENV="y";;
         f) FORCE_DEFAULTS="y";;
         z) DISABLE_SYSTEMCTL="y";;
+        x) SKIP_POLKIT="y";;
         c) CONFIG_PATH=$OPTARG;;
         l) LOG_PATH=$OPTARG;;
+        d) DATA_PATH=$OPTARG;;
+        a) INSTANCE_ALIAS=$OPTARG;;
     esac
 done
 
@@ -170,6 +230,7 @@ install_packages
 create_virtualenv
 install_script
 check_polkit_rules
+init_data_path
 if [ $DISABLE_SYSTEMCTL = "n" ]; then
     start_software
 fi


### PR DESCRIPTION
This pull request will significantly change how file paths are configured.  There are two primary goals: 

1) Clean up the somewhat disjointed way Moonraker's file paths are organized
2) Reduce "worst case scenarios" should an instance be compromised by a malicious actor

As things stand today, a compromised system could have their config and/or gcode paths reconfigured.  This pull request organizes all of Moonraker's into a single data folder, named `$HOME/printer_data` by default.  The folder is organized something like the following:

```
/home/pi/printer_data
├── backup
│   └── 20220822T202419Z
│       ├── config
│       │   └── moonraker.conf
│       └── service
│           └── moonraker.service
├── certs
│   ├── moonraker.cert (optional)
│   └── moonraker.key (optional)
├── config
│   ├── moonraker.conf
│   └── printer.cfg
├── database
│   ├── data.mdb
│   └── lock.mdb
├── gcodes
│   ├── test_gcode_one.gcode
│   └── test_gcode_two.gcode
├── logs
│   ├── klippy.log
│   └── moonraker.log
├── systemd
│   └── moonraker.env
└── moonraker.secrets (optional)
```

Each instance of Moonraker should have its own data path, however its acceptable for the files and folders within it to be symbolic links.  A new command line option for Moonraker, `-d <datapath>`, has been introduced to configure this location.  The `-c` and `-l` options still exist if a user desires custom names and/or locations for the log and config. 

This change comes with an update to Moonraker's systemd service.  The new file will look something like the following:
```ini
# systemd service file for moonraker
[Unit]
Description=API Server for Klipper SV1
Requires=network-online.target
After=network-online.target

[Install]
WantedBy=multi-user.target

[Service]
Type=simple
User=pi
SupplementaryGroups=moonraker-admin
RemainAfterExit=yes
WorkingDirectory=/home/pi/moonraker
EnvironmentFile=/home/pi/printer_data/systemd/moonraker.env
ExecStart=/home/pi/moonraker-env/bin/python $MOONRAKER_ARGS
Restart=always
RestartSec=10
```

There are two significant changes to the service:
- The description is versioned `SV1`
- The addition of the environment file

The environment file contains Moonraker's arguments, this will make possible to update the arguments in the future without updating the service itself.  The version is for the `InstallValidator` covered below.

Having learned from the polkit experience, this pull request also includes an `InstallValidator` that attempts to automate the changes required to the service unit and configuration.  There will be situations where this isn't possible (ie: instances running in containers).  Options are available to disable either service or config validation in the `machine` section, its possible that containers can get away with only config validation.

The validator will first check the service version, if it does not match it will attempt to update the unit file.  It will use the current unit file's name to determine the alias, and thus the new data folder location.  If this is successful, Moonraker will move to config validation.  It will look for the existing path options, remove them, and create symbolic links to them in the data folder.

Everything should go smoothly if Moonraker user has passwordless sudo, however this isn't the case on MainsailOS (not sure about FluiddPi).   Thus I had to come up with a means to allow users to enter their linux user password.  At this time I am leveraging announcements and Moonraker's landing page to handle this.  APIs are available for front ends to handle this directly in the future if they choose to do so.

When Moonraker requests sudo access, users will get some warnings and the announcement:

Mainsail:
![mainsail-root-announcement](https://user-images.githubusercontent.com/9563098/186702296-3639f652-d923-4a05-b190-9042d2add5d4.png)

Fluidd:
![fluidd-root-warning](https://user-images.githubusercontent.com/9563098/186659689-5a6918be-ed92-4137-ae52-2be6e8624000.png)
![fluidd-root-announcement](https://user-images.githubusercontent.com/9563098/186702322-3d1f763e-a50f-49cc-81cf-10df0397a5e9.png)


Clicking through the link will take them to the landing page:
![moonraker-landing-root-request](https://user-images.githubusercontent.com/9563098/186659998-c67ad8c6-88c3-4e24-9f2f-5710763fd098.png)

After entering the correct password, they'll get the following message:
![moonraker-landing-update-complete](https://user-images.githubusercontent.com/9563098/186660124-d0f2b889-108a-4557-8345-7038413395a7.png)

The data folder will look like the following after completion.  Only items that are configured are linked, so if the user does not have ssl certs they won't be linked, etc :
![update-tree](https://user-images.githubusercontent.com/9563098/187792423-50ba045e-ac51-4799-a64e-47d7f1256826.png)

I have done quite a bit of testing with this, but it could certainly use more.  Assuming there are no objections I plan to leave this up for a few days, make an announcement, then merge a few days later.
