### PR TITLE
docs: fixes minor typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Moonraker is a Python 3 based web server that exposes APIs with which
 client applications may use to interact with the 3D printing firmware
-[Klipper](https://github.com/KevinOConnor/klipper). Communcation between
+[Klipper](https://github.com/KevinOConnor/klipper). Communication between
 the Klippy host and Moonraker is done over a Unix Domain Socket.  Tornado
 is used to provide Moonraker's server functionality.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -3,7 +3,7 @@
 While Moonraker exists as a service independently from Klipper, it relies
 on Klipper to be useful.  Thus, the tentative plan is to eventually merge
 the Moonraker application into the Klipper repo after Moonraker matures,
-at which point this repo will be archived.  As such, contibuting guidelines
+at which point this repo will be archived.  As such, contributing guidelines
 are near those of Klipper:
 
 #### New Module Contributions

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 Moonraker is a Python 3 based web server that exposes APIs with which
 client applications may use to interact with the 3D printing firmware
-[Klipper](https://github.com/Klipper3d/klipper). Communcation between
+[Klipper](https://github.com/Klipper3d/klipper). Communication between
 the Klippy host and Moonraker is done over a Unix Domain Socket.  Tornado
 is used to provide Moonraker's server functionality.
 
@@ -14,7 +14,7 @@ Client developers may refer to the [Client API](web_api.md)
 documentation.
 
 Backend developers should refer to the
-[contibuting](contributing.md) section for basic contribution
+[contributing](contributing.md) section for basic contribution
 guidelines prior to creating a pull request.  The
 [components](components.md) document provides a brief overview
 of how to create a component and interact with Moonraker's

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ nav:
     - 'User Documentation':
         - Installation: installation.md
         - Configuration : configuration.md
-    - 'Developer Documenation':
+    - 'Developer Documentation':
         - Remote API: web_api.md
         - Printer Objects: printer_objects.md
         - Components: components.md


### PR DESCRIPTION
Fixes a couple of typos on the main page and readme file.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>