### PR TITLE
Added basic integration to the Spoolman filament manager

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog].
 - **metadata**: Added support for OrcaSlicer
 - **zeroconf**: Added support for a configurable mDNS hostname.
 - **zeroconf**: Added support for UPnP/SSDP Discovery.
+- **spoolman**: Added integration to the
+  [Spoolman](https://github.com/Donkie/Spoolman) filament manager.
 
 ### Fixed
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2622,6 +2622,7 @@ Front ends can also utilize this config to provide a built-in management tool.
 
 [spoolman]
 server: http://192.168.0.123:7912
+#   URL to the Spoolman instance. This parameter must be provided.
 ```
 
 ## Include directives

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2578,6 +2578,21 @@ state_response_template:
   {set_result("energy", notification["aenergy"]["by_minute"][0]|float * 0.000001)}
 ```
 
+### `[spoolman]`
+
+Enables integration with the [Spoolman](https://github.com/Donkie/Spoolman)
+filament manager. Moonraker will automatically send filament usage updates to
+the Spoolman database.
+
+Front ends can also utilize this config to provide a built-in management tool.
+
+```ini
+# moonraker.conf
+
+[spoolman]
+server: http://192.168.0.123:7912
+```
+
 ## Include directives
 
 It is possible to include configuration from other files via include

--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -3798,7 +3798,7 @@ JSON-RPC request:
 {
     "jsonrpc": "2.0",
     "method": "server.webcams.get_item",
-    "parmams": {
+    "params": {
         "name": "cam_name"
     },
     "id": 4654
@@ -3862,7 +3862,7 @@ JSON-RPC request:
 {
     "jsonrpc": "2.0",
     "method": "server.webcams.post_item",
-    "parmams": {
+    "params": {
         "name": "cam_name",
         "snapshot_url": "/webcam?action=snapshot",
         "stream_url": "/webcam?action=stream"
@@ -3948,7 +3948,7 @@ JSON-RPC request:
 {
     "jsonrpc": "2.0",
     "method": "server.webcams.delete_item",
-    "parmams": {
+    "params": {
         "name": "cam_name"
     },
     "id": 4654
@@ -3997,7 +3997,7 @@ JSON-RPC request:
 {
     "jsonrpc": "2.0",
     "method": "server.webcams.test",
-    "parmams": {
+    "params": {
         "name": "cam_name"
     },
     "id": 4654

--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -5211,6 +5211,127 @@ An object containing all measurements for every configured sensor:
 }
 ```
 
+### Spoolman APIs
+The following APIs are available to interact with the Spoolman integration:
+
+#### Set active spool
+Set the ID of the spool that Moonraker should report usage to Spoolman of.
+
+HTTP request:
+```http
+POST /spoolman/spool_id
+Content-Type: application/json
+
+{
+    "spool_id": 1
+}
+```
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "spoolman.post_spool_id",
+    "params": {
+        "spool_id": 1
+    },
+    "id": 4654
+}
+```
+
+Returns:
+
+The id of the now active spool:
+
+```json
+{
+    "spool_id": 1
+}
+```
+
+!!! note
+    Send an empty object, `{}`, to un-set the spool ID and stop any reporting.
+    The response `spool_id` will then be set to *null*
+
+#### Get active spool
+Retrieve the ID of the spool to which Moonraker reports usage for Spoolman.
+
+HTTP request:
+```http
+GET /spoolman/spool_id
+```
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "spoolman.get_spool_id",
+    "id": 4654
+}
+```
+
+Returns:
+
+The id of the active spool:
+
+```json
+{
+    "spool_id": 1
+}
+```
+
+!!! note
+    The `spool_id` can be *null* if there is no active spool.
+
+#### Proxy
+
+Moonraker supplies a proxy endpoint where you have full access to the Spoolman
+API without having to configure the endpoint yourself.
+
+See Spoolman's [OpenAPI Description](https://donkie.github.io/Spoolman/) for
+detailed information about it's API.
+
+HTTP request:
+```http
+POST /spoolman/proxy
+Content-Type: application/json
+
+{
+    "request_method": "POST",
+    "path": "/v1/spool",
+    "query": "a=1&b=4",
+    "body": {
+        "filament_id": 1
+    }
+}
+```
+
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "spoolman.post_proxy",
+    "params": {
+        "request_method": "POST",
+        "path": "/v1/spool",
+        "query": "a=1&b=4",
+        "body": {
+            "filament_id": 1
+        }
+    },
+    "id": 4654
+}
+```
+
+The following parameters are available. `request_method` and `path` are required, the rest are optional.
+
+- `request_method`: The HTTP request method, e.g. `GET`, `POST`, `DELETE`, etc.
+- `path`: The endpoint, including API version, e.g. `/v1/filament`.
+- `query`: The query part of the URL, e.g. `filament_material=PLA&vendor_name=Prima`.
+- `body`: The request body for the request.
+
+Returns:
+
+The json response from the Spoolman server.
+
 ### OctoPrint API emulation
 Partial support of OctoPrint API is implemented with the purpose of
 allowing uploading of sliced prints to a moonraker instance.
@@ -6622,6 +6743,25 @@ webcam is added, removed, or updated.
 
 The `webcams` field contans an array of objects like those returned by the
 [list webcams](#list-webcams) API.
+
+#### Spoolman active spool ID changed
+
+Moonraker will emit the `notify_active_spool_set` event when the active spool
+ID for the Spoolman integration has been changed.
+
+See the [Spoolman API](#spoolman-apis) for more information.
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "notify_active_spool_set",
+    "params": [
+        {
+            "spool_id": 1
+        }
+    ]
+}
+```
 
 #### Agent Events
 Moonraker will emit the `notify_agent_event` notification when it

--- a/moonraker/components/spoolman.py
+++ b/moonraker/components/spoolman.py
@@ -173,6 +173,8 @@ class SpoolManager:
 
         if query is not None:
             query = f"?{query}"
+        else:
+            query = ""
 
         full_url = f"{self.spoolman_url}{path}{query}"
 

--- a/moonraker/components/spoolman.py
+++ b/moonraker/components/spoolman.py
@@ -8,20 +8,23 @@ from __future__ import annotations
 import asyncio
 import datetime
 import logging
-from typing import TYPE_CHECKING, Dict, Any, List
+from typing import TYPE_CHECKING, Dict, Any
 from urllib.parse import urlencode
 
 if TYPE_CHECKING:
     from typing import Optional
     from moonraker.websockets import WebRequest
     from moonraker.components.http_client import HttpClient
-    from moonraker.components.database import MoonrakerDatabase, NamespaceWrapper
+    from moonraker.components.database import (
+        MoonrakerDatabase,
+        NamespaceWrapper,
+    )
     from .klippy_apis import KlippyAPI as APIComp
     from confighelper import ConfigHelper
 
 SPOOL_NAMESPACE = "spoolman"
-MOONRAKER_NAMESPACE = "moonraker"
 ACTIVE_SPOOL_KEY = "spoolman.active_spool_id"
+
 
 class SpoolManager:
     def __init__(self, config: ConfigHelper):
@@ -31,49 +34,66 @@ class SpoolManager:
         self.sync_rate_seconds = config.getint("sync_rate", 5)
         self.last_sync_time = datetime.datetime.now()
         self.extruded_lock = asyncio.Lock()
-        
+
         self.spoolman_url = config.get("server", None)
         if self.spoolman_url is None:
             logging.error("Server config not set for spoolman.")
             return
         self.spoolman_url = f"{self.spoolman_url.rstrip('/')}/api/v1"
 
-        self.http_client: HttpClient = self.server.lookup_component("http_client")
+        self.http_client: HttpClient = self.server.lookup_component(
+            "http_client"
+        )
 
         database: MoonrakerDatabase = self.server.lookup_component("database")
-        database.register_local_namespace("spoolman")
+        database.register_local_namespace(SPOOL_NAMESPACE)
         self.moonraker_db: NamespaceWrapper = database.wrap_namespace(
-            MOONRAKER_NAMESPACE, parse_keys=False)
+            SPOOL_NAMESPACE, parse_keys=False
+        )
 
         self._register_listeners()
         self._register_endpoints()
-        self.klippy_apis: APIComp = self.server.lookup_component('klippy_apis')
+        self.klippy_apis: APIComp = self.server.lookup_component("klippy_apis")
 
     def _register_listeners(self):
-        self.server.register_event_handler('server:klippy_ready',
-                                           self._handle_server_ready)
+        self.server.register_event_handler(
+            "server:klippy_ready", self._handle_server_ready
+        )
 
     def _register_endpoints(self):
         self.server.register_endpoint(
-            r"/spoolman/[\W\w]+$", ['GET', 'POST', 'DELETE', 'PUT', 'PATCH'],
-            self._proxy_spoolman_request)
+            r"/spoolman/set_spool$",
+            ["POST"],
+            self._handle_set_spool,
+        )
+        self.server.register_endpoint(
+            r"/spoolman/[\W\w]+$",
+            ["GET", "POST", "DELETE", "PUT", "PATCH"],
+            self._proxy_spoolman_request,
+        )
 
     async def _handle_server_ready(self):
         self.server.register_event_handler(
-            'server:status_update', self._handle_status_update)
-        sub: Dict[str, Optional[List[str]]] = {'toolhead': ['position']}
-        result = await self.klippy_apis.subscribe_objects(sub)
+            "server:status_update", self._handle_status_update
+        )
+        result = await self.klippy_apis.subscribe_objects(
+            {"toolhead": ["position"]}
+        )
         initial_e_pos = self._eposition_from_status(result)
+
+        logging.info(f"Initial epos: {initial_e_pos}")
 
         if initial_e_pos is not None:
             self.highest_e_pos = initial_e_pos
         else:
-            logging.error("Spool manager unable to subscribe to epos")
-            raise self.server.error('Unable to subscribe to e position')
+            logging.error("Spoolman integration unable to subscribe to epos")
+            raise self.server.error("Unable to subscribe to e position")
 
-    def _eposition_from_status(self, status: Dict[str, Any]) -> Optional[float]:
-        position = status.get('toolhead', {}).get('position', [])
-        return position[3] if len(position) > 0 else None
+    def _eposition_from_status(
+        self, status: Dict[str, Any]
+    ) -> Optional[float]:
+        position = status.get("toolhead", {}).get("position", [])
+        return position[3] if len(position) > 3 else None
 
     async def _handle_status_update(self, status: Dict[str, Any]) -> None:
         epos = self._eposition_from_status(status)
@@ -90,21 +110,31 @@ class SpoolManager:
             logging.debug("Sync period elapsed, tracking usage")
             await self.track_filament_usage()
 
-    async def set_active_spool(self, spool_id: str) -> bool:
+    async def set_active_spool(self, spool_id: Optional[str]) -> bool:
         self.moonraker_db[ACTIVE_SPOOL_KEY] = spool_id
-        await self.server.send_event('spool_manager:active_spool_set',
-                                        {'spool_id': spool_id})
-        logging.info(f'Setting spool active, id: {spool_id}')
+        await self.server.send_event(
+            "spool_manager:active_spool_set", {"spool_id": spool_id}
+        )
+        logging.info(f"Setting spool active, id: {spool_id}")
         return True
-        
-    async def get_active_spool_id(self) -> str:
+
+    async def get_active_spool_id(self) -> Optional[str]:
         return await self.moonraker_db.get(ACTIVE_SPOOL_KEY, None)
-    
+
     async def track_filament_usage(self):
         spool_id = await self.get_active_spool_id()
+        if spool_id is None:
+            logging.debug("No active spool, skipping tracking")
+            return
         async with self.extruded_lock:
             if self.extruded > 0:
                 used_length = self.extruded
+
+                logging.info(
+                    f"Sending spool usage request, "
+                    f"spool_id: {spool_id}, "
+                    f"length: {used_length}, "
+                )
 
                 response = await self.http_client.request(
                     method="PUT",
@@ -117,10 +147,13 @@ class SpoolManager:
 
                 self.extruded = 0
 
-                logging.info(f'Tracking filament usage, '
-                                f'spool_id: {spool_id}, ' +
-                                f'length: {used_length}, ')
-                    
+    async def _handle_set_spool(self, web_request: WebRequest):
+        spool_id = web_request.get("spool_id", None)
+
+        await self.set_active_spool(spool_id)
+
+        return True
+
     async def _proxy_spoolman_request(self, web_request: WebRequest):
         body = None
         query = ""
@@ -133,7 +166,7 @@ class SpoolManager:
         full_url = f"{self.spoolman_url}{endpoint}{query}"
 
         logging.debug(f"Proxying {web_request.action} request to {full_url}")
-        
+
         response = await self.http_client.request(
             method=web_request.action,
             url=full_url,
@@ -142,6 +175,7 @@ class SpoolManager:
         response.raise_for_status()
 
         return response.json()
+
 
 def load_component(config: ConfigHelper) -> SpoolManager:
     return SpoolManager(config)

--- a/moonraker/components/spoolman.py
+++ b/moonraker/components/spoolman.py
@@ -43,9 +43,13 @@ class SpoolManager:
             DB_NAMESPACE, ACTIVE_SPOOL_KEY, None
         )
 
+        self._register_notifications()
         self._register_listeners()
         self._register_endpoints()
         self.klippy_apis: APIComp = self.server.lookup_component("klippy_apis")
+
+    def _register_notifications(self):
+        self.server.register_notification("spoolman:active_spool_set")
 
     def _register_listeners(self):
         self.server.register_event_handler(
@@ -73,7 +77,7 @@ class SpoolManager:
         )
         initial_e_pos = self._eposition_from_status(result)
 
-        logging.info(f"Initial epos: {initial_e_pos}")
+        logging.debug(f"Initial epos: {initial_e_pos}")
 
         if initial_e_pos is not None:
             self.highest_e_pos = initial_e_pos

--- a/moonraker/components/spoolman.py
+++ b/moonraker/components/spoolman.py
@@ -145,9 +145,10 @@ class SpoolManager:
                 self.extruded = 0
 
     async def _handle_spool_id_request(self, web_request: WebRequest):
-        if web_request.method == "GET":
+        action = web_request.get_action()
+        if action == "GET":
             return {"spool_id": self.get_active_spool()}
-        elif web_request.method == "POST":
+        elif action == "POST":
             spool_id = web_request.get_int("spool_id", None)
             await self.set_active_spool(spool_id)
             return True

--- a/moonraker/components/spoolman.py
+++ b/moonraker/components/spoolman.py
@@ -115,7 +115,7 @@ class SpoolManager:
         self.spool_id = spool_id
         self.database.insert_item(DB_NAMESPACE, ACTIVE_SPOOL_KEY, spool_id)
         self.server.send_event(
-            "spool_manager:active_spool_set", {"spool_id": spool_id}
+            "spoolman:active_spool_set", {"spool_id": spool_id}
         )
         logging.info(f"Setting active spool to: {spool_id}")
 

--- a/moonraker/components/spoolman.py
+++ b/moonraker/components/spoolman.py
@@ -136,7 +136,7 @@ class SpoolManager:
 
                 response = await self.http_client.request(
                     method="PUT",
-                    url=f"{self.spoolman_url}/spool/{spool_id}/use",
+                    url=f"{self.spoolman_url}/v1/spool/{spool_id}/use",
                     body={
                         "use_length": used_length,
                     },

--- a/moonraker/components/spoolman.py
+++ b/moonraker/components/spoolman.py
@@ -24,16 +24,17 @@ ACTIVE_SPOOL_KEY = "spoolman.spool_id"
 
 
 class SpoolManager:
+    spool_id: Optional[int] = None
+    highest_e_pos: float = 0.0
+    extruded: float = 0.0
+
     def __init__(self, config: ConfigHelper):
         self.server = config.get_server()
 
-        self.highest_e_pos = 0.0
-        self.extruded = 0.0
         self.sync_rate_seconds = config.getint("sync_rate", default=5, above=1)
         self.last_sync_time = datetime.datetime.now()
         self.extruded_lock = asyncio.Lock()
         self.spoolman_url = f"{config.get('server').rstrip('/')}/api"
-        self.spool_id: Optional[int] = None
 
         self.klippy_apis: APIComp = self.server.lookup_component("klippy_apis")
         self.http_client: HttpClient = self.server.lookup_component(
@@ -115,7 +116,7 @@ class SpoolManager:
         )
         logging.info(f"Setting active spool to: {spool_id}")
 
-    async def get_active_spool(self) -> Optional[int]:
+    def get_active_spool(self) -> Optional[int]:
         return self.spool_id
 
     async def track_filament_usage(self):

--- a/moonraker/components/spoolman.py
+++ b/moonraker/components/spoolman.py
@@ -1,0 +1,147 @@
+# Integration with Spoolman
+#
+# Copyright (C) 2023 Daniel Hultgren <daniel.cf.hultgren@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+from __future__ import annotations
+import asyncio
+import datetime
+import logging
+from typing import TYPE_CHECKING, Dict, Any, List
+from urllib.parse import urlencode
+
+if TYPE_CHECKING:
+    from typing import Optional
+    from moonraker.websockets import WebRequest
+    from moonraker.components.http_client import HttpClient
+    from moonraker.components.database import MoonrakerDatabase, NamespaceWrapper
+    from .klippy_apis import KlippyAPI as APIComp
+    from confighelper import ConfigHelper
+
+SPOOL_NAMESPACE = "spoolman"
+MOONRAKER_NAMESPACE = "moonraker"
+ACTIVE_SPOOL_KEY = "spoolman.active_spool_id"
+
+class SpoolManager:
+    def __init__(self, config: ConfigHelper):
+        self.server = config.get_server()
+        self.highest_e_pos = 0.0
+        self.extruded = 0.0
+        self.sync_rate_seconds = config.getint("sync_rate", 5)
+        self.last_sync_time = datetime.datetime.now()
+        self.extruded_lock = asyncio.Lock()
+        
+        self.spoolman_url = config.get("server", None)
+        if self.spoolman_url is None:
+            logging.error("Server config not set for spoolman.")
+            return
+        self.spoolman_url = f"{self.spoolman_url.rstrip('/')}/api/v1"
+
+        self.http_client: HttpClient = self.server.lookup_component("http_client")
+
+        database: MoonrakerDatabase = self.server.lookup_component("database")
+        database.register_local_namespace("spoolman")
+        self.moonraker_db: NamespaceWrapper = database.wrap_namespace(
+            MOONRAKER_NAMESPACE, parse_keys=False)
+
+        self._register_listeners()
+        self._register_endpoints()
+        self.klippy_apis: APIComp = self.server.lookup_component('klippy_apis')
+
+    def _register_listeners(self):
+        self.server.register_event_handler('server:klippy_ready',
+                                           self._handle_server_ready)
+
+    def _register_endpoints(self):
+        self.server.register_endpoint(
+            r"/spoolman/[\W\w]+$", ['GET', 'POST', 'DELETE', 'PUT', 'PATCH'],
+            self._proxy_spoolman_request)
+
+    async def _handle_server_ready(self):
+        self.server.register_event_handler(
+            'server:status_update', self._handle_status_update)
+        sub: Dict[str, Optional[List[str]]] = {'toolhead': ['position']}
+        result = await self.klippy_apis.subscribe_objects(sub)
+        initial_e_pos = self._eposition_from_status(result)
+
+        if initial_e_pos is not None:
+            self.highest_e_pos = initial_e_pos
+        else:
+            logging.error("Spool manager unable to subscribe to epos")
+            raise self.server.error('Unable to subscribe to e position')
+
+    def _eposition_from_status(self, status: Dict[str, Any]) -> Optional[float]:
+        position = status.get('toolhead', {}).get('position', [])
+        return position[3] if len(position) > 0 else None
+
+    async def _handle_status_update(self, status: Dict[str, Any]) -> None:
+        epos = self._eposition_from_status(status)
+        logging.info(f"Epos: {epos}")
+        if epos and epos > self.highest_e_pos:
+            async with self.extruded_lock:
+                self.extruded += epos - self.highest_e_pos
+                self.highest_e_pos = epos
+
+        now = datetime.datetime.now()
+        difference = now - self.last_sync_time
+        if difference.total_seconds() > self.sync_rate_seconds:
+            self.last_sync_time = now
+            logging.debug("Sync period elapsed, tracking usage")
+            await self.track_filament_usage()
+
+    async def set_active_spool(self, spool_id: str) -> bool:
+        self.moonraker_db[ACTIVE_SPOOL_KEY] = spool_id
+        await self.server.send_event('spool_manager:active_spool_set',
+                                        {'spool_id': spool_id})
+        logging.info(f'Setting spool active, id: {spool_id}')
+        return True
+        
+    async def get_active_spool_id(self) -> str:
+        return await self.moonraker_db.get(ACTIVE_SPOOL_KEY, None)
+    
+    async def track_filament_usage(self):
+        spool_id = await self.get_active_spool_id()
+        async with self.extruded_lock:
+            if self.extruded > 0:
+                used_length = self.extruded
+
+                response = await self.http_client.request(
+                    method="PUT",
+                    url=f"{self.spoolman_url}/spool/{spool_id}/use",
+                    body={
+                        "use_length": used_length,
+                    },
+                )
+                response.raise_for_status()
+
+                self.extruded = 0
+
+                logging.info(f'Tracking filament usage, '
+                                f'spool_id: {spool_id}, ' +
+                                f'length: {used_length}, ')
+                    
+    async def _proxy_spoolman_request(self, web_request: WebRequest):
+        body = None
+        query = ""
+        if web_request.action != "GET":
+            body = web_request.args
+        else:
+            query = "?" + urlencode(web_request.args)
+
+        endpoint = web_request.endpoint.removeprefix("/spoolman")
+        full_url = f"{self.spoolman_url}{endpoint}{query}"
+
+        logging.debug(f"Proxying {web_request.action} request to {full_url}")
+        
+        response = await self.http_client.request(
+            method=web_request.action,
+            url=full_url,
+            body=body,
+        )
+        response.raise_for_status()
+
+        return response.json()
+
+def load_component(config: ConfigHelper) -> SpoolManager:
+    return SpoolManager(config)


### PR DESCRIPTION
https://github.com/Donkie/Spoolman

The component pretty much does three things:
1. Act as a proxy for Spoolman's REST API, so that frontends doesn't need to be configured or worry about authentication to the Spoolman server. Frontends can e.g. query "/spoolman/spool" to get a list of spools.
2. Log spool usage similar to how the old integration attempts do it. 
3. Handle active spool ID. Set by the /spoolman/set_spool endpoint.

Regarding 3., I've not yet settled on whether this is something Moonraker should keep track of, or whether Spoolman should be extended to also have a database of printers and spools assigned to them. It would make the interaction with Spoolman more complicated but perhaps the community is looking for a more complete system anyway?

Spoolman itself is also very WIP, but my aim is to start off small and see what needs there are, both from users and from moonraker/frontend devs and develop from that.

Heavily based off of #123 and #597 so many thanks to them for the base code.

Example moonraker.conf:
```
[spoolman]
server: http://192.168.0.100:7912
```