### PR TITLE
machine: use virtualization.virt_identifier property

### DIFF
--- a/moonraker/components/machine.py
+++ b/moonraker/components/machine.py
@@ -232,7 +232,8 @@ class Machine:
     async def _handle_machine_request(self, web_request: WebRequest) -> str:
         ep = web_request.get_endpoint()
         if self.inside_container:
-            virt_id = self.system_info['virtualization'].get('virt_id', "none")
+            virt_id = self.system_info['virtualization'].get(
+                'virt_identifier', "none")
             raise self.server.error(
                 f"Cannot {ep.split('/')[-1]} from within a "
                 f"{virt_id} container")


### PR DESCRIPTION
I believe this this get should use `virt_identifier`, not `virt_id`.

Before:

![image](https://user-images.githubusercontent.com/85504/203283642-04331723-2391-4f59-ba81-3edb73d9e7ca.png)

After:

![image](https://user-images.githubusercontent.com/85504/203283504-1640ff3c-3827-4a7f-be32-345b1f960c34.png)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>