### PR TITLE
metadata: strip delimiting quotes in strings

### DIFF
--- a/moonraker/components/file_manager/metadata.py
+++ b/moonraker/components/file_manager/metadata.py
@@ -91,7 +91,7 @@ def _regex_find_int(pattern: str, data: str) -> Optional[int]:
 def _regex_find_string(pattern: str, data: str) -> Optional[str]:
     match = re.search(pattern, data)
     if match:
-        return match.group(1)
+        return match.group(1).strip('"')
     return None
 
 # Slicer parsing implementations


### PR DESCRIPTION
Trim any delimiting quotes from metadata strings.

I know we could just update the regular expressions to do this, but seems easier (and safer!) to just trim the quotes after finding the values.

Here's an example from a Prusa Slicer sliced file showing the problem:

![image](https://user-images.githubusercontent.com/85504/191759498-3adbed22-d8f4-438e-a776-0af089ce39ab.png)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>