### PR TITLE
update_manager: fix error message displaying the wrong option

### DIFF
--- a/moonraker/components/update_manager/app_deploy.py
+++ b/moonraker/components/update_manager/app_deploy.py
@@ -103,7 +103,7 @@ class AppDeploy(BaseDeploy):
             if svc not in svc_choices:
                 raw = " ".join(services)
                 self.server.add_warning(
-                    f"[{config.get_name()}]: Option 'restart_action: {raw}' "
+                    f"[{config.get_name()}]: Option 'managed_services: {raw}' "
                     f"contains an invalid value '{svc}'.  All values must be "
                     f"one of the following choices: {svc_choices}"
                 )


### PR DESCRIPTION
an user on discord reported this error:

```
[update_manager client KlipperScreen]: Option 'restart_action: KlipperScreen' contains an invalid value 'KlipperScreen'. All values must be one of the following choices: ['client KlipperScreen', 'klipper', 'moonraker']
```

> My machine does not have a restart_action in Moonraker config 

so i concluded that `restart_action` must have been the name during development and the error warning was not updated.