### PR TITLE
Add support for USB hub power control via uhubctl

### DIFF
--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -1424,8 +1424,13 @@ class UhubctlDevice(PowerDevice):
         ports = {}
 
         for line in result:
-            if line[:6] == "Current":
+            first_word = line.split(" ")[0]
+
+            if first_word in [ "Current", "New" ]:
                 hub = line.split(" ")[4]
+                continue
+
+            if first_word == "Sent":
                 continue
 
             port, info = tuple(line.strip()[4:].split(": "))

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -1433,7 +1433,7 @@ class UhubctlDevice(PowerDevice):
             if first_word == "Sent":
                 continue
 
-            port, info = tuple(line.strip()[4:].split(": "))
+            port, info = tuple(line.strip()[5:].split(": "))
             ports[hub + "." + port] = info.split(" ")
 
         id = self.hub + "." + self.port

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -1459,8 +1459,6 @@ class UhubctlDevice(PowerDevice):
         else:
             self.state = "error"
 
-        logging.info(f"uhubctl device {self.name} entered {self.state} state")
-
         return
 
     async def set_power(self, state: str) -> None:

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -1427,7 +1427,7 @@ class UhubctlDevice(PowerDevice):
                 hub = line.split(" ")[4]
                 continue
 
-            port, info = tuple(line.strip().[4:].split(": "))
+            port, info = tuple(line.strip()[4:].split(": "))
             ports[hub + "." + port] = info.split(" ")
 
         id = self.hub + "." + self.port

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -1398,7 +1398,8 @@ class UhubctlDevice(PowerDevice):
         proc = subprocess.Popen(
             [ self.bin_path ] + args,
             stdout = subprocess.PIPE,
-            stderr = subprocess.PIPE
+            stderr = subprocess.PIPE,
+            text = True
         )
 
         try:

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -1452,14 +1452,14 @@ class UhubctlDevice(PowerDevice):
 
         if not result:
             self.state = "error"
-            return
-
-        if result[1] == "power":
+        elif result[1] == "power":
             self.state = "on"
         elif result[1] == "off":
             self.state = "off"
         else:
             self.state = "error"
+
+        logging.info(f"uhubctl device {self.name} entered {self.state} state")
 
         return
 

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -23,7 +23,8 @@ from typing import (
     Dict,
     Coroutine,
     Union,
-    cast
+    cast,
+    Tuple
 )
 
 if TYPE_CHECKING:
@@ -1406,7 +1407,7 @@ class UhubctlDevice(PowerDevice):
         try:
             out, err = proc.communicate(timeout=5)
 
-        except TimeoutExpired:
+        except subprocess.TimeoutExpired:
             proc.kill()
             out, err = proc.communicate()
 
@@ -1420,7 +1421,7 @@ class UhubctlDevice(PowerDevice):
 
         if err:
             logging.exception("uhubctl returned error: " + "\n".join(err))
-            return
+            return []
 
         ports = {}
 
@@ -1442,7 +1443,7 @@ class UhubctlDevice(PowerDevice):
         if id in ports:
             return ports[id]
 
-        return
+        return []
 
     async def init_state(self) -> None:
         await self.set_power("on" if self.initial_state else "off")

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -1444,7 +1444,7 @@ class UhubctlDevice(PowerDevice):
         if not result:
             result = self._uhubctl()
 
-        if not result
+        if not result:
             self.state = "error"
             return
 

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -1393,6 +1393,7 @@ class UhubctlDevice(PowerDevice):
 
         self.bin_path = config.get("bin_path", "uhubctl")
         self.hub, self.port = tuple(config.get("port").split("."))
+        self.initial_state = config.getboolean("initial_state", True)
 
     def _uhubctl(self, args: List[str] = []) -> Tuple:
         proc = subprocess.Popen(
@@ -1444,6 +1445,7 @@ class UhubctlDevice(PowerDevice):
         return
 
     async def init_state(self) -> None:
+        await self.set_power("on" if self.initial_state else "off")
         return
 
     async def refresh_status(self, result = False) -> None:

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -1392,7 +1392,7 @@ class UhubctlDevice(PowerDevice):
         super().__init__(config)
 
         self.bin_path = config.get("bin_path", "uhubctl")
-        self.hub, self.port = tuple(config.getint("port").split("."))
+        self.hub, self.port = tuple(config.get("port").split("."))
 
     def _uhubctl(self, args: List[str] = []) -> Tuple:
         proc = subprocess.Popen(

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -1411,7 +1411,7 @@ class UhubctlDevice(PowerDevice):
 
         return (out.strip().splitlines(), err.strip().splitlines())
 
-    def _port_status(self, toggle: str) -> List[str]:
+    def _port_status(self, toggle: str = "") -> List[str]:
         result, err = self._uhubctl(
             [ "-l", self.hub, "-p", self.port ] +
             ([ "-a", toggle ] if toggle else [])
@@ -1448,7 +1448,7 @@ class UhubctlDevice(PowerDevice):
 
     async def refresh_status(self, result = False) -> None:
         if not result:
-            result = self._uhubctl()
+            result = self._port_status()
 
         if not result:
             self.state = "error"

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -1417,7 +1417,7 @@ class UhubctlDevice(PowerDevice):
         )
 
         if err:
-            logging.exception("uhubctl returned error: " + err.join("\n"))
+            logging.exception("uhubctl returned error: " + "\n".join(err))
             return
 
         ports = {}

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -1457,7 +1457,7 @@ class UhubctlDevice(PowerDevice):
 
         return
 
-    async def set_power(self, state str) -> None:
+    async def set_power(self, state: str) -> None:
         self.refresh_status(self._port_status(state))
         return
 

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -1464,7 +1464,7 @@ class UhubctlDevice(PowerDevice):
         return
 
     async def set_power(self, state: str) -> None:
-        self.refresh_status(self._port_status(state))
+        await self.refresh_status(self._port_status(state))
         return
 
 

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -1392,13 +1392,12 @@ class UhubctlDevice(PowerDevice):
     def __init__(self, config: ConfigHelper) -> None:
         super().__init__(config)
 
-        self.bin_path = config.get("bin_path", "uhubctl")
         self.hub, self.port = tuple(config.get("port").split("."))
         self.initial_state = config.getboolean("initial_state", True)
 
     def _uhubctl(self, args: List[str] = []) -> Tuple:
         proc = subprocess.Popen(
-            [self.bin_path] + args,
+            ["uhubctl"] + args,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -1397,14 +1397,14 @@ class UhubctlDevice(PowerDevice):
 
     def _uhubctl(self, args: List[str] = []) -> Tuple:
         proc = subprocess.Popen(
-            [ self.bin_path ] + args,
-            stdout = subprocess.PIPE,
-            stderr = subprocess.PIPE,
-            text = True
+            [self.bin_path] + args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True
         )
 
         try:
-            out, err = proc.communicate(timeout = 5)
+            out, err = proc.communicate(timeout=5)
 
         except TimeoutExpired:
             proc.kill()
@@ -1414,8 +1414,8 @@ class UhubctlDevice(PowerDevice):
 
     def _port_status(self, toggle: str = "") -> List[str]:
         result, err = self._uhubctl(
-            [ "-l", self.hub, "-p", self.port ] +
-            ([ "-a", toggle ] if toggle else [])
+            ["-l", self.hub, "-p", self.port] +
+            (["-a", toggle] if toggle else [])
         )
 
         if err:
@@ -1427,7 +1427,7 @@ class UhubctlDevice(PowerDevice):
         for line in result:
             first_word = line.split(" ")[0]
 
-            if first_word in [ "Current", "New" ]:
+            if first_word in ["Current", "New"]:
                 hub = line.split(" ")[4]
                 continue
 
@@ -1448,7 +1448,7 @@ class UhubctlDevice(PowerDevice):
         await self.set_power("on" if self.initial_state else "off")
         return
 
-    async def refresh_status(self, result = False) -> None:
+    async def refresh_status(self, result=False) -> None:
         if not result:
             result = self._port_status()
 

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -1432,7 +1432,7 @@ class UhubctlDevice(PowerDevice):
 
         id = self.hub + "." + self.port
 
-        if id in ports
+        if id in ports:
             return ports[id]
 
         return


### PR DESCRIPTION
This adds support for toggling power to certain USB hubs/ports on or off via the command line tool [uhubctl](https://github.com/mvp/uhubctl) (available via apt on Raspbian). This is useful to completely shut down MCUs, LCDs, and other peripherals that are powered over USB.

On my RPi 3 + RAMPS 1.4 printer setup, the following config lets me turn off the entire printer plus its webcam (port 2 controls power to all 4 ports on the RPi):

```ini
[power USB]
type: uhubctl
port: 1-1.2
bound_service: klipper
```

**Disclaimer:** I am not a Python developer, and the entire Klipper ecosystem is new to me as of a few days ago, but I've done my best 😅 Feedback welcome 🙂

Signed-off-by: Jim C K Flaten <jckf@jckf.no>