### PR TITLE
module: add ratos-configurator to default services

### DIFF
--- a/moonraker/components/machine.py
+++ b/moonraker/components/machine.py
@@ -64,7 +64,8 @@ DEFAULT_ALLOWED_SERVICES = [
     "moonraker-obico",
     "sonar",
     "crowsnest",
-    "octoeverywhere"
+    "octoeverywhere",
+    "ratos-configurator"
 ]
 CGROUP_PATH = "/proc/1/cgroup"
 SCHED_PATH = "/proc/1/sched"


### PR DESCRIPTION
Adds the RatOS configurator to the default service list in machine.py so future installs of moonraker will allow the ratos configurator service to be managed from frontends.