### PR TITLE
file_manager: Added event for metadata update

### DIFF
--- a/moonraker/components/file_manager/file_manager.py
+++ b/moonraker/components/file_manager/file_manager.py
@@ -2435,6 +2435,7 @@ class MetadataStorage:
                     logging.exception("Error running extract_metadata.py")
                     retries -= 1
                 else:
+                    self.server.send_event("file_manager:metadata_updated", { "filename": fname })
                     break
             else:
                 if ufp_path is None:


### PR DESCRIPTION
I'm working on a component that should do some work after a file's metadata has been updated. This PR adds an event that fires when a file's metadata has been successfully parsed and updated.

Signed-off-by: Kieran Eglin <kieran.eglin@gmail.com>