### PR TITLE
docs: updated prebuild images config path note to `~/printer_data`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 This document describes Moonraker's full configuration. By default Moonraker
 loads the configuration file from `~/moonraker.conf`, however prebuilt
 images such as MainsailOS and FluiddPi configure Moonraker to load the
-configuration from `~/klipper_config/moonraker.conf`.
+configuration from `~/printer_data/config/moonraker.conf`.
 
 As this document references configuration for both Klipper (`printer.cfg`)
 and Moonraker (`moonraker.conf`), each example contains a comment indicating


### PR DESCRIPTION
MainsailOS loads the moonraker.conf from `~/printer_data/config/` 
Source:
[MainsailOS moonraker](https://github.com/mainsail-crew/MainsailOS/tree/develop/src/modules/moonraker/filesystem/home/pi)
[MainsailOS klipper](https://github.com/mainsail-crew/MainsailOS/blob/develop/src/modules/klipper/config#L28)