### PR TITLE
notify: bump apprise to v1.2.1

### DIFF
--- a/scripts/moonraker-requirements.txt
+++ b/scripts/moonraker-requirements.txt
@@ -14,5 +14,5 @@ zeroconf==0.39.4
 preprocess-cancellation==0.2.0
 jinja2==3.1.2
 dbus-next==0.2.3
-apprise==1.2.0
+apprise==1.2.1
 ldap3==2.9.1


### PR DESCRIPTION
Bumps the apprise version to v1.2.1

Changelog:  
https://github.com/caronc/apprise/releases/tag/v1.2.1