### PR TITLE
[Bug] Fix for TPLinkSmart Strip Index Changing.

### DIFF
--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -809,10 +809,9 @@ class TPLinkSmartPlug(PowerDevice):
             # TPLink device controls multiple devices
             if self.output_id is not None:
                 sysinfo = await self._send_tplink_command("info")
-                dev_id = sysinfo["system"]["get_sysinfo"]["deviceId"]
-                out_cmd["context"] = {
-                    'child_ids': [f"{dev_id}{self.output_id:02}"]
-                }
+                children = sysinfo["system"]["get_sysinfo"]["children"]
+                child_id = children[self.output_id]["id"]
+                out_cmd["context"] = {"child_ids": [f"{child_id}"]}
         elif command == "info":
             out_cmd = {'system': {'get_sysinfo': {}}}
         elif command == "clear_rules":


### PR DESCRIPTION
There is a feature in the Kasa app that will allow you to change plug index (basically for naming). However, in the power.py there are 2 different methods for retreiving children devices (plugs). If you have the index reordered in Kasa then you will get inconsistent results since those methods for retrieval are not the same. This PR unifies them properly and now they work as intended. Simple change.

Signed-off-by: Rick Marino <rcmarino@gmail.com>