### PR TITLE
scripts: update streaming-form-data dependency

### DIFF
--- a/scripts/moonraker-requirements.txt
+++ b/scripts/moonraker-requirements.txt
@@ -4,7 +4,7 @@ pyserial==3.4
 pyserial-asyncio==0.6
 pillow==9.0.1
 lmdb==1.2.1
-streaming-form-data==1.8.1
+streaming-form-data==1.11.0
 distro==1.5.0
 inotify-simple==1.3.5
 libnacl==1.7.2


### PR DESCRIPTION
Updates streaming-form-data to Version 1.11.0 to be compatible with Python 3.11.0

Signed-off-by: Markus Küffner <kueffner.markus@gmail.com>