### PR TITLE
metadata: support new g-code slicer - OrcaSlicer

### DIFF
--- a/moonraker/components/file_manager/metadata.py
+++ b/moonraker/components/file_manager/metadata.py
@@ -322,6 +322,7 @@ class PrusaSlicer(BaseSlicer):
         aliases = {
             'PrusaSlicer': r"PrusaSlicer\s(.*)\son",
             'SuperSlicer': r"SuperSlicer\s(.*)\son",
+            'OrcaSlicer': r"OrcaSlicer\s(.*)\son",
             'SliCR-3D': r"SliCR-3D\s(.*)\son",
             'BambuStudio': r"BambuStudio[^ ]*\s(.*)\n",
             'A3dp-Slicer': r"A3dp-Slicer\s(.*)\son",


### PR DESCRIPTION
This PR adds support to extract thumbnails from the g-code files generated by [OrcaSlicer](https://github.com/SoftFever/OrcaSlicer) (previously known as BambuStudio-SoftFever)

 Previous PR #501
