### PR TITLE
use systemctl poweroff instead of halt

### DIFF
--- a/moonraker/components/machine.py
+++ b/moonraker/components/machine.py
@@ -780,7 +780,7 @@ class BaseProvider:
         return await machine.exec_sudo_command(command)
 
     async def shutdown(self) -> None:
-        await self._exec_sudo_command("systemctl halt")
+        await self._exec_sudo_command("systemctl poweroff")
 
     async def reboot(self) -> None:
         await self._exec_sudo_command("systemctl reboot")


### PR DESCRIPTION
"systemctl halt" doesn't shut down power (it halts but remains powered on). "systemctl poweroff" is better suited, as it actually powers the machine off.