### PR TITLE
data_store: check for numeric temperature

### DIFF
--- a/moonraker/components/data_store.py
+++ b/moonraker/components/data_store.py
@@ -115,8 +115,13 @@ class DataStore:
         for sensor in self.temperature_store:
             if sensor in data:
                 last_val = self.last_temps[sensor]
+                temperature = data[sensor].get('temperature')
+                if temperature is None:
+                    temperature = last_val[0]
+                else:
+                    temperature = round(temperature, 2)
                 self.last_temps[sensor] = (
-                    round(data[sensor].get('temperature', last_val[0]), 2),
+                    temperature,
                     data[sensor].get('target', last_val[1]),
                     data[sensor].get('power', last_val[2]),
                     data[sensor].get('speed', last_val[3]))


### PR DESCRIPTION
This is a follow up on https://github.com/Klipper3d/klipper/pull/6210

Right now, Moonraker will throw an error if/when it receives a null temperature (due to the forced `round` operation)

All this PR does right now is check for a non-None value before doing the `round` so it does not throw.