### PR TITLE
file_manager: disallow drilling down protected folders

### DIFF
--- a/moonraker/components/file_manager/file_manager.py
+++ b/moonraker/components/file_manager/file_manager.py
@@ -491,6 +491,7 @@ class FileManager:
         if not os.path.isdir(path):
             raise self.server.error(
                 f"Directory does not exist ({path})")
+        self.check_reserved_path(path, False)
         flist: Dict[str, Any] = {'dirs': [], 'files': []}
         for fname in os.listdir(path):
             full_path = os.path.join(path, fname)


### PR DESCRIPTION
The /server/files/directory endpoint allows enumerating all files even in reserved folders marked as not readable because only accessibility of the folder on the filesystem is checked.

I created a small extra component to keep Mainsail from drilling down my .git subfolders in the klipper_config and other folders where it isn't supposed to stick its nose in, by adding those folders as reserved paths, but even then Mainsail would recursively fetch info on each and every file in those folders (see [this Mainsail issue](https://github.com/mainsail-crew/mainsail/issues/1141)).

I think Moonraker allowing this access is a bug and hope that this PR is accepted to address this (as far as my limited knowledge on the ins and outs of Moonraker allow me to propose). 