### PR TITLE
Explain stream types

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -355,7 +355,7 @@ enabled: True
 service: mjpegstreamer
 #   The name of the application or service hosting the webcam stream.  Front-
 #   ends may use this configuration to determine how to launch or start the
-#   program.  The default is "mjpegstreamer".
+#   program.  The default is "mjpegstreamer". Other valid values include: 'mjpegstreamer-adaptive', 'hlsstream', 'webrtc-camerastreamer', 'ipstream', 'iframe', and 'webrtc-go2rtc'.
 target_fps: 15
 #   An integer value specifying the target framerate.  The default is 15 fps.
 target_fps_idle: 5


### PR DESCRIPTION
Add a list of allowed stream types. I thought this was valuable because the stream types are not explained in this document. I had to look in the fluidd codebase to find a list of valid values. The valid values are not the same as the options shown in the fluidd webUI.

https://github.com/fluidd-core/fluidd/blob/999ccddd1a39d6037ec6a8f34b689b0216ea592d/src/components/settings/cameras/CameraConfigDialog.vue#L86

Signed-off-by: Wayne Manion treowayne@gmail.com
