### PR TITLE
requirements: bump lmdb to 1.4.1

### DIFF
--- a/scripts/moonraker-requirements.txt
+++ b/scripts/moonraker-requirements.txt
@@ -3,7 +3,7 @@ tornado==6.2.0
 pyserial==3.4
 pyserial-asyncio==0.6
 pillow==9.3.0
-lmdb==1.3.0
+lmdb==1.4.1
 streaming-form-data==1.11.0
 distro==1.8.0
 inotify-simple==1.3.5


### PR DESCRIPTION
While trying to build a test docker container based on `debian:latest` (at the moment, that's `debian:12`) with Klipper and Moonraker, I get this error message:

![image](https://github.com/Arksine/moonraker/assets/85504/c859aa93-d308-4010-8c80-1b447d9ba4d6)

The base docker image uses Python 3.11, so I checked, and looking at [lmdb changelog](https://github.com/jnwatson/py-lmdb/blob/master/ChangeLog), it shows a more recent version to support it, and when I used that, the error goes away!

One odd thing is this only happens if I build Klipper before Moonraker... nevertheless, it completely seems to go away if I update the lmdb version, hence this PR!