### PR TITLE
Fixes Minor Typo

### DIFF
--- a/docs/printer_objects.md
+++ b/docs/printer_objects.md
@@ -47,7 +47,7 @@ The `gcode_move` object reports the current gcode state:
 - `speed_factor`: AKA "feedrate", this is the current speed multiplier
 - `speed`: The current gcode speed in mm/s.
 - `extrude_factor`: AKA "extrusion multiplier".
-- `absolute_coorinates`: true if the machine axes are moved using
+- `absolute_coordinates`: true if the machine axes are moved using
   absolute coordinates, false if using relative coordinates.
 - `absolute_extrude`: true if the extruder is moved using absolute
   coordinates, false if using relative coordinates.


### PR DESCRIPTION
Fixes a minor typo in the `gcode_move` section of `print_objects.md`.

`coorinates` becomes `coordinates`