### PR TITLE
Feature: Generic sensor support and data logging

### DIFF
--- a/docs/api_changes.md
+++ b/docs/api_changes.md
@@ -1,6 +1,20 @@
 ##
 This document keeps a record of all changes to Moonraker's web APIs.
 
+### February 20th 2023
+- The following new endpoints are available when at least one `[sensor]`
+  section has been configured:
+  - `GET /server/sensors/list`
+  - `GET /server/sensors/sensor`
+  - `GET /server/sensors/measurements`
+
+  See [web_api.md](web_api.md) for details on these new endpoints.
+- A `sensors:sensor_update` notification has been added.  When at least one
+  monitored sensor is reporting a changed value Moonraker will broadcast this
+  notification.
+
+  See [web_api.md](web_api.md) for details on this new notification.
+
 ### February 17 2023
 - Moonraker API Version 1.2.1
 - An error in the return value for some file manager endpoints has

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1160,8 +1160,8 @@ device_id:
 #   An explanation on how you could get the device id, can be found here:
 #   https://developers.meethue.com/develop/get-started-2/#turning-a-light-on-and-off
 device_type: light
-#   Set to light to control a single hue light, or group to control a hue light gorup. 
-#   If device_type is set to light, the device_id should be the light id, 
+#   Set to light to control a single hue light, or group to control a hue light gorup.
+#   If device_type is set to light, the device_id should be the light id,
 #   and if the device_type is group, the device_id should be the group id.
 #   The default is "light.
 
@@ -1610,7 +1610,7 @@ instance_name:
 status_objects:
 #   A newline separated list of Klipper objects whose state will be
 #   published.  There are two different ways to publish the states - you
-#   can use either or both depending on your need.  See the 
+#   can use either or both depending on your need.  See the
 #   "publish_split_status" options for details.
 #
 #   For example, this option could be set as follows:
@@ -1634,7 +1634,7 @@ status_objects:
 #   If not configured then no objects will be tracked and published to
 #   the klipper/status topic.
 publish_split_status: False
-#   Configures how to publish status updates to MQTT.  
+#   Configures how to publish status updates to MQTT.
 #
 #   When set to False (default), all Klipper object state updates will be
 #   published to a single mqtt state with the following topic:
@@ -2186,6 +2186,85 @@ ambient_sensor:
 
 More on how your data is used in the SimplyPrint privacy policy here;
 [https://simplyprint.io/legal/privacy](https://simplyprint.io/legal/privacy)
+
+### `[sensor]`
+
+Enables data collection from additional sensor sources.  Multiple "sensor"
+sources may be configured, each with their own section, ie: `[sensor current]`,
+`[sensor voltage]`.
+
+#### Options common to all sensor devices
+
+The following configuration options are available for all sensor types:
+
+```ini
+# moonraker.conf
+
+[sensor my_sensor]
+type:
+#   The type of device.  Supported types: mqtt
+#   This parameter must be provided.
+name:
+#   The display name of the sensor.
+#   The default is the sensor source name.
+unit:
+#   The unit for the values that are being collected, e.g. °C, W, A or kWh.
+#   The default is unitless.
+```
+
+#### MQTT Sensor Configuration
+
+The following options are available for `mqtt` sensor types:
+
+```ini
+# moonraker.conf
+
+qos:
+#  The MQTT QOS level to use when publishing and subscribing to topics.
+#  The default is to use the setting supplied in the [mqtt] section.
+state_topic:
+#  The mqtt topic to subscribe to for sensor state updates.  This parameter
+#  must be provided.
+state_response_template:
+#  A template used to parse the payload received with the state topic.  A
+#  "payload" variable is provided the template's context.  This template
+#  must resolve to a float value.  For example:
+#    {% set resp = payload|fromjson %}
+#    {resp["power"]|float}
+#  The above example assumes a json response is received, with a "power" field
+#  that is coerced to a float value. The default is the payload.
+```
+
+!!! Note
+    Moonraker's MQTT client must be properly configured to add a MQTT sensor.
+    See the [mqtt](#mqtt) section for details.
+
+!!! Tip
+    MQTT is the most robust way of collecting sensor data from networked
+    devices through Moonraker.  A well implemented MQTT sensor will publish all
+    changes in state to the `state_topic`.  Moonraker receives these changes,
+    updates its internal state, and notifies connected clients.
+
+Example:
+
+```ini
+# moonraker.conf
+
+# Example configuration for a Shelly Pro 1PM (Gen2) switch with
+# integrated power meter running the Shelly firmware over MQTT.
+[sensor mqtt_powermeter]
+type: mqtt
+name: active_power
+# Use a different display name
+unit: W
+# The values collected are in Watt
+state_topic: shellypro1pm-8cb113caba09/status/switch:0
+# The response is a JSON object with a "apower" field that we convert to
+# a float value
+state_response_template:
+  {% set resp = payload|fromjson %}
+  {resp["apower"]|float}
+```
 
 ## Include directives
 

--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -4915,6 +4915,154 @@ State of the strip.
 }
 ```
 
+### Sensor APIs
+The APIs below are available when the `[sensor]` component has been configured.
+
+#### Get Sensor List
+HTTP request:
+```http
+GET /server/sensors/list
+```
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method":"machine.device_power.devices",
+    "id": 5646
+}
+```
+Returns:
+
+An array of objects containing info for each configured sensor.
+```json
+{
+    "sensors": {
+        "sensor1": {
+            "id": "sensor1",
+            "friendly_name": "Sensor 1",
+            "type": "mqtt",
+            "values": {
+                "value1": 0,
+                "value2": 119.8
+            }
+        }
+    }
+}
+```
+
+#### Get Sensor Information
+Returns the status for a single configured sensor.
+
+HTTP request:
+```http
+GET /server/sensors/list?sensor=sensor1
+```
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "machine.device_power.get_device",
+    "params": {
+        "sensor": "sensor1"
+    },
+    "id": 4564
+}
+```
+Returns:
+
+An object containing sensor information for the requested sensor:
+```json
+{
+    "id": "sensor1",
+    "friendly_name": "Sensor 1",
+    "type": "mqtt",
+    "values": {
+        "value1": 0.0,
+        "value2": 120.0
+    }
+}
+```
+
+#### Get Sensor Measurements
+Returns all recorded measurements for a configured sensor.
+
+HTTP request:
+```http
+GET /server/sensors/measurements?sensor=sensor1
+```
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "server.sensors.measurements",
+    "params": {
+        "sensor": "sensor1"
+    },
+    "id": 4564
+}
+```
+Returns:
+
+An object containing all recorded measurements for the requested sensor:
+```json
+{
+    "sensor1": {
+        "value1": [
+            3.1,
+            3.2,
+            3.0
+        ],
+        "value2": [
+            120.0,
+            120.0,
+            119.9
+        ]
+    }
+}
+```
+
+#### Get Batch Sensor Measurements
+Returns recorded measurements for all sensors.
+
+HTTP request:
+```http
+GET /server/sensors/measurements
+```
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "server.sensors.measurements",
+    "id": 4564
+}
+```
+Returns:
+
+An object containing all measurements for every configured sensor:
+```json
+{
+    "sensor1": {
+        "value1": [
+            3.1,
+            3.2,
+            3.0
+        ],
+        "value2": [
+            120.0,
+            120.0,
+            119.9
+        ]
+    },
+    "sensor2": {
+        "value_a": [
+            1,
+            1,
+            0
+        ]
+    }
+}
+```
+
 ### OctoPrint API emulation
 Partial support of OctoPrint API is implemented with the purpose of
 allowing uploading of sliced prints to a moonraker instance.
@@ -6289,6 +6437,30 @@ for that agent, with its identity info in the `data` field.  When an agent
 disconnects clients will receive a `disconnected` event with the data field
 omitted.  All other events are determined by the agent, where each event may
 or may not include optional `data`.
+
+#### Sensor Events
+
+Moonraker will emit a `sensors:sensor_update` notification when a measurement
+from at least one monitored sensor changes.
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "sensors:sensor_update",
+    "params": [
+        {
+            "sensor1": {
+                "humidity": 28.9,
+                "temperature": 22.4
+            }
+        }
+    ]
+  ```
+
+When a sensor reading changes, all connections will receive a
+`sensors:sensor_update` event where the params contains a data struct
+with the sensor id as the key and the sensors letest measurements as value
+struct.
 
 ### Appendix
 

--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -4927,7 +4927,7 @@ JSON-RPC request:
 ```json
 {
     "jsonrpc": "2.0",
-    "method":"machine.device_power.devices",
+    "method":"server.sensors.list",
     "id": 5646
 }
 ```
@@ -4955,13 +4955,13 @@ Returns the status for a single configured sensor.
 
 HTTP request:
 ```http
-GET /server/sensors/list?sensor=sensor1
+GET /server/sensors/info?sensor=sensor1
 ```
 JSON-RPC request:
 ```json
 {
     "jsonrpc": "2.0",
-    "method": "machine.device_power.get_device",
+    "method": "/server/sensors/info?sensor=sensor1",
     "params": {
         "sensor": "sensor1"
     },
@@ -6455,7 +6455,7 @@ from at least one monitored sensor changes.
             }
         }
     ]
-  ```
+```
 
 When a sensor reading changes, all connections will receive a
 `sensors:sensor_update` event where the params contains a data struct

--- a/moonraker/components/sensor.py
+++ b/moonraker/components/sensor.py
@@ -189,7 +189,7 @@ class Sensors:
             self._handle_sensor_list_request,
         )
         self.server.register_endpoint(
-            "/server/sensors/sensor",
+            "/server/sensors/info",
             ["GET"],
             self._handle_sensor_info_request,
         )
@@ -294,7 +294,7 @@ class Sensors:
         output = {
             key: sensor.get_sensor_measurements()
             for key, sensor in self.sensors.items()
-            if sensor_name is None or key == sensor_name
+            if sensor_name is "" or key == sensor_name
         }
 
         return output

--- a/moonraker/components/sensor.py
+++ b/moonraker/components/sensor.py
@@ -1,0 +1,232 @@
+# Generic sensor support
+#
+# Copyright (C) 2022 Morton Jonuschat <mjonuschat+moonraker@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+# Component to read additional generic sensor data and make it
+# available to clients
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, replace
+from collections import deque
+
+# Annotation imports
+from typing import Any, Dict, List, Optional, Type, Deque, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from confighelper import ConfigHelper
+    from websockets import WebRequest
+
+SENSOR_UPDATE_TIME = 1.0
+
+
+@dataclass(frozen=True)
+class SensorConfiguration:
+    id: str
+    name: str
+    source: str = ""
+    unit: str = ""
+    accuracy_decimals: int = 2
+
+
+if TYPE_CHECKING:
+    from confighelper import ConfigHelper
+
+    from .mqtt import MQTTClient
+
+
+@dataclass(frozen=True)
+class Sensor:
+    config: SensorConfiguration
+    values: Deque
+
+
+class BaseSensor:
+    def __init__(
+        self, name: str, cfg: ConfigHelper, store_size: int = 1200
+    ) -> None:
+        self.server = cfg.get_server()
+        self.error_state: Optional[str] = None
+
+        self.config = SensorConfiguration(
+            id=name,
+            name=cfg.get("name", name),
+            unit=cfg.get("unit", ""),
+            accuracy_decimals=cfg.getint("accuracy_decimals", 2),
+        )
+        self.last_value: float = 0.0
+        self.values: Deque[float] = deque(maxlen=store_size)
+        self.sensor_update_timer = self.server.get_event_loop().register_timer(
+            self._update_sensor_value
+        )
+
+    def _update_sensor_value(self, eventtime: float) -> float:
+        """
+        Append the last updated value to the store.
+        """
+        self.values.append(self.last_value)
+
+        return eventtime + SENSOR_UPDATE_TIME
+
+    async def initialize(self) -> None:
+        """
+        Sensor initialization executed on Moonraker startup.
+        """
+        self.sensor_update_timer.start()
+        logging.info("Registered sensor '%s'", self.config.name)
+
+    def close(self) -> None:
+        self.sensor_update_timer.stop()
+
+
+class MQTTSensor(BaseSensor):
+    def __init__(self, name: str, cfg: ConfigHelper, store_size: int = 1200):
+        super().__init__(name=name, cfg=cfg)
+        self.mqtt: MQTTClient = self.server.load_component(cfg, "mqtt")
+
+        self.state_topic: str = cfg.get("state_topic")
+        self.state_response = cfg.load_template(
+            "state_response_template", "{payload}"
+        )
+        self.config = replace(self.config, source=self.state_topic)
+        self.qos: Optional[int] = cfg.getint("qos", None, minval=0, maxval=2)
+
+        self.server.register_event_handler(
+            "mqtt:disconnected", self._on_mqtt_disconnected
+        )
+
+    def _on_state_update(self, payload: bytes) -> None:
+        err: Optional[Exception] = None
+        context = {"payload": payload.decode()}
+        logging.debug("Context: %s", context)
+        try:
+            response = float(self.state_response.render(context))
+        except Exception as e:
+            self.error_state = str(e)
+        else:
+            self.error_state = None
+
+            self.last_value = round(response, self.config.accuracy_decimals)
+            logging.debug(
+                "Received updated sensor value for %s: %s%s",
+                self.config.name,
+                self.last_value,
+                self.config.unit,
+            )
+
+    async def _on_mqtt_disconnected(self):
+        self.error_state = "MQTT Disconnected"
+        self.last_value = 0.0
+
+    async def initialize(self) -> None:
+        try:
+            self.mqtt.subscribe_topic(
+                self.state_topic, self._on_state_update, self.qos
+            )
+            self.error_state = None
+        except Exception as e:
+            self.error_state = str(e)
+
+        return await super().initialize()
+
+
+class Sensors:
+    __sensor_types: Dict[str, Type[BaseSensor]] = {"MQTT": MQTTSensor}
+
+    def __init__(self, config: ConfigHelper) -> None:
+        self.server = config.get_server()
+        prefix_sections = config.get_prefix_sections("sensor")
+
+        self.sensors = {}
+        # Register endpoints
+        self.server.register_endpoint(
+            "/server/sensors", ["GET"], self._handle_sensor_data_request
+        )
+
+        for section in prefix_sections:
+            cfg = config[section]
+
+            try:
+                try:
+                    _, name = cfg.get_name().split(maxsplit=1)
+                except ValueError:
+                    raise cfg.error(f"Invalid section name: {cfg.get_name()}")
+
+                logging.info(f"Configuring sensor: {name}")
+
+                sensor_type: str = cfg.get("type", "mqtt")
+                sensor_class: Optional[
+                    Type[BaseSensor]
+                ] = self.__sensor_types.get(sensor_type.upper(), None)
+                if sensor_class is None:
+                    raise config.error(
+                        f"Unsupported sensor type: {sensor_type}"
+                    )
+
+                self.sensors[name] = sensor_class(name=name, cfg=cfg)
+            except Exception as e:
+                # Ensures that configuration errors are shown to the user
+                self.server.add_warning(
+                    f"Failed to configure sensor [{cfg.get_name()}]\n{e}"
+                )
+                continue
+
+    async def component_init(self) -> None:
+        try:
+            logging.debug("Initializing sensor component")
+            event_loop = self.server.get_event_loop()
+            cur_time = event_loop.get_loop_time()
+            endtime = cur_time + 120.0
+
+            uninitialized_sensors = list(self.sensors.values())
+            while cur_time < endtime:
+                failed_sensors: List[BaseSensor] = []
+                for sensor in uninitialized_sensors:
+                    ret = sensor.initialize()
+                    if ret is not None:
+                        await ret
+                    if sensor.error_state is not None:
+                        failed_sensors.append(sensor)
+                if not failed_sensors:
+                    logging.debug("All sensors have been initialized")
+                    return
+
+                uninitialized_sensors = failed_sensors
+                await asyncio.sleep(2.0)
+                cur_time = event_loop.get_loop_time()
+
+            for sensor in failed_sensors:
+                msg = (
+                    f"Sensor {sensor.config.name} is not available: "
+                    f"{sensor.error_state}"
+                )
+                logging.warning(msg)
+                self.server.add_warning(msg)
+
+        except Exception as e:
+            logging.exception(e)
+
+    async def _handle_sensor_data_request(
+        self, web_request: WebRequest
+    ) -> Dict[str, Dict[str, Any]]:
+        data = {}
+        for sensor in self.sensors.values():
+            data[sensor.config.id] = {
+                "source": sensor.config.source,
+                "name": sensor.config.name,
+                "unit_of_measurement": sensor.config.unit,
+                "accuracy_decimals": sensor.config.accuracy_decimals,
+                "measurements": list(sensor.values),
+            }
+        return data
+
+    def close(self) -> None:
+        for sensor in self.sensors.values():
+            sensor.close()
+
+
+def load_component(config: ConfigHelper) -> Sensors:
+    return Sensors(config)


### PR DESCRIPTION
This feature implements a sensor component that can be used to track/log generic sensors from multiple sources. Each sensor can have properties like unit of measurement, accuracy and a display name that help frontends display the tracked measurements.

Some supported sources could be locally connected I2C, SPI or 1-wire sensors as well as remote sensor providers like MQTT or REST API driven sensor.

Example of the component in use with a ESPHome device connected through MQTT:

```
[sensor.py:component_init()] - Initializing sensor component
[sensor.py:initialize()] - Registered sensor 'Chamber Temperature'
[sensor.py:initialize()] - Registered sensor 'Chamber Humidity'
[sensor.py:initialize()] - Registered sensor 'Power Usage'
[sensor.py:component_init()] - All sensors have been initialized
...
[mqtt.py:__call__()] - MQTT Subscriptions Acknowledged
 Topic: devvm-mjonuschat.sharks-with-lasers.net/moonraker/api/request | Granted QoS 0
 Topic: hank/sensor/chamber_temperature/state | Granted QoS 0
 Topic: hank/sensor/chamber_humidity/state | Granted QoS 0
 Topic: hank/sensor/pzem-004t_v3_power/state | Granted QoS 0
[sensor.py:_on_state_update()] - Context: {'payload': '27.7'}
[sensor.py:_on_state_update()] - Received updated sensor value for Chamber Temperature: 27.7°C
[sensor.py:_on_state_update()] - Context: {'payload': '44.9'}
[sensor.py:_on_state_update()] - Received updated sensor value for Chamber Humidity: 44.9%
[sensor.py:_on_state_update()] - Context: {'payload': '1.60'}
[sensor.py:_on_state_update()] - Received updated sensor value for Power Usage: 1.6W
...
```
Querying the aggregated endpoint to retrieve sensor values:
```
{
  "result": {
    "chamber_temperature": {
      "source": "hank/sensor/chamber_temperature/state",
      "name": "Chamber Temperature",
      "unit_of_measurement": "°C",
      "accuracy_decimals": 1,
      "measurements": [
        0,
        27.7,
        27.7,
        27.7,
        27.7,
        27.7,
        27.7,
        27.7,
        27.7,
        27.7,
        27.7,
        27.7,
        27.7
      ]
    },
    "chamber_humidity": {
      "source": "hank/sensor/chamber_humidity/state",
      "name": "Chamber Humidity",
      "unit_of_measurement": "%",
      "accuracy_decimals": 1,
      "measurements": [
        0,
        44.9,
        44.9,
        44.9,
        44.9,
        44.9,
        44.9,
        44.9,
        44.9,
        44.9,
        44.9,
        44.9,
        44.9
      ]
    },
    "power_usage": {
      "source": "hank/sensor/pzem-004t_v3_power/state",
      "name": "Power Usage",
      "unit_of_measurement": "W",
      "accuracy_decimals": 2,
      "measurements": [
        0,
        1.6,
        1.6,
        1.6,
        1.6,
        1.6,
        1.6,
        1.6,
        1.6,
        1.6,
        1.6,
        1.6,
        1.6
      ]
    }
  }
}
```

Signed-off-by: Morton Jonuschat <mjonuschat+moonraker@gmail.com>