### PR TITLE
job_queue: add "reset" parameter to post endpoint

### DIFF
--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -2665,7 +2665,8 @@ Content-Type: application/json
         "job1.gcode",
         "job2.gcode",
         "subdir/job3.gcode"
-    ]
+    ],
+    "reset": false
 }
 ```
 
@@ -2679,11 +2680,17 @@ JSON-RPC request:
             "job1.gcode",
             "job2.gcode",
             "subdir/job3.gcode"
-        ]
+        ],
+        "reset": false
     },
     "id": 4654
 }
 ```
+
+Parameters:
+
+- `reset`: A boolean value indicating whether Moonraker should clear the
+  existing queued jobs before adding the new jobs. Defaults to `false`.
 
 Returns:
 


### PR DESCRIPTION
Adds a new optional `reset` Boolean parameter to the POST endpoint of the `job_queue` component, allowing to clear the job queue before adding the new filenames.

Resolves #382

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>