### PR TITLE
docs: fix typos in docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -147,7 +147,7 @@ enable_inotify_warnings: True
 #   option to suppress warnings when necessary.  The default is True.
 ```
 
-!!! Note:
+!!! Note
     Previously the `[file_manager]` section contained `config_path` and
     `log_path` options. These options are now deprecated, as both locations
     are determined by the `data path` configured on the command line.
@@ -255,7 +255,7 @@ gcode:
 
 ### `[database]`
 
-!!! Note:
+!!! Note
     This section no long has configuration options.  Previously the
     `database_path` option was used to determine the locatation of
     the database folder, it is now determined by the `data path`


### PR DESCRIPTION
Thank you for sharing such a fantastic project. It has made my 3D printer even more convenient.

While reading through the documentation, I came across a section that may have a typo, so I have created this pull request. I would greatly appreciate it if you could review it.

<img width="1543" alt="スクリーンショット 2023-10-20 3 14 08" src="https://github.com/Arksine/moonraker/assets/3256629/235b19a3-4b5c-4b9a-876d-ba735ef18241">
