### PR TITLE
Git submodules use a .git file instead of a directory

### DIFF
--- a/moonraker/components/update_manager/git_deploy.py
+++ b/moonraker/components/update_manager/git_deploy.py
@@ -562,7 +562,7 @@ class GitRepo:
 
     async def update_repo_status(self) -> bool:
         async with self.git_operation_lock:
-            if not self.git_path.joinpath(".git").is_dir():
+            if not self.git_path.joinpath(".git").exists():
                 logging.info(
                     f"Git Repo {self.alias}: path '{self.git_path}'"
                     " is not a valid git repo")


### PR DESCRIPTION
I'm playing with using git submodules to track my entire printer config,
 and moonraker only works with separate clones as is. Using `.exists()`
 instead of `.is_dir()` allows moonraker to control the submodules.