### PR TITLE
data_store: make additional fields configurable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -239,6 +239,13 @@ temperature_store_size: 1200
 #   that this value also applies to the "target", "power", and "fan_speed"
 #   if the sensor reports them.  The default is 1200, which is enough to
 #   store approximately 20 minutes of data at one value per second.
+temperature_store_additional_fields:
+    voc
+    rpm
+#  This list defines sensor fields to be added to the temperature store.
+#  The fields "temperature", "target", "power" and "speed" are alway recorded,
+#  if available for the sensor. This configuration is additive to that.
+#  The default is no additional fields.
 gcode_store_size:  1000
 #   The maximum number "gcode lines" to store.  The default is 1000.
 ```

--- a/moonraker/components/data_store.py
+++ b/moonraker/components/data_store.py
@@ -96,7 +96,8 @@ class DataStore:
                 else:
                     new_store[sensor] = {}
                     for field in self.stored_fields:
-                        if field in fields:
+                        # Enforce temperature, as frontends rely on that field.
+                        if field in fields or field == "temperature":
                             new_store[sensor][self.pluralize(field)] = deque(
                                 maxlen=self.temp_store_size)
                 if sensor not in self.last_temps:


### PR DESCRIPTION
Prior to this PR, the temperature_store records these sensor fields:
- temperature
- target
- power
- speed

There is a need to create time series records for new combined sensors like VOC-, particle- or humidity sensors with their special measurements.
This PR introduces a new configuration "temperature_store_additional_fields" which extends the existing default fields. It is not possible to replace or reduce that default by configuration, so there is no break in compatability.