### PR TITLE
ldap: Add option to use a customer LDAP query for looking up the user logging in

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -381,7 +381,16 @@ group_dn: CN=moonraker,OU=Groups,DC=ldap,DC=local
 #   authentication.  This option accepts Jinja2 Templates, see the [secrets]
 #   section for details. The default is no group requirement.
 is_active_directory: True
-#   Enables support for Microsoft Active Directory.  The default is False.
+#   Enables support for Microsoft Active Directory. This option changes the
+#   field used to lookup a user by username to sAMAccountName.
+#   The default is False.
+user_filter: (&(objectClass=user)(cn=USERNAME))
+#   Allows filter of users by custom LDAP query. Must contain the USERNAME
+#   token, it will be replaced by the user's username during lookup. Will
+#   override the change done by is_active_directory. This option accepts
+#   Jinja2 Templates, see the [secrets] section for details.
+#   The default is empty, which will change the lookup query depending on
+#   is_active_directory.
 ```
 
 ### `[octoprint_compat]`


### PR DESCRIPTION
This allows for more advanced integration of LDAP databases that are not covered by the default behaviour of is_active_directory.

Signed-off-by: Nick Douma <n.douma@nekoconeko.nl>