### PR TITLE
Adding OctoEverywhere.com as a default allowed service.

### DIFF
--- a/moonraker/components/machine.py
+++ b/moonraker/components/machine.py
@@ -62,7 +62,8 @@ DEFAULT_ALLOWED_SERVICES = [
     "moonraker-telegram-bot",
     "moonraker-obico",
     "sonar",
-    "crowsnest"
+    "crowsnest",
+    "octoeverywhere"
 ]
 CGROUP_PATH = "/proc/1/cgroup"
 SCHED_PATH = "/proc/1/sched"


### PR DESCRIPTION
I'm adding support for Moonraker / Mainsail / Fluidd to OctoEverywhere.com! My plugin is almost ready for early testing; things are looking great.

This simple PR allows the "services" UI to show the OctoEverywhere service. 