### PR TITLE
Add support to extract metadata from g-code files generated by Bambu Studio

### DIFF
--- a/moonraker/components/file_manager/metadata.py
+++ b/moonraker/components/file_manager/metadata.py
@@ -307,7 +307,8 @@ class PrusaSlicer(BaseSlicer):
         aliases = {
             'PrusaSlicer': r"PrusaSlicer\s(.*)\son",
             'SuperSlicer': r"SuperSlicer\s(.*)\son",
-            'SliCR-3D': r"SliCR-3D\s(.*)\son"
+            'SliCR-3D': r"SliCR-3D\s(.*)\son",
+            'BambuStudio': r"BambuStudio[^ ]*\s(.*)\n"
         }
         for name, expr in aliases.items():
             match = re.search(expr, data)


### PR DESCRIPTION
Bambu Studio is a slicer developed by Bambulab.
It's forked from Prusa Slicer. 
It has some cool features like tree support and enhanced overhang performance.
Their repo: https://github.com/bambulab/BambuStudio

I made a customized version from it so it can be used on Voron and other Klipper-based machines.
See the repo here: https://github.com/SoftFever/BambuStudio-SoftFever/releases/tag/v1.1

This PR adds support to extract thumbnails from the g-code files generated by it.