### PR TITLE
proc_stats: expose network packets, errors and drops

### DIFF
--- a/moonraker/components/proc_stats.py
+++ b/moonraker/components/proc_stats.py
@@ -242,7 +242,13 @@ class ProcStats:
                 parsed_stats = stats.strip().split()
                 net_stats[dev_name] = {
                     'rx_bytes': int(parsed_stats[0]),
-                    'tx_bytes': int(parsed_stats[8])
+                    'tx_bytes': int(parsed_stats[8]),
+                    'rx_packets': int(parsed_stats[1]),
+                    'tx_packets': int(parsed_stats[9]),
+                    'rx_errs': int(parsed_stats[2]),
+                    'tx_errs': int(parsed_stats[10]),
+                    'rx_drop': int(parsed_stats[3]),
+                    'tx_drop': int(parsed_stats[11])
                 }
             return net_stats
         except Exception:


### PR DESCRIPTION
This PR exposes additional network stats to the /machine/proc_stats endpoint.
They are helpful for troubleshooting network issues, especially when using a CanBus network. 

```
user@hostname:/opt/moonraker $ curl -s localhost:7125/machine/proc_stats | jq '.result.network.wlan0'
{
  "rx_bytes": 168137592,
  "tx_bytes": 40569317,
  "rx_packets": 177732,
  "tx_packets": 104178,
  "rx_errs": 0,
  "tx_errs": 0,
  "rx_drop": 0,
  "tx_drop": 0,
  "bandwidth": 1630.96
}
user@hostname:/opt/moonraker $ curl -s localhost:7125/machine/proc_stats | jq '.result.network.can0'
{
  "rx_bytes": 2198209,
  "tx_bytes": 3765756,
  "rx_packets": 347331,
  "tx_packets": 565789,
  "rx_errs": 0,
  "tx_errs": 0,
  "rx_drop": 0,
  "tx_drop": 0,
  "bandwidth": 1234.07
}
```

Signed-off-by: Rogerio Goncalves <rogerlz@gmail.com>