### PR TITLE
Added ability to control hue device groups in power.py

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1152,6 +1152,11 @@ device_id:
 #   The device id of the light/socket you want to control.
 #   An explanation on how you could get the device id, can be found here:
 #   https://developers.meethue.com/develop/get-started-2/#turning-a-light-on-and-off
+device_type: light
+#   Set to light to control a single hue light, or group to control a hue light gorup. 
+#   If device_type is set to light, the device_id should be the light id, 
+#   and if the device_type is group, the device_id should be the group id.
+#   The default is "light.
 
 ```
 

--- a/moonraker/components/authorization.py
+++ b/moonraker/components/authorization.py
@@ -754,14 +754,9 @@ class Authorization:
         else:
             return None
 
-    def check_logins_maxed(self, ip_addr: Union[str, IPAddr]) -> bool:
+    def check_logins_maxed(self, ip_addr: IPAddr) -> bool:
         if self.max_logins is None:
             return False
-        if isinstance(ip_addr, str):
-            try:
-                ip_addr = ipaddress.ip_address(ip_addr)  # type: ignore
-            except ValueError:
-                return False
         return self.failed_logins.get(ip_addr, 0) >= self.max_logins
 
     def check_authorized(self,

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -1362,7 +1362,7 @@ class HueDevice(HTTPDevice):
     def __init__(self, config: ConfigHelper) -> None:
         super().__init__(config)
         self.device_id = config.get("device_id")
-        self.device_type = config.get("device_type","light")
+        self.device_type = config.get("device_type", "light")
         if self.device_type == "group":
             self.state_key = "action"
             self.on_state = "all_on"
@@ -1373,19 +1373,24 @@ class HueDevice(HTTPDevice):
     async def _send_power_request(self, state: str) -> str:
         new_state = True if state == "on" else False
         url = (
-            f"http://{self.addr}/api/{self.user}/{self.device_type}s/{self.device_id}/{self.state_key}"
+            f"http://{self.addr}/api/{self.user}/{self.device_type}s/"
+            "{self.device_id}/{self.state_key}"
         )
         url = self.client.escape_url(url)
         ret = await self.client.request("PUT", url, body={"on": new_state})
         resp = cast(List[Dict[str, Dict[str, Any]]], ret.json())
+        state_url = (
+            f"/{self.device_type}s/{self.device_id}/{self.state_key}/on"
+        )
         return (
-            "on" if resp[0]["success"][f"/{self.device_type}s/{self.device_id}/{self.state_key}/on"]
+            "on" if resp[0]["success"][state_url]
             else "off"
         )
 
     async def _send_status_request(self) -> str:
         url = (
-            f"http://{self.addr}/api/{self.user}/{self.device_type}s/{self.device_id}"
+            f"http://{self.addr}/api/{self.user}/{self.device_type}s"
+            "/{self.device_id}"
         )
         url = self.client.escape_url(url)
         ret = await self.client.request("GET", url)

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -1370,7 +1370,6 @@ class HueDevice(HTTPDevice):
             self.state_key = "state"
             self.on_state = "on"
 
-
     async def _send_power_request(self, state: str) -> str:
         new_state = True if state == "on" else False
         url = (

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -54,8 +54,7 @@ class PrinterPower:
             "rf": RFDevice,
             "mqtt": MQTTDevice,
             "smartthings": SmartThings,
-            "hue": HueDevice,
-            "hueGroup": HueDeviceGroup
+            "hue": HueDevice
         }
 
         for section in prefix_sections:
@@ -1363,55 +1362,36 @@ class HueDevice(HTTPDevice):
     def __init__(self, config: ConfigHelper) -> None:
         super().__init__(config)
         self.device_id = config.get("device_id")
+        self.device_type = config.get("device_type","light")
+        if self.device_type == "group":
+            self.state_key = "action"
+            self.on_state = "all_on"
+        else:
+            self.state_key = "state"
+            self.on_state = "on"
+
 
     async def _send_power_request(self, state: str) -> str:
         new_state = True if state == "on" else False
         url = (
-            f"http://{self.addr}/api/{self.user}/lights/{self.device_id}/state"
+            f"http://{self.addr}/api/{self.user}/{self.device_type}s/{self.device_id}/{self.state_key}"
         )
         url = self.client.escape_url(url)
         ret = await self.client.request("PUT", url, body={"on": new_state})
         resp = cast(List[Dict[str, Dict[str, Any]]], ret.json())
         return (
-            "on" if resp[0]["success"][f"/lights/{self.device_id}/state/on"]
+            "on" if resp[0]["success"][f"/{self.device_type}s/{self.device_id}/{self.state_key}/on"]
             else "off"
         )
 
     async def _send_status_request(self) -> str:
         url = (
-            f"http://{self.addr}/api/{self.user}/lights/{self.device_id}"
+            f"http://{self.addr}/api/{self.user}/{self.device_type}s/{self.device_id}"
         )
         url = self.client.escape_url(url)
         ret = await self.client.request("GET", url)
         resp = cast(Dict[str, Dict[str, Any]], ret.json())
-        return "on" if resp["state"]["on"] else "off"
-
-class HueDeviceGroup(HTTPDevice):
-
-    def __init__(self, config: ConfigHelper) -> None:
-        super().__init__(config)
-        self.group_id = config.get("group_id")
-
-    async def _send_power_request(self, state: str) -> str:
-        new_state = True if state == "on" else False
-        url = (
-            f"http://{self.addr}/api/{self.user}/groups/{self.group_id}/action"
-        )
-        url = self.client.escape_url(url)
-        ret = await self.client.request("PUT", url, body={"on": new_state})
-        resp = cast(List[Dict[str, Dict[str, Any]]], ret.json())
-        return (
-            "on" if resp[0]["success"][f"/groups/{self.group_id}/action/on"]
-            else "off"
-        )
-    async def _send_status_request(self) -> str:
-        url = (
-            f"http://{self.addr}/api/{self.user}/groups/{self.group_id}"
-        )
-        url = self.client.escape_url(url)
-        ret = await self.client.request("GET", url)
-        resp = cast(Dict[str, Dict[str, Any]], ret.json())
-        return "on" if resp["state"]["all_on"] else "off"
+        return "on" if resp["state"][self.on_state] else "off"
 
 
 # The power component has multiple configuration sections

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -1373,8 +1373,8 @@ class HueDevice(HTTPDevice):
     async def _send_power_request(self, state: str) -> str:
         new_state = True if state == "on" else False
         url = (
-            f"http://{self.addr}/api/{self.user}/{self.device_type}s/"
-            "{self.device_id}/{self.state_key}"
+            f"http://{self.addr}/api/{self.user}/{self.device_type}s"
+            f"/{self.device_id}/{self.state_key}"
         )
         url = self.client.escape_url(url)
         ret = await self.client.request("PUT", url, body={"on": new_state})
@@ -1390,7 +1390,7 @@ class HueDevice(HTTPDevice):
     async def _send_status_request(self) -> str:
         url = (
             f"http://{self.addr}/api/{self.user}/{self.device_type}s"
-            "/{self.device_id}"
+            f"/{self.device_id}"
         )
         url = self.client.escape_url(url)
         ret = await self.client.request("GET", url)

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -54,8 +54,7 @@ class PrinterPower:
             "rf": RFDevice,
             "mqtt": MQTTDevice,
             "smartthings": SmartThings,
-            "hue": HueDevice,
-            "hueGroup": HueDeviceGroup
+            "hue": HueDevice
         }
 
         for section in prefix_sections:
@@ -1393,33 +1392,6 @@ class HueDevice(HTTPDevice):
         ret = await self.client.request("GET", url)
         resp = cast(Dict[str, Dict[str, Any]], ret.json())
         return "on" if resp["state"][self.on_state] else "off"
-
-class HueDeviceGroup(HTTPDevice):
-
-    def __init__(self, config: ConfigHelper) -> None:
-        super().__init__(config)
-        self.group_id = config.get("group_id")
-
-    async def _send_power_request(self, state: str) -> str:
-        new_state = True if state == "on" else False
-        url = (
-            f"http://{self.addr}/api/{self.user}/groups/{self.group_id}/action"
-        )
-        url = self.client.escape_url(url)
-        ret = await self.client.request("PUT", url, body={"on": new_state})
-        resp = cast(List[Dict[str, Dict[str, Any]]], ret.json())
-        return (
-            "on" if resp[0]["success"][f"/groups/{self.group_id}/action/on"]
-            else "off"
-        )
-    async def _send_status_request(self) -> str:
-        url = (
-            f"http://{self.addr}/api/{self.user}/groups/{self.group_id}"
-        )
-        url = self.client.escape_url(url)
-        ret = await self.client.request("GET", url)
-        resp = cast(Dict[str, Dict[str, Any]], ret.json())
-        return "on" if resp["state"]["all_on"] else "off"
 
 
 # The power component has multiple configuration sections

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -54,7 +54,8 @@ class PrinterPower:
             "rf": RFDevice,
             "mqtt": MQTTDevice,
             "smartthings": SmartThings,
-            "hue": HueDevice
+            "hue": HueDevice,
+            "hueGroup": HueDeviceGroup
         }
 
         for section in prefix_sections:
@@ -1384,6 +1385,33 @@ class HueDevice(HTTPDevice):
         ret = await self.client.request("GET", url)
         resp = cast(Dict[str, Dict[str, Any]], ret.json())
         return "on" if resp["state"]["on"] else "off"
+
+class HueDeviceGroup(HTTPDevice):
+
+    def __init__(self, config: ConfigHelper) -> None:
+        super().__init__(config)
+        self.group_id = config.get("group_id")
+
+    async def _send_power_request(self, state: str) -> str:
+        new_state = True if state == "on" else False
+        url = (
+            f"http://{self.addr}/api/{self.user}/groups/{self.group_id}/action"
+        )
+        url = self.client.escape_url(url)
+        ret = await self.client.request("PUT", url, body={"on": new_state})
+        resp = cast(List[Dict[str, Dict[str, Any]]], ret.json())
+        return (
+            "on" if resp[0]["success"][f"/groups/{self.group_id}/action/on"]
+            else "off"
+        )
+    async def _send_status_request(self) -> str:
+        url = (
+            f"http://{self.addr}/api/{self.user}/groups/{self.group_id}"
+        )
+        url = self.client.escape_url(url)
+        ret = await self.client.request("GET", url)
+        resp = cast(Dict[str, Dict[str, Any]], ret.json())
+        return "on" if resp["state"]["all_on"] else "off"
 
 
 # The power component has multiple configuration sections


### PR DESCRIPTION
Added the ability to control entire Hue device power groups in addition to controlling Hue devices individually. This can be advantageous if you have several Hue lights in the area of the printer that you would like to control all together. 