### PR TITLE
Rework load_system_module

### DIFF
--- a/moonraker/utils/__init__.py
+++ b/moonraker/utils/__init__.py
@@ -200,20 +200,20 @@ def verify_source(
     return checksum, checksum == orig_chksum
 
 def load_system_module(name: str) -> ModuleType:
+    try:
+        return importlib.import_module(name)
+    except ImportError:
+        pass
     for module_path in SYS_MOD_PATHS:
         sys.path.insert(0, module_path)
         try:
-            module = importlib.import_module(name)
+            return importlib.import_module(name)
         except ImportError as e:
             if not isinstance(e, ModuleNotFoundError):
                 logging.exception(f"Failed to load {name} module")
+        finally:
             sys.path.pop(0)
-        else:
-            sys.path.pop(0)
-            break
-    else:
-        raise ServerError(f"Unable to import module {name}")
-    return module
+    raise ServerError(f"Unable to import module {name}")
 
 def get_unix_peer_credentials(
     writer: asyncio.StreamWriter, name: str


### PR DESCRIPTION
This fixes #669.

New logic:
First try to import the module directly which will likely succeed.
If it doesn't then try workarounds.
Using `try`…`finally` makes sure that the inserted entry will be removed from `sys.path` even if some unexpected (not `ImportError`) exception happens.