### PR TITLE
components: correct handling of empty string

### DIFF
--- a/moonraker/components/sensor.py
+++ b/moonraker/components/sensor.py
@@ -289,7 +289,7 @@ class Sensors:
         output = {
             key: sensor.get_sensor_measurements()
             for key, sensor in self.sensors.items()
-            if sensor_name is "" or key == sensor_name
+            if not sensor_name or key == sensor_name
         }
 
         return output


### PR DESCRIPTION
Just a minor correction to handling of empty string / variable for `sensor.py` in components.

Signed-off-by: John Unland