### PR TITLE
SimplyPrint docs update

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1974,14 +1974,9 @@ gcode:
 ```
 
 ### `[simplyprint]`
-
-!!! Note
-    Currently the SimplyPrint service is only available for developers
-    and testers.  When the service is available for end users this note
-    will be removed.
-
 Enables support for print monitoring through
-[SimplyPrint](https://simplyprint.io).
+[SimplyPrint](https://simplyprint.io),
+publicly launched Moonraker integration Nov 21st 2022.
 
 ```ini
 # moonraker.conf
@@ -2040,9 +2035,12 @@ ambient_sensor:
     - Current print time elapse
     - Estimated ambient temperature
     - Webcam configuration (if available)
-    - Webcam images.  These images are also sent to `printpal.io`
+    - Webcam images
     - Power device state (if configured)
     - Filament sensor state (if configured)
+
+    More on how your data is used in the SimplyPrint privacy policy here; 
+    [https://simplyprint.io/legal/privacy](https://simplyprint.io/legal/privacy)
 
 ## Include directives
 


### PR DESCRIPTION
Removed the "only for testers and developers" note and inserted link to privacy policy