### PR TITLE
machine.py: add support for supervisord service management

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,8 +120,9 @@ with system services such as systemd.
 provider: systemd_dbus
 #   The provider implementation used to collect system service information
 #   and run service actions (ie: start, restart, stop).  This can be "none",
-#   "systemd_dbus", or "systemd_cli".  If the provider is set to "none" service
-#   action APIs will be disabled.  The default is systemd_dbus.
+#   "supervisord", "systemd_dbus", or "systemd_cli".  If the provider is set
+#   to "none" service action APIs will be disabled.
+#   The default is systemd_dbus.
 sudo_password:
 #   The password for the linux user.  When set Moonraker can run linux commands
 #   that require elevated permissions.  This option accepts Jinja2 Templates,
@@ -140,6 +141,10 @@ force_validation:
 #   By default Moonraker will not attempt to revalidate if a previous attempt
 #   at validation successfully completed. Setting this value to True will force
 #   Moonraker to perform validation.  The default is False.
+supervisord_config_path:
+#   Path to the superrvisord config file. In case for multi supervisord instance
+#   running on single machine, the default '/var/run/supervisord.sock' is occupied
+#   by other services.
 ```
 
 !!! Note

--- a/moonraker/components/machine.py
+++ b/moonraker/components/machine.py
@@ -1236,8 +1236,8 @@ class SuperisordProvider(BaseProvider):
             resp = await self.svc_cmd.run_with_response(
                 log_complete=False, timeout=6.
             )
-            resp = resp.strip().split("\n")  # drop lengend
-            for svc, state in zip(svcs, resp):
+            resp_l = resp.strip().split("\n")  # drop lengend
+            for svc, state in zip(svcs, resp_l):
                 sub_state = state.split()[1].lower()
                 new_state: Dict[str, str] = {
                     'active_state': "active",

--- a/moonraker/components/machine.py
+++ b/moonraker/components/machine.py
@@ -1160,11 +1160,11 @@ class SystemdDbusProvider(BaseProvider):
 # since in container, all command is launched by normal user,
 # sudo_cmd is not needed.
 class SuperisordProvider(BaseProvider):
+    def __init__(self, config: ConfigHelper) -> None:
+        super().__init__(config)
+        self.spv_conf: str = config.get("supervisord_config_path", "")
+
     async def initialize(self) -> None:
-        self.spv_conf = self.server.config.get(
-            "supervisord_config_path", None
-        )
-        self.spv_conf = f'-c {self.spv_conf} ' if self.spv_conf else ' '
         for svc in ("klipper", "moonraker"):
             self.available_services[svc] = {
                 'active_state': "none",
@@ -1179,14 +1179,14 @@ class SuperisordProvider(BaseProvider):
         pstats.register_stat_callback(self._update_service_status)
 
     async def shutdown(self) -> None:
-        self.server.add_warning(
+        raise self.server.error(
             "[machine]: Supervisord manager can not process SHUTDOWN."
             "Please try KILL container or stop Supervisord via ssh terminal."
         )
         return
 
     async def reboot(self) -> None:
-        self.server.add_warning(
+        raise self.server.error(
             "[machine]: Supervisord manager can not process REBOOT."
             "Please try KILL container or stop Supervisord via ssh terminal."
         )

--- a/moonraker/components/machine.py
+++ b/moonraker/components/machine.py
@@ -1161,7 +1161,7 @@ class SystemdDbusProvider(BaseProvider):
 # sudo_cmd is not needed.
 class SuperisordProvider(BaseProvider):
     async def initialize(self) -> None:
-        self.spv_conf=self.server.config.get(
+        self.spv_conf = self.server.config.get(
             "supervisord_config_path", None
         )
         self.spv_conf = f'-c {self.spv_conf} ' if self.spv_conf else ' '
@@ -1198,9 +1198,9 @@ class SuperisordProvider(BaseProvider):
         # slow reaction for supervisord, timeout set to 6.0
         await self._exec_command(
             f"supervisorctl {self.spv_conf}"
-            f"{action} {service_name}", 
+            f"{action} {service_name}",
             timeout=6.
-            )
+        )
 
     async def check_virt_status(self) -> Dict[str, Any]:
         virt_id = virt_type = "none"


### PR DESCRIPTION
Signed-off-by: mirokymac <toufubomb@gmail.com>

Add supervisord to the service provider. 

As supervisord is used as the service manager in containers, this commit is looking forward to populating the service manager of klipper-moonraker container.