### PR TITLE
mqtt: add option to publish states to individual mqtt topics

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1486,8 +1486,7 @@ status_objects:
 #   A newline separated list of Klipper objects whose state will be
 #   published.  There are two different ways to publish the states - you
 #   can use either or both depending on your need.  See the 
-#   "publish_combined_status" and "publish_split_status" options for
-#   details.
+#   "publish_split_status" options for details.
 #
 #   For example, this option could be set as follows:
 #
@@ -1509,12 +1508,14 @@ status_objects:
 #
 #   If not configured then no objects will be tracked and published to
 #   the klipper/status topic.
-publish_combined_status: True
-#   Defaults to True. All Klipper object state updates will be published to
-#   a single mqtt state with the following topic:
-#     {instance_name}/klipper/status
 publish_split_status: False
-#   Defaults to False. All Klipper object state updates will be published to
+#   Configures how to publish status updates to MQTT.  
+#
+#   When set to False (default), all Klipper object state updates will be
+#   published to a single mqtt state with the following topic:
+#     {instance_name}/klipper/status
+#
+#   When set to True, all Klipper object state updates will be published to
 #   separate mqtt topics derived from the object and item in the following
 #   format:
 #     {instance_name}/klipper/state/{objectname}/{statename}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1484,8 +1484,11 @@ instance_name:
 #   The default is the machine's hostname.
 status_objects:
 #   A newline separated list of Klipper objects whose state will be
-#   published in the payload of the following topic:
-#      {instance_name}/klipper/status
+#   published.  There are two different ways to publish the states - you
+#   can use either or both depending on your need.  See the 
+#   "publish_combined_status" and "publish_split_status" options for
+#   details.
+#
 #   For example, this option could be set as follows:
 #
 #     status_objects:
@@ -1506,6 +1509,21 @@ status_objects:
 #
 #   If not configured then no objects will be tracked and published to
 #   the klipper/status topic.
+publish_combined_status: True
+#   Defaults to True. All Klipper object state updates will be published to
+#   a single mqtt state with the following topic:
+#     {instance_name}/klipper/status
+publish_split_status: False
+#   Defaults to False. All Klipper object state updates will be published to
+#   separate mqtt topics derived from the object and item in the following
+#   format:
+#     {instance_name}/klipper/state/{objectname}/{statename}
+#
+#   The actual value of the state is published as "value" to the topic above.
+#   For example, if the heater_bed temperature was 24.0, this is the payload:
+#     {"eventtime": {timestamp}, "value": 24.0}
+#   It would be published to this topic:
+#     {instance_name}/klipper/state/heater_bed/temperature
 default_qos: 0
 #   The default QOS level used when publishing or subscribing to topics.
 #   Must be an integer value from 0 to 2.  The default is 0.

--- a/moonraker/components/mqtt.py
+++ b/moonraker/components/mqtt.py
@@ -280,6 +280,8 @@ class MQTTClient(APITransport, Subscribable):
             raise config.error(
                 "Option 'default_qos' in section [mqtt] must be "
                 "between 0 and 2")
+        self.publish_split_status = config.getboolean("publish_split_status", False)
+        self.publish_combined_status = config.getboolean("publish_combined_status", True)
         self.client = ExtPahoClient(protocol=self.protocol)
         self.client.on_connect = self._on_connect
         self.client.on_message = self._on_message
@@ -308,6 +310,7 @@ class MQTTClient(APITransport, Subscribable):
         self.api_request_topic = f"{self.instance_name}/moonraker/api/request"
         self.api_resp_topic = f"{self.instance_name}/moonraker/api/response"
         self.klipper_status_topic = f"{self.instance_name}/klipper/status"
+        self.klipper_state_prefix = f"{self.instance_name}/klipper/state"
         self.moonraker_status_topic = f"{self.instance_name}/moonraker/status"
         status_cfg: Dict[str, Any] = config.getdict("status_objects", {},
                                                     allow_empty_fields=True)
@@ -726,8 +729,15 @@ class MQTTClient(APITransport, Subscribable):
                     ) -> None:
         if not status or not self.is_connected():
             return
-        payload = {'eventtime': eventtime, 'status': status}
-        self.publish_topic(self.klipper_status_topic, payload)
+        if self.publish_combined_status:
+            payload = {'eventtime': eventtime, 'status': status}
+            self.publish_topic(self.klipper_status_topic, payload)
+        if self.publish_split_status:
+            for objkey in status:
+                objval = status[objkey]
+                for statekey in objval:
+                    payload = {'eventtime': eventtime, 'value': objval[statekey]}
+                    self.publish_topic(f"{self.klipper_state_prefix}/{objkey}/{statekey}", payload)
 
     def get_instance_name(self) -> str:
         return self.instance_name

--- a/moonraker/components/mqtt.py
+++ b/moonraker/components/mqtt.py
@@ -742,7 +742,7 @@ class MQTTClient(APITransport, Subscribable):
                                'value': objval[statekey]}
                     self.publish_topic(
                         f"{self.klipper_state_prefix}/{objkey}/{statekey}",
-                        payload)
+                        payload, retain=True)
 
     def get_instance_name(self) -> str:
         return self.instance_name

--- a/moonraker/components/mqtt.py
+++ b/moonraker/components/mqtt.py
@@ -282,8 +282,6 @@ class MQTTClient(APITransport, Subscribable):
                 "between 0 and 2")
         self.publish_split_status = \
             config.getboolean("publish_split_status", False)
-        self.publish_combined_status = \
-            config.getboolean("publish_combined_status", True)
         self.client = ExtPahoClient(protocol=self.protocol)
         self.client.on_connect = self._on_connect
         self.client.on_message = self._on_message
@@ -731,9 +729,6 @@ class MQTTClient(APITransport, Subscribable):
                     ) -> None:
         if not status or not self.is_connected():
             return
-        if self.publish_combined_status:
-            payload = {'eventtime': eventtime, 'status': status}
-            self.publish_topic(self.klipper_status_topic, payload)
         if self.publish_split_status:
             for objkey in status:
                 objval = status[objkey]
@@ -743,6 +738,10 @@ class MQTTClient(APITransport, Subscribable):
                     self.publish_topic(
                         f"{self.klipper_state_prefix}/{objkey}/{statekey}",
                         payload, retain=True)
+        else:
+            payload = {'eventtime': eventtime, 'status': status}
+            self.publish_topic(self.klipper_status_topic, payload)
+
 
     def get_instance_name(self) -> str:
         return self.instance_name

--- a/moonraker/components/mqtt.py
+++ b/moonraker/components/mqtt.py
@@ -280,8 +280,10 @@ class MQTTClient(APITransport, Subscribable):
             raise config.error(
                 "Option 'default_qos' in section [mqtt] must be "
                 "between 0 and 2")
-        self.publish_split_status = config.getboolean("publish_split_status", False)
-        self.publish_combined_status = config.getboolean("publish_combined_status", True)
+        self.publish_split_status = \
+            config.getboolean("publish_split_status", False)
+        self.publish_combined_status = \
+            config.getboolean("publish_combined_status", True)
         self.client = ExtPahoClient(protocol=self.protocol)
         self.client.on_connect = self._on_connect
         self.client.on_message = self._on_message
@@ -736,8 +738,11 @@ class MQTTClient(APITransport, Subscribable):
             for objkey in status:
                 objval = status[objkey]
                 for statekey in objval:
-                    payload = {'eventtime': eventtime, 'value': objval[statekey]}
-                    self.publish_topic(f"{self.klipper_state_prefix}/{objkey}/{statekey}", payload)
+                    payload = {'eventtime': eventtime,
+                               'value': objval[statekey]}
+                    self.publish_topic(
+                        f"{self.klipper_state_prefix}/{objkey}/{statekey}",
+                        payload)
 
     def get_instance_name(self) -> str:
         return self.instance_name


### PR DESCRIPTION
This change allows the user to choose the strategy for publishing klipper states to MQTT.  The original strategy where all state updates are published to a common topic is still the default, but can be turned off using the "publish_combined_status" config option.

The newly added strategy is publishing individual state updates to separate mqtt topics.  It is disabled by default, and can be enabled with the "publish_split_status" config option.

Both strategies can be used together.

Example - when the "heater_bed" attribute "temperature" is published:

publish_combined_status (the existing strategy) publishes a payload similar to:
{"eventtime": timestamp, "status":{ "heater_bed": {"temperature": 55.00}}}
to {instance_name}/klipper/status.  There may be other values in the status key.

publish_split_status would publish a payload similar to:
{"eventtime": timestamp, "value": 55.00}
to {instance_name}/klipper/states/heater_bed/temperature

The newly added strategy is useful for interfacing with other systems as the
information is always available as the last published change.  For example, by using this
strategy, the HomeAssistant example should be able to be redone without needing
to poll the REST API (at least for the sensors), and could determine the printer's
online/offline status properly using the {instance_name}/moonraker/status payload.

I will follow up with an updated HomeAssistant example if this is merged.

Signed-off-by: Matt White <m.w.white@gmail.com>