### PR TITLE
Support Creality Print Slicer generated gcode metadata.

### DIFF
--- a/moonraker/components/file_manager/metadata.py
+++ b/moonraker/components/file_manager/metadata.py
@@ -1003,14 +1003,16 @@ class Creality(BaseSlicer):
     def parse_filament_total(self) -> Optional[float]:
         filament_total = _regex_find_first(
             r";Filament used:(\d+\.?\d*)m", self.header_data)
-        filament_total = filament_total * 1000
-        return filament_total
+        if filament_total:
+            return filament_total * 1000
+        return None
 
     def parse_filament_weight_total(self) -> Optional[float]:
         filament_total = _regex_find_first(
             r";Filament used:(\d+\.?\d*)m", self.header_data)
-        filament_weight_total = filament_total * 5.88
-        return filament_weight_total
+        if filament_total:
+            return filament_total * 5.88
+        return None
 
     def parse_estimated_time(self) -> Optional[float]:
         total_time = _regex_find_first(
@@ -1019,11 +1021,11 @@ class Creality(BaseSlicer):
 
     def parse_first_layer_extr_temp(self) -> Optional[float]:
         return _regex_find_first(
-            r";Print Temperature:(\d+\.?\d*)", self.footer_data)
+            r";Print Temperature:(\d+\.?\d*)", self.header_data)
 
     def parse_first_layer_bed_temp(self) -> Optional[float]:
         return _regex_find_first(
-            r";Bed Temperature:(\d+\.?\d*)", self.footer_data)
+            r";Bed Temperature:(\d+\.?\d*)", self.header_data)
 
 
 READ_SIZE = 512 * 1024


### PR DESCRIPTION
Most of the code are from Creality's version of moonraker. I removed their thumbnail override and fallback the default. They also originally look for these metadata in the footer which was wrong or changed. Looking for them in the header works now.

Example metascan
```
curl -XPOST localhost:7125/server/files/metascan?filename=piggy_fab_K1_0.4_Hyper\ PLA_1.75_1h29m.gcode | jq .
{
  "result": {
    "size": 7928645,
    "modified": 1697844230.756268,
    "uuid": "7cbcc8b8-2752-40ee-9d18-f635d5bc637d",
    "slicer": "Creality",
    "slicer_version": "4.3.6.6242",
    "gcode_start_byte": 133872,
    "gcode_end_byte": 7928630,
    "layer_count": 409,
    "object_height": 81.8,
    "estimated_time": 5380,
    "layer_height": 0.2,
    "first_layer_height": 0.2,
    "first_layer_extr_temp": 220,
    "first_layer_bed_temp": 45,
    "filament_name": "Hyper PLA_1.75",
    "filament_type": "PLA",
    "filament_total": 20671.199999999997,
    "filament_weight_total": 121.54665599999998,
    "thumbnails": [
      {
        "width": 32,
        "height": 32,
        "size": 1874,
        "relative_path": ".thumbs/piggy_fab_K1_0.4_Hyper PLA_1.75_1h29m-32x32.png"
      },
      {
        "width": 300,
        "height": 300,
        "size": 42965,
        "relative_path": ".thumbs/piggy_fab_K1_0.4_Hyper PLA_1.75_1h29m-300x300.png"
      }
    ],
    "print_start_time": null,
    "job_id": null,
    "filename": "piggy_fab_K1_0.4_Hyper PLA_1.75_1h29m.gcode"
  }
}

```