### PR TITLE
octoprint_compat: add webcam_rotation parameter

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -305,7 +305,7 @@ stream_url:
 #   same host as Moonraker at port 80.  This parameter must be provided.
 snapshot_url:
 #   The url for the camera snapshot request.  This may be a full url or a
-#   relative path (ie: /webcam?action=stream) if the stream is served on the
+#   relative path (ie: /webcam?action=snapshot) if the stream is served on the
 #   same host as Moonraker at port 80.  This parameter must be provided.
 flip_horizontal: False
 #   A boolean value indicating whether the stream should be flipped
@@ -438,12 +438,19 @@ enable_ufp: True
 #   upload files in .gcode format.  This setting has no impact on other
 #   slicers.  The default is True.
 
+webcam_rotation: 0
+#   Set the webcam rotation in degrees. Valid values are 0, 90, 180, and 270.
+#   The `flip_h`, `flip_v`, and `rotate_90` values below will override whatever 
+#   is set here. The default is 0.
 flip_h: False
-#   Set the webcam horizontal flip.  The default is False.
+#   Flip the webcam image horizontally, overriding `webcam_rotation`.
+#   The default is False.
 flip_v: False
-#   Set the webcam vertical flip.  The default is False.
+#   Flip the webcam image vertically, overriding `webcam_rotation`.
+#   The default is False.
 rotate_90: False
-#   Set the webcam rotation by 90 degrees.  The default is False.
+#   Set the webcam rotation to 90 degrees, overriding `webcam_rotation`.
+#   The default is False.
 stream_url: /webcam/?action=stream
 #   The URL to use for streaming the webcam.  It can be set to an absolute
 #   URL if needed. In order to get the webcam to work in Cura through

--- a/moonraker/components/octoprint_compat.py
+++ b/moonraker/components/octoprint_compat.py
@@ -44,10 +44,16 @@ class OctoPrintCompat:
         self.enable_ufp: bool = config.getboolean('enable_ufp', True)
 
         # Get webcam settings from config
+        rotation = config.getint('webcam_rotation', 0)
+        if rotation not in [0, 90, 180, 270]:
+            self.server.add_warning(
+                f"Invalid value '{rotation}' for option 'webcam_rotation'.  "
+                "Value must be 0, 90, 180, or 270.")
+
         self.webcam: Dict[str, Any] = {
-            'flipH': config.getboolean('flip_h', False),
-            'flipV': config.getboolean('flip_v', False),
-            'rotate90': config.getboolean('rotate_90', False),
+            'flipH': config.getboolean('flip_h', rotation in [180, 270]),
+            'flipV': config.getboolean('flip_v', rotation in [180, 270]),
+            'rotate90': config.getboolean('rotate_90', rotation in [90, 270]),
             'streamUrl': config.get('stream_url', '/webcam/?action=stream'),
             'webcamEnabled': config.getboolean('webcam_enabled', True),
         }


### PR DESCRIPTION
octoprint_compat: add webcam_rotation parameter
docs: document webcam_rotation parameter in configuration.md

Add `webcam_rotation` parameter to the `[octoprint_compat]` settings to allow specifying a rotation in degrees (0, 90, 180, 270) to match the `[webcam]` `rotation` parameter. Since a horizontal flip and a vertical flip combined are equivalent to a 180-degree rotation, this is implemented by setting `flipH` and `flipV` to true for a 180 degree rotation and setting those parameter plus `rotate90` to true for a 270-degree rotation.

Re-submission of #592 in line with the contributing guidelines.

Signed-off-by: Zan Hecht <github@zansstuff.com>