### PR TITLE
add energy_meter component: energy usage per job

### DIFF
--- a/moonraker/components/energy_meter.py
+++ b/moonraker/components/energy_meter.py
@@ -1,0 +1,130 @@
+# Energy Meter - process energy data from sensors and provide delta measurements
+#
+# Copyright (C) 2023 Sandro Pischinger <mail@sandropischinger.de>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+from __future__ import annotations
+import logging
+from dataclasses import dataclass
+
+# Annotation imports
+from typing import (
+    Dict,
+    Optional,
+    TYPE_CHECKING,
+    Union,
+)
+
+if TYPE_CHECKING:
+    from ..confighelper import ConfigHelper
+    from .sensor import BaseSensor, Sensors
+
+
+@dataclass(frozen=True)
+class EnergyMeterConfiguration:
+    sensor: str
+    field: str
+
+
+class DeltaMeasurement:
+    start_value: Optional[Union[int, float]] = None
+    last_value: Optional[Union[int, float]] = None
+
+    def delta(self) -> Optional[Union[int, float]]:
+        if self.start_value is None or self.last_value is None:
+            return None
+        return self.last_value - self.start_value
+
+
+class EnergyMeter:
+    def __init__(self, config: ConfigHelper) -> None:
+        self.server = config.get_server()
+        sensors: Sensors = self.server.load_component(config, "sensor")
+        self.sensors = sensors.sensors
+        self.config = EnergyMeterConfiguration(
+            sensor=config.get("sensor"),
+            field=config.get("field", "energy"),
+        )
+        self.active_msmnt: Optional[DeltaMeasurement] = None
+
+        self.server.register_event_handler(
+            "sensors:sensor_update", self._on_sensor_update
+        )
+
+    def _update_values(self, sensor_values: Dict[str, Union[int, float]]) -> None:
+        """
+        Update local values from sensor_values.
+        """
+        if self.active_msmnt is None:
+            return
+        if self.config.field not in sensor_values:
+            logging.error(
+                f"Energy value field '{self.config.field}'"
+                "not in data of sensor: '{self.config.sensor}'"
+            )
+            return None
+        value = sensor_values[self.config.field]
+        if self.active_msmnt.start_value is None:
+            logging.debug("EnergyMeter start value: %d", value)
+            self.active_msmnt.start_value = value
+
+        self.active_msmnt.last_value = value
+
+    def _on_sensor_update(
+        self,
+        changed_data: Dict[str, Dict[str, Union[int, float]]]
+    ) -> None:
+        """
+        Listen to sensor update and find the energy sensor.
+        """
+        if self.active_msmnt is None:
+            return
+        sensor_values = changed_data.get(self.config.sensor)
+        if sensor_values is None:
+            return
+        self._update_values(sensor_values)
+
+    def start_measurement(self) -> Optional[DeltaMeasurement]:
+        """
+        Start a measurement and fill with initial values.
+        """
+        if self.active_msmnt is not None:
+            logging.warning(
+                "Can not start another measurement when currently active."
+            )
+            return None
+        sensor: Optional[BaseSensor] = self.sensors.get(self.config.sensor)
+        if sensor is None:
+            logging.warning(
+                "Could not start measurement: sensor '%s' is missing",
+                self.config.sensor
+            )
+            return None
+        self.active_msmnt = DeltaMeasurement()
+        msmnts: Dict[str, Union[int, float]] = {key: values[0] for key, values
+                                                in sensor.values.items()}
+        self._update_values(msmnts)
+
+        return self.active_msmnt
+
+    def stop_measurement(self) -> Optional[DeltaMeasurement]:
+        """
+        Stop the current measurement and return results.
+        """
+        am = self.active_msmnt
+        self.active_msmnt = None
+        return am
+
+    async def initialize(self) -> bool:
+        """
+        EnergyMeter initialization on Moonraker startup.
+        """
+        logging.info(
+            "Registered EnergyMeter for sensor '%s'",
+            self.config.sensor
+        )
+        return True
+
+
+def load_component(config: ConfigHelper) -> EnergyMeter:
+    return EnergyMeter(config)

--- a/moonraker/components/sensor.py
+++ b/moonraker/components/sensor.py
@@ -102,6 +102,9 @@ class BaseSensor:
     def get_sensor_measurements(self) -> Dict[str, List[Union[int, float]]]:
         return {key: list(values) for key, values in self.values.items()}
 
+    def get_last_value(self) -> Dict[str, Union[int, float]]:
+        return self.last_value
+
     def get_name(self) -> str:
         return self.config.name
 
@@ -226,6 +229,12 @@ class Sensors:
                     f"Failed to configure sensor [{cfg.get_name()}]\n{e}"
                 )
                 continue
+
+    def get_sensor(self, sensor_id: str) -> Optional[BaseSensor]:
+        """
+        return the sensor if exists
+        """
+        return self.sensors.get(sensor_id)
 
     def _update_sensor_values(self, eventtime: float) -> float:
         """


### PR DESCRIPTION
fixes #445 

This adds a new component `energy_meter` which is used for starting and stopping a energy measurement. For the actual data, a sensor is to be specified in the config section. The `history` component collects print stats already for jobs, I added the energy measuring there:  On print start, the current value from the sensor's energy counter is saved. When the print stops, this saved value then gets subtracted from the most recent sensor value and voila, we get the energy used for the print.

Here's a sample configuration used for a ShellyPlus1PM:
```
[mqtt]
address: 192.168.230.1
username: {secrets.mqtt.username}
password: {secrets.mqtt.password}
enable_moonraker_api: True

[sensor powermeter]
type: mqtt
name: powermeter
state_topic: shellies/shellyplus1pm-4855199da2e4/status/switch:0
state_response_template:
  {% set notification = payload|fromjson %}
  {set_result("power", notification["apower"]|float)}
  {set_result("voltage", notification["voltage"]|float)}
  {set_result("current", notification["current"]|float)}
  {set_result("energy", notification["aenergy"]["by_minute"][0]|float * 0.000001)}

[energy_meter]
sensor: powermeter
field: energy
```