### PR TITLE
Suggestion: use term "sudo" instead of "root"

### DIFF
--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -5545,7 +5545,7 @@ when a sudo request has been granted.
         {
             "sudo_requested": true,
             "sudo_messages": [
-                "Root access required to update Moonraker's systemd service."
+                "Sudo password required to update Moonraker's systemd service."
             ]
         }
     ]

--- a/moonraker/assets/welcome.html
+++ b/moonraker/assets/welcome.html
@@ -364,7 +364,7 @@
             <div id="update_modal" class="modal">
                 <div class="modal-card">
                     <h1 id="modal_header_msg">
-                        Moonraker Root Request
+                        Moonraker Sudo Password Request
                     </h1>
                     <div id="modal_body" class="modal-content">
                         <div id="main_form">
@@ -454,7 +454,7 @@
                     pwd_req.onerror = () => {
                         console.log("Error setting password");
                         update_modal(
-                            "Request to set root password failed with " +
+                            "Request to set sudo password failed with " +
                             "a network error."
                         )
                     };

--- a/moonraker/components/machine.py
+++ b/moonraker/components/machine.py
@@ -1399,7 +1399,7 @@ class InstallValidator:
         if not source_dir.is_dir():
             raise ValidationError(
                 f"Failed to link subfolder '{folder_name}' to source path "
-                f"'{source_dir}'.  The requusted path is not a valid directory."
+                f"'{source_dir}'.  The requested path is not a valid directory."
             )
         subfolder = self.data_path.joinpath(folder_name)
         if subfolder.is_symlink():
@@ -1547,7 +1547,7 @@ class InstallValidator:
         machine: Machine = self.server.lookup_component("machine")
         machine.register_sudo_request(
             self._on_password_received,
-            "Root access required to update Moonraker's systemd service."
+            "Sudo password required to update Moonraker's systemd service."
         )
         if not machine.public_ip:
             async def wrapper(pub_ip):


### PR DESCRIPTION
![22-10-15_09-48-15_brave](https://user-images.githubusercontent.com/31533186/195980138-52644032-c2c8-473a-82b3-e6077519de72.png)

Currently Moonraker asks for "root request" and the "root password".
That could be misleading in a way, that users might think moonraker wants access to the root user account (UID 0).

This PR rephrases the terms to "Sudo password" and "sudo" respectively. It also fixes another typo.
It might be a bit nitpicking and i am fine with this PR getting declined. 


Signed-off-by: Dominik Willner <th33xitus@gmail.com>