### PR TITLE
Internal endpoint refactoring, handler optimizations

### DIFF
--- a/moonraker/app.py
+++ b/moonraker/app.py
@@ -28,7 +28,8 @@ from .common import (
     APIDefinition,
     APITransport,
     TransportType,
-    RequestType
+    RequestType,
+    KlippyState
 )
 from .utils import json_wrapper as jsonw
 from .websockets import (
@@ -1133,11 +1134,10 @@ class WelcomeHandler(tornado.web.RequestHandler):
                 "The [authorization] section in moonraker.conf must be "
                 "configured to enable CORS."
             )
-        kstate = self.server.get_klippy_state()
-        if kstate != "disconnected":
-            kinfo = self.server.get_klippy_info()
-            kmsg = kinfo.get("state_message", kstate)
-            summary.append(f"Klipper reports {kmsg.lower()}")
+        kconn: Klippy = self.server.lookup_component("klippy_connection")
+        kstate = kconn.state
+        if kstate != KlippyState.DISCONNECTED:
+            summary.append(f"Klipper reports {kstate.message.lower()}")
         else:
             summary.append(
                 "Moonraker is not currently connected to Klipper.  Make sure "

--- a/moonraker/app.py
+++ b/moonraker/app.py
@@ -328,8 +328,8 @@ class MoonrakerApp:
                     f"Local endpoint '{endpoint}' already registered"
                 )
             return
+        logging.debug(f"Registering API: {api_def}")
         if TransportType.HTTP in transports:
-            logging.info(f"Registering HTTP Endpoint: ({request_types}) {http_path}")
             params: dict[str, Any] = {}
             params["api_definition"] = api_def
             params["wrap_result"] = wrap_result
@@ -339,8 +339,6 @@ class MoonrakerApp:
             )
         self.registered_base_handlers.append(http_path)
         for request_type, method_name in api_def.rpc_items():
-            transports = api_def.transports & ~TransportType.HTTP
-            logging.info(f"Registering RPC Method: ({transports}) {method_name}")
             self.json_rpc.register_method(method_name, request_type, api_def)
 
     def register_static_file_handler(
@@ -396,6 +394,7 @@ class MoonrakerApp:
     def remove_endpoint(self, endpoint: str) -> None:
         api_def = APIDefinition.pop_cached_def(endpoint)
         if api_def is not None:
+            logging.debug(f"Removing Endpoint: {endpoint}")
             if api_def.http_path in self.registered_base_handlers:
                 self.registered_base_handlers.remove(api_def.http_path)
             self.mutable_router.remove_handler(api_def.http_path)

--- a/moonraker/app.py
+++ b/moonraker/app.py
@@ -323,6 +323,10 @@ class MoonrakerApp:
         )
         http_path = api_def.http_path
         if http_path in self.registered_base_handlers:
+            if not is_remote:
+                raise self.server.error(
+                    f"Local endpoint '{endpoint}' already registered"
+                )
             return
         if TransportType.HTTP in transports:
             logging.info(f"Registering HTTP Endpoint: ({request_types}) {http_path}")

--- a/moonraker/common.py
+++ b/moonraker/common.py
@@ -171,6 +171,18 @@ class APIDefinition:
     auth_required: bool
     _cache: ClassVar[Dict[str, APIDefinition]] = {}
 
+    def __str__(self) -> str:
+        tprt_str = "|".join([tprt.name for tprt in self.transports if tprt.name])
+        val: str = f"(Transports: {tprt_str})"
+        if TransportType.HTTP in self.transports:
+            req_types = "|".join([rt.name for rt in self.request_types if rt.name])
+            val += f" (HTTP Request: {req_types} {self.http_path})"
+        if self.rpc_methods:
+            methods = " ".join(self.rpc_methods)
+            val += f" (RPC Methods: {methods})"
+        val += f" (Auth Required: {self.auth_required})"
+        return val
+
     def request(
         self,
         args: Dict[str, Any],

--- a/moonraker/common.py
+++ b/moonraker/common.py
@@ -123,6 +123,37 @@ class JobEvent(ExtendedEnum):
     def is_printing(self) -> bool:
         return self.value in [2, 4]
 
+class KlippyState(ExtendedEnum):
+    DISCONNECTED = 1
+    STARTUP = 2
+    READY = 3
+    ERROR = 4
+    SHUTDOWN = 5
+
+    @classmethod
+    def from_string(cls, enum_name: str, msg: str = ""):
+        str_name = enum_name.upper()
+        for name, member in cls.__members__.items():
+            if name == str_name:
+                instance = cls(member.value)
+                if msg:
+                    instance.set_message(msg)
+                return instance
+        raise ValueError(f"No enum member named {enum_name}")
+
+
+    def set_message(self, msg: str) -> None:
+        self._state_message: str = msg
+
+    @property
+    def message(self) -> str:
+        if hasattr(self, "_state_message"):
+            return self._state_message
+        return ""
+
+    def startup_complete(self) -> bool:
+        return self.value > 2
+
 class Subscribable:
     def send_status(
         self, status: Dict[str, Any], eventtime: float

--- a/moonraker/common.py
+++ b/moonraker/common.py
@@ -9,7 +9,7 @@ import sys
 import ipaddress
 import logging
 import copy
-from enum import Flag, auto
+from enum import Enum, Flag, auto
 from .utils import ServerError, Sentinel
 from .utils import json_wrapper as jsonw
 
@@ -89,6 +89,39 @@ class TransportType(ExtendedFlag):
     WEBSOCKET = auto()
     MQTT = auto()
     INTERNAL = auto()
+
+class ExtendedEnum(Enum):
+    @classmethod
+    def from_string(cls, enum_name: str):
+        str_name = enum_name.upper()
+        for name, member in cls.__members__.items():
+            if name == str_name:
+                return cls(member.value)
+        raise ValueError(f"No enum member named {enum_name}")
+
+    def __str__(self) -> str:
+        return self._name_.lower()  # type: ignore
+
+class JobEvent(ExtendedEnum):
+    STANDBY = 1
+    STARTED = 2
+    PAUSED = 3
+    RESUMED = 4
+    COMPLETE = 5
+    ERROR = 6
+    CANCELLED = 7
+
+    @property
+    def finished(self) -> bool:
+        return self.value >= 5
+
+    @property
+    def aborted(self) -> bool:
+        return self.value >= 6
+
+    @property
+    def is_printing(self) -> bool:
+        return self.value in [2, 4]
 
 class Subscribable:
     def send_status(

--- a/moonraker/components/data_store.py
+++ b/moonraker/components/data_store.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import logging
 import time
 from collections import deque
+from ..common import RequestType
 
 # Annotation imports
 from typing import (
@@ -59,11 +60,13 @@ class DataStore:
 
         # Register endpoints
         self.server.register_endpoint(
-            "/server/temperature_store", ['GET'],
-            self._handle_temp_store_request)
+            "/server/temperature_store", RequestType.GET,
+            self._handle_temp_store_request
+        )
         self.server.register_endpoint(
-            "/server/gcode_store", ['GET'],
-            self._handle_gcode_store_request)
+            "/server/gcode_store", RequestType.GET,
+            self._handle_gcode_store_request
+        )
 
     async def _init_sensors(self) -> None:
         klippy_apis: APIComp = self.server.lookup_component('klippy_apis')

--- a/moonraker/components/extensions.py
+++ b/moonraker/components/extensions.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import asyncio
 import pathlib
 import logging
-from ..common import BaseRemoteConnection
+from ..common import BaseRemoteConnection, RequestType, TransportType
 from ..utils import get_unix_peer_credentials
 
 # Annotation imports
@@ -35,19 +35,19 @@ class ExtensionManager:
         self.agent_methods: Dict[int, List[str]] = {}
         self.uds_server: Optional[asyncio.AbstractServer] = None
         self.server.register_endpoint(
-            "/connection/register_remote_method", ["POST"],
+            "/connection/register_remote_method", RequestType.POST,
             self._register_agent_method,
-            transports=["websocket"]
+            transports=TransportType.WEBSOCKET
         )
         self.server.register_endpoint(
-            "/connection/send_event", ["POST"], self._handle_agent_event,
-            transports=["websocket"]
+            "/connection/send_event", RequestType.POST, self._handle_agent_event,
+            transports=TransportType.WEBSOCKET
         )
         self.server.register_endpoint(
-            "/server/extensions/list", ["GET"], self._handle_list_extensions
+            "/server/extensions/list", RequestType.GET, self._handle_list_extensions
         )
         self.server.register_endpoint(
-            "/server/extensions/request", ["POST"], self._handle_call_agent
+            "/server/extensions/request", RequestType.POST, self._handle_call_agent
         )
 
     def register_agent(self, connection: BaseRemoteConnection) -> None:

--- a/moonraker/components/history.py
+++ b/moonraker/components/history.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import time
 import logging
 from asyncio import Lock
-from ..common import JobEvent
+from ..common import JobEvent, RequestType
 
 # Annotation imports
 from typing import (
@@ -54,14 +54,19 @@ class History:
         self.server.register_notification("history:history_changed")
 
         self.server.register_endpoint(
-            "/server/history/job", ['GET', 'DELETE'], self._handle_job_request)
+            "/server/history/job", RequestType.GET | RequestType.DELETE,
+            self._handle_job_request
+        )
         self.server.register_endpoint(
-            "/server/history/list", ['GET'], self._handle_jobs_list)
+            "/server/history/list", RequestType.GET, self._handle_jobs_list
+        )
         self.server.register_endpoint(
-            "/server/history/totals", ['GET'], self._handle_job_totals)
+            "/server/history/totals", RequestType.GET, self._handle_job_totals
+        )
         self.server.register_endpoint(
-            "/server/history/reset_totals", ['POST'],
-            self._handle_job_total_reset)
+            "/server/history/reset_totals", RequestType.POST,
+            self._handle_job_total_reset
+        )
 
         database.register_local_namespace(HIST_NAMESPACE)
         self.history_ns = database.wrap_namespace(HIST_NAMESPACE,
@@ -78,14 +83,14 @@ class History:
                                   web_request: WebRequest
                                   ) -> Dict[str, Any]:
         async with self.request_lock:
-            action = web_request.get_action()
-            if action == "GET":
+            req_type = web_request.get_request_type()
+            if req_type == RequestType.GET:
                 job_id = web_request.get_str("uid")
                 if job_id not in self.cached_job_ids:
                     raise self.server.error(f"Invalid job uid: {job_id}", 404)
                 job = await self.history_ns[job_id]
                 return {"job": self._prep_requested_job(job, job_id)}
-            if action == "DELETE":
+            if req_type == RequestType.DELETE:
                 all = web_request.get_boolean("all", False)
                 if all:
                     deljobs = self.cached_job_ids

--- a/moonraker/components/job_queue.py
+++ b/moonraker/components/job_queue.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import asyncio
 import time
 import logging
-from ..common import JobEvent
+from ..common import JobEvent, RequestType
 
 # Annotation imports
 from typing import (
@@ -56,16 +56,21 @@ class JobQueue:
                                            self.start_queue)
 
         self.server.register_endpoint(
-            "/server/job_queue/job", ['POST', 'DELETE'],
-            self._handle_job_request)
+            "/server/job_queue/job", RequestType.POST | RequestType.DELETE,
+            self._handle_job_request
+        )
         self.server.register_endpoint(
-            "/server/job_queue/pause", ['POST'], self._handle_pause_queue)
+            "/server/job_queue/pause", RequestType.POST, self._handle_pause_queue
+        )
         self.server.register_endpoint(
-            "/server/job_queue/start", ['POST'], self._handle_start_queue)
+            "/server/job_queue/start", RequestType.POST, self._handle_start_queue
+        )
         self.server.register_endpoint(
-            "/server/job_queue/status", ['GET'], self._handle_queue_status)
+            "/server/job_queue/status", RequestType.GET, self._handle_queue_status
+        )
         self.server.register_endpoint(
-            "/server/job_queue/jump", ['POST'], self._handle_jump)
+            "/server/job_queue/jump", RequestType.POST, self._handle_jump
+        )
 
     async def _handle_ready(self) -> None:
         async with self.lock:
@@ -248,23 +253,23 @@ class JobQueue:
                 'queue_state': self.queue_state
             })
 
-    async def _handle_job_request(self,
-                                  web_request: WebRequest
-                                  ) -> Dict[str, Any]:
-        action = web_request.get_action()
-        if action == "POST":
+    async def _handle_job_request(
+        self, web_request: WebRequest
+    ) -> Dict[str, Any]:
+        req_type = web_request.get_request_type()
+        if req_type == RequestType.POST:
             files = web_request.get_list('filenames')
             reset = web_request.get_boolean("reset", False)
             # Validate that all files exist before queueing
             await self.queue_job(files, reset=reset)
-        elif action == "DELETE":
+        elif req_type == RequestType.DELETE:
             if web_request.get_boolean("all", False):
                 await self.delete_job([], all=True)
             else:
                 job_ids = web_request.get_list('job_ids')
                 await self.delete_job(job_ids)
         else:
-            raise self.server.error(f"Invalid action: {action}")
+            raise self.server.error(f"Invalid request type: {req_type}")
         return {
             'queued_jobs': self._job_map_to_list(),
             'queue_state': self.queue_state

--- a/moonraker/components/job_state.py
+++ b/moonraker/components/job_state.py
@@ -15,6 +15,7 @@ from typing import (
     Dict,
     List,
 )
+from ..common import JobEvent
 if TYPE_CHECKING:
     from ..confighelper import ConfigHelper
     from .klippy_apis import KlippyAPI
@@ -65,8 +66,16 @@ class JobState:
                     f"Job State Changed - Prev State: {old_state}, "
                     f"New State: {new_state}"
                 )
+                # NOTE: Individual job_state events are DEPRECATED.  New modules
+                # should register handlers for "job_state: status_changed" and
+                # match against the JobEvent object provided.
+                self.server.send_event(f"job_state:{new_state}", prev_ps, new_ps)
                 self.server.send_event(
-                    f"job_state:{new_state}", prev_ps, new_ps)
+                    "job_state:state_changed",
+                    JobEvent.from_string(new_state),
+                    prev_ps,
+                    new_ps
+                )
         if "info" in ps:
             cur_layer: Optional[int] = ps["info"].get("current_layer")
             if cur_layer is not None:

--- a/moonraker/components/job_state.py
+++ b/moonraker/components/job_state.py
@@ -15,7 +15,7 @@ from typing import (
     Dict,
     List,
 )
-from ..common import JobEvent
+from ..common import JobEvent, KlippyState
 if TYPE_CHECKING:
     from ..confighelper import ConfigHelper
     from .klippy_apis import KlippyAPI
@@ -27,8 +27,8 @@ class JobState:
         self.server.register_event_handler(
             "server:klippy_started", self._handle_started)
 
-    async def _handle_started(self, state: str) -> None:
-        if state != "ready":
+    async def _handle_started(self, state: KlippyState) -> None:
+        if state != KlippyState.READY:
             return
         kapis: KlippyAPI = self.server.lookup_component('klippy_apis')
         sub: Dict[str, Optional[List[str]]] = {"print_stats": None}

--- a/moonraker/components/klippy_apis.py
+++ b/moonraker/components/klippy_apis.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 from ..utils import Sentinel
-from ..common import WebRequest, Subscribable
+from ..common import WebRequest, Subscribable, RequestType
 
 # Annotation imports
 from typing import (
@@ -52,17 +52,23 @@ class KlippyAPI(Subscribable):
 
         # Register GCode Aliases
         self.server.register_endpoint(
-            "/printer/print/pause", ['POST'], self._gcode_pause)
+            "/printer/print/pause", RequestType.POST, self._gcode_pause
+        )
         self.server.register_endpoint(
-            "/printer/print/resume", ['POST'], self._gcode_resume)
+            "/printer/print/resume", RequestType.POST, self._gcode_resume
+        )
         self.server.register_endpoint(
-            "/printer/print/cancel", ['POST'], self._gcode_cancel)
+            "/printer/print/cancel", RequestType.POST, self._gcode_cancel
+        )
         self.server.register_endpoint(
-            "/printer/print/start", ['POST'], self._gcode_start_print)
+            "/printer/print/start", RequestType.POST, self._gcode_start_print
+        )
         self.server.register_endpoint(
-            "/printer/restart", ['POST'], self._gcode_restart)
+            "/printer/restart", RequestType.POST, self._gcode_restart
+        )
         self.server.register_endpoint(
-            "/printer/firmware_restart", ['POST'], self._gcode_firmware_restart)
+            "/printer/firmware_restart", RequestType.POST, self._gcode_firmware_restart
+        )
         self.server.register_event_handler(
             "server:klippy_disconnect", self._on_klippy_disconnect
         )

--- a/moonraker/components/klippy_apis.py
+++ b/moonraker/components/klippy_apis.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 from ..utils import Sentinel
-from ..common import WebRequest, Subscribable, RequestType
+from ..common import WebRequest, APITransport, RequestType
 
 # Annotation imports
 from typing import (
@@ -38,7 +38,7 @@ STATUS_ENDPOINT = "objects/query"
 OBJ_LIST_ENDPOINT = "objects/list"
 REG_METHOD_ENDPOINT = "register_remote_method"
 
-class KlippyAPI(Subscribable):
+class KlippyAPI(APITransport):
     def __init__(self, config: ConfigHelper) -> None:
         self.server = config.get_server()
         self.klippy: Klippy = self.server.lookup_component("klippy_connection")
@@ -103,7 +103,7 @@ class KlippyAPI(Subscribable):
         default: Any = Sentinel.MISSING
     ) -> Any:
         try:
-            req = WebRequest(method, params, conn=self)
+            req = WebRequest(method, params, transport=self)
             result = await self.klippy.request(req)
         except self.server.error:
             if default is Sentinel.MISSING:

--- a/moonraker/components/machine.py
+++ b/moonraker/components/machine.py
@@ -23,6 +23,7 @@ import configparser
 from ..confighelper import FileSourceWrapper
 from ..utils import source_info
 from ..utils import json_wrapper as jsonw
+from ..common import RequestType
 
 # Annotation imports
 from typing import (
@@ -132,26 +133,29 @@ class Machine:
         self.sudo_requests: List[Tuple[SudoCallback, str]] = []
 
         self.server.register_endpoint(
-            "/machine/reboot", ['POST'], self._handle_machine_request)
+            "/machine/reboot", RequestType.POST, self._handle_machine_request
+        )
         self.server.register_endpoint(
-            "/machine/shutdown", ['POST'], self._handle_machine_request)
+            "/machine/shutdown", RequestType.POST, self._handle_machine_request
+        )
         self.server.register_endpoint(
-            "/machine/services/restart", ['POST'],
-            self._handle_service_request)
+            "/machine/services/restart", RequestType.POST, self._handle_service_request
+        )
         self.server.register_endpoint(
-            "/machine/services/stop", ['POST'],
-            self._handle_service_request)
+            "/machine/services/stop", RequestType.POST, self._handle_service_request
+        )
         self.server.register_endpoint(
-            "/machine/services/start", ['POST'],
-            self._handle_service_request)
+            "/machine/services/start", RequestType.POST, self._handle_service_request
+        )
         self.server.register_endpoint(
-            "/machine/system_info", ['GET'],
-            self._handle_sysinfo_request)
+            "/machine/system_info", RequestType.GET, self._handle_sysinfo_request
+        )
         self.server.register_endpoint(
-            "/machine/sudo/info", ["GET"], self._handle_sudo_info)
+            "/machine/sudo/info", RequestType.GET, self._handle_sudo_info
+        )
         self.server.register_endpoint(
-            "/machine/sudo/password", ["POST"],
-            self._set_sudo_password)
+            "/machine/sudo/password", RequestType.POST, self._set_sudo_password
+        )
 
         self.server.register_notification("machine:service_state_changed")
         self.server.register_notification("machine:sudo_alert")

--- a/moonraker/components/machine.py
+++ b/moonraker/components/machine.py
@@ -47,7 +47,6 @@ if TYPE_CHECKING:
     from .shell_command import ShellCommandFactory as SCMDComp
     from .database import MoonrakerDatabase
     from .file_manager.file_manager import FileManager
-    from .authorization import Authorization
     from .announcements import Announcements
     from .proc_stats import ProcStats
     from .dbus_manager import DbusManager
@@ -1933,11 +1932,6 @@ class InstallValidator:
         if self._sudo_requested:
             return
         self._sudo_requested = True
-        auth: Optional[Authorization]
-        auth = self.server.lookup_component("authorization", None)
-        if auth is not None:
-            # Bypass authentication requirements
-            auth.register_permited_path("/machine/sudo/password")
         machine: Machine = self.server.lookup_component("machine")
         machine.register_sudo_request(
             self._on_password_received,

--- a/moonraker/components/mqtt.py
+++ b/moonraker/components/mqtt.py
@@ -18,7 +18,8 @@ from ..common import (
     Subscribable,
     WebRequest,
     APITransport,
-    JsonRPC
+    JsonRPC,
+    KlippyState
 )
 from ..utils import json_wrapper as jsonw
 
@@ -372,7 +373,7 @@ class MQTTClient(APITransport, Subscribable):
             self._do_reconnect(first=True)
         )
 
-    async def _handle_klippy_started(self, state: str) -> None:
+    async def _handle_klippy_started(self, state: KlippyState) -> None:
         if self.status_objs:
             args = {'objects': self.status_objs}
             try:

--- a/moonraker/components/notifier.py
+++ b/moonraker/components/notifier.py
@@ -10,6 +10,7 @@ import apprise
 import logging
 import pathlib
 import re
+from ..common import JobEvent
 
 # Annotation imports
 from typing import (
@@ -29,23 +30,20 @@ class Notifier:
     def __init__(self, config: ConfigHelper) -> None:
         self.server = config.get_server()
         self.notifiers: Dict[str, NotifierInstance] = {}
-        self.events: Dict[str, NotifierEvent] = {}
+        self.events: Dict[str, List[NotifierInstance]] = {}
         prefix_sections = config.get_prefix_sections("notifier")
-
-        self.register_events(config)
         self.register_remote_actions()
-
         for section in prefix_sections:
             cfg = config[section]
             try:
                 notifier = NotifierInstance(cfg)
-
-                for event in self.events:
-                    if event in notifier.events or "*" in notifier.events:
-                        self.events[event].register_notifier(notifier)
-
+                for job_event in list(JobEvent):
+                    if job_event == JobEvent.STANDBY:
+                        continue
+                    evt_name = str(job_event)
+                    if "*" in notifier.events or evt_name in notifier.events:
+                        self.events.setdefault(evt_name, []).append(notifier)
                 logging.info(f"Registered notifier: '{notifier.get_name()}'")
-
             except Exception as e:
                 msg = f"Failed to load notifier[{cfg.get_name()}]\n{e}"
                 self.server.add_warning(msg)
@@ -53,6 +51,9 @@ class Notifier:
             self.notifiers[notifier.get_name()] = notifier
 
         self.register_endpoints(config)
+        self.server.register_event_handler(
+            "job_state:state_changed", self._on_job_state_changed
+        )
 
     def register_remote_actions(self):
         self.server.register_remote_method("notify", self.notify_action)
@@ -61,40 +62,17 @@ class Notifier:
         if name not in self.notifiers:
             raise self.server.error(f"Notifier '{name}' not found", 404)
         notifier = self.notifiers[name]
-
         await notifier.notify("remote_action", [], message)
 
-    def register_events(self, config: ConfigHelper):
-
-        self.events["started"] = NotifierEvent(
-            "started",
-            "job_state:started",
-            config)
-
-        self.events["complete"] = NotifierEvent(
-            "complete",
-            "job_state:complete",
-            config)
-
-        self.events["error"] = NotifierEvent(
-            "error",
-            "job_state:error",
-            config)
-
-        self.events["cancelled"] = NotifierEvent(
-            "cancelled",
-            "job_state:cancelled",
-            config)
-
-        self.events["paused"] = NotifierEvent(
-            "paused",
-            "job_state:paused",
-            config)
-
-        self.events["resumed"] = NotifierEvent(
-            "resumed",
-            "job_state:resumed",
-            config)
+    async def _on_job_state_changed(
+            self,
+            job_event: JobEvent,
+            prev_stats: Dict[str, Any],
+            new_stats: Dict[str, Any]
+    ) -> None:
+        evt_name = str(job_event)
+        for notifier in self.events.get(evt_name, []):
+            await notifier.notify(evt_name, [prev_stats, new_stats])
 
     def register_endpoints(self, config: ConfigHelper):
         self.server.register_endpoint(
@@ -133,34 +111,6 @@ class Notifier:
             "status": "success",
             "stats": print_stats
         }
-
-
-class NotifierEvent:
-    def __init__(self, identifier: str, event_name: str, config: ConfigHelper):
-        self.identifier = identifier
-        self.event_name = event_name
-        self.server = config.get_server()
-        self.notifiers: Dict[str, NotifierInstance] = {}
-        self.config = config
-
-        self.server.register_event_handler(self.event_name, self._handle)
-
-    def register_notifier(self, notifier: NotifierInstance):
-        self.notifiers[notifier.get_name()] = notifier
-
-    async def _handle(self, *args) -> None:
-        logging.info(f"'{self.identifier}' notifier event triggered'")
-        await self.invoke_notifiers(args)
-
-    async def invoke_notifiers(self, args):
-        for notifier_name in self.notifiers:
-            try:
-                notifier = self.notifiers[notifier_name]
-                await notifier.notify(self.identifier, args)
-            except Exception as e:
-                logging.info(f"Failed to notify [{notifier_name}]\n{e}")
-                continue
-
 
 class NotifierInstance:
     def __init__(self, config: ConfigHelper) -> None:

--- a/moonraker/components/notifier.py
+++ b/moonraker/components/notifier.py
@@ -10,7 +10,7 @@ import apprise
 import logging
 import pathlib
 import re
-from ..common import JobEvent
+from ..common import JobEvent, RequestType
 
 # Annotation imports
 from typing import (
@@ -76,10 +76,10 @@ class Notifier:
 
     def register_endpoints(self, config: ConfigHelper):
         self.server.register_endpoint(
-            "/server/notifiers/list", ["GET"], self._handle_notifier_list
+            "/server/notifiers/list", RequestType.GET, self._handle_notifier_list
         )
         self.server.register_debug_endpoint(
-            "/debug/notifiers/test", ["POST"], self._handle_notifier_test
+            "/debug/notifiers/test", RequestType.POST, self._handle_notifier_test
         )
 
     async def _handle_notifier_list(

--- a/moonraker/components/octoprint_compat.py
+++ b/moonraker/components/octoprint_compat.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 import logging
+from ..common import RequestType, TransportType
 
 # Annotation imports
 from typing import (
@@ -65,22 +66,27 @@ class OctoPrintCompat:
 
         # Version & Server information
         self.server.register_endpoint(
-            '/api/version', ['GET'], self._get_version,
-            transports=['http'], wrap_result=False)
+            '/api/version', RequestType.GET, self._get_version,
+            transports=TransportType.HTTP, wrap_result=False
+        )
         self.server.register_endpoint(
-            '/api/server', ['GET'], self._get_server,
-            transports=['http'], wrap_result=False)
+            '/api/server', RequestType.GET, self._get_server,
+            transports=TransportType.HTTP, wrap_result=False
+        )
 
         # Login, User & Settings
         self.server.register_endpoint(
-            '/api/login', ['POST'], self._post_login_user,
-            transports=['http'], wrap_result=False)
+            '/api/login', RequestType.POST, self._post_login_user,
+            transports=TransportType.HTTP, wrap_result=False
+        )
         self.server.register_endpoint(
-            '/api/currentuser', ['GET'], self._post_login_user,
-            transports=['http'], wrap_result=False)
+            '/api/currentuser', RequestType.GET, self._post_login_user,
+            transports=TransportType.HTTP, wrap_result=False
+        )
         self.server.register_endpoint(
-            '/api/settings', ['GET'], self._get_settings,
-            transports=['http'], wrap_result=False)
+            '/api/settings', RequestType.GET, self._get_settings,
+            transports=TransportType.HTTP, wrap_result=False
+        )
 
         # File operations
         # Note that file upload is handled in file_manager.py
@@ -88,30 +94,34 @@ class OctoPrintCompat:
 
         # Job operations
         self.server.register_endpoint(
-            '/api/job', ['GET'], self._get_job,
-            transports=['http'], wrap_result=False)
+            '/api/job', RequestType.GET, self._get_job,
+            transports=TransportType.HTTP, wrap_result=False
+        )
         # TODO: start/cancel/restart/pause jobs
 
         # Printer operations
         self.server.register_endpoint(
-            '/api/printer', ['GET'], self._get_printer,
-            transports=['http'], wrap_result=False)
+            '/api/printer', RequestType.GET, self._get_printer,
+            transports=TransportType.HTTP, wrap_result=False)
         self.server.register_endpoint(
-            '/api/printer/command', ['POST'], self._post_command,
-            transports=['http'], wrap_result=False)
+            '/api/printer/command', RequestType.POST, self._post_command,
+            transports=TransportType.HTTP, wrap_result=False
+        )
         # TODO: head/tool/bed/chamber specific read/issue
 
         # Printer profiles
         self.server.register_endpoint(
-            '/api/printerprofiles', ['GET'], self._get_printerprofiles,
-            transports=['http'], wrap_result=False)
+            '/api/printerprofiles', RequestType.GET, self._get_printerprofiles,
+            transports=TransportType.HTTP, wrap_result=False
+        )
 
         # Upload Handlers
         self.server.register_upload_handler(
             "/api/files/local", location_prefix="api/files/moonraker")
         self.server.register_endpoint(
-            "/api/files/moonraker/(?P<relative_path>.+)", ['POST'],
-            self._select_file, transports=['http'], wrap_result=False)
+            "/api/files/moonraker/(?P<relative_path>.+)", RequestType.POST,
+            self._select_file, transports=TransportType.HTTP, wrap_result=False
+        )
 
         # System
         # TODO: shutdown/reboot/restart operations

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -12,6 +12,7 @@ import asyncio
 import time
 from urllib.parse import quote, urlencode
 from ..utils import json_wrapper as jsonw
+from ..common import RequestType
 
 # Annotation imports
 from typing import (
@@ -74,20 +75,24 @@ class PrinterPower:
             self.devices[dev.get_name()] = dev
 
         self.server.register_endpoint(
-            "/machine/device_power/devices", ['GET'],
-            self._handle_list_devices)
+            "/machine/device_power/devices", RequestType.GET, self._handle_list_devices
+        )
         self.server.register_endpoint(
-            "/machine/device_power/status", ['GET'],
-            self._handle_batch_power_request)
+            "/machine/device_power/status", RequestType.GET,
+            self._handle_batch_power_request
+        )
         self.server.register_endpoint(
-            "/machine/device_power/on", ['POST'],
-            self._handle_batch_power_request)
+            "/machine/device_power/on", RequestType.POST,
+            self._handle_batch_power_request
+        )
         self.server.register_endpoint(
-            "/machine/device_power/off", ['POST'],
-            self._handle_batch_power_request)
+            "/machine/device_power/off", RequestType.POST,
+            self._handle_batch_power_request
+        )
         self.server.register_endpoint(
-            "/machine/device_power/device", ['GET', 'POST'],
-            self._handle_single_power_request)
+            "/machine/device_power/device", RequestType.GET | RequestType.POST,
+            self._handle_single_power_request
+        )
         self.server.register_remote_method(
             "set_device_power", self.set_device_power)
         self.server.register_event_handler(
@@ -122,34 +127,35 @@ class PrinterPower:
                 )
                 await dev.process_request("on")
 
-    async def _handle_list_devices(self,
-                                   web_request: WebRequest
-                                   ) -> Dict[str, Any]:
+    async def _handle_list_devices(
+        self, web_request: WebRequest
+    ) -> Dict[str, Any]:
         dev_list = [d.get_device_info() for d in self.devices.values()]
         output = {"devices": dev_list}
         return output
 
-    async def _handle_single_power_request(self,
-                                           web_request: WebRequest
-                                           ) -> Dict[str, Any]:
+    async def _handle_single_power_request(
+        self, web_request: WebRequest
+    ) -> Dict[str, Any]:
         dev_name: str = web_request.get_str('device')
-        req_action = web_request.get_action()
+        req_type = web_request.get_request_type()
         if dev_name not in self.devices:
             raise self.server.error(f"No valid device named {dev_name}")
         dev = self.devices[dev_name]
-        if req_action == 'GET':
+        if req_type == RequestType.GET:
             action = "status"
-        elif req_action == "POST":
+        elif req_type == RequestType.POST:
             action = web_request.get_str('action').lower()
             if action not in ["on", "off", "toggle"]:
-                raise self.server.error(
-                    f"Invalid requested action '{action}'")
+                raise self.server.error(f"Invalid requested action '{action}'")
+        else:
+            raise self.server.error(f"Invalid Request Type: {req_type}")
         result = await dev.process_request(action)
         return {dev_name: result}
 
-    async def _handle_batch_power_request(self,
-                                          web_request: WebRequest
-                                          ) -> Dict[str, Any]:
+    async def _handle_batch_power_request(
+        self, web_request: WebRequest
+    ) -> Dict[str, Any]:
         args = web_request.get_args()
         ep = web_request.get_endpoint()
         if not args:

--- a/moonraker/components/proc_stats.py
+++ b/moonraker/components/proc_stats.py
@@ -15,6 +15,7 @@ import pathlib
 import logging
 from collections import deque
 from ..utils import ioctl_macros
+from ..common import RequestType
 
 # Annotation imports
 from typing import (
@@ -79,9 +80,11 @@ class ProcStats:
         self.cpu_stats_file = pathlib.Path(CPU_STAT_PATH)
         self.meminfo_file = pathlib.Path(MEM_AVAIL_PATH)
         self.server.register_endpoint(
-            "/machine/proc_stats", ["GET"], self._handle_stat_request)
+            "/machine/proc_stats", RequestType.GET, self._handle_stat_request
+        )
         self.server.register_event_handler(
-            "server:klippy_shutdown", self._handle_shutdown)
+            "server:klippy_shutdown", self._handle_shutdown
+        )
         self.server.register_notification("proc_stats:proc_stat_update")
         self.proc_stat_queue: Deque[Dict[str, Any]] = deque(maxlen=30)
         self.last_update_time = time.time()

--- a/moonraker/components/sensor.py
+++ b/moonraker/components/sensor.py
@@ -12,6 +12,7 @@ import logging
 from collections import defaultdict, deque
 from dataclasses import dataclass, replace
 from functools import partial
+from ..common import RequestType
 
 # Annotation imports
 from typing import (
@@ -180,17 +181,17 @@ class Sensors:
         # Register endpoints
         self.server.register_endpoint(
             "/server/sensors/list",
-            ["GET"],
+            RequestType.GET,
             self._handle_sensor_list_request,
         )
         self.server.register_endpoint(
             "/server/sensors/info",
-            ["GET"],
+            RequestType.GET,
             self._handle_sensor_info_request,
         )
         self.server.register_endpoint(
             "/server/sensors/measurements",
-            ["GET"],
+            RequestType.GET,
             self._handle_sensor_measurements_request,
         )
 

--- a/moonraker/components/simplyprint.py
+++ b/moonraker/components/simplyprint.py
@@ -17,7 +17,7 @@ import logging.handlers
 import tempfile
 from queue import SimpleQueue
 from ..loghelper import LocalQueueHandler
-from ..common import APITransport, WebRequest, JobEvent, KlippyState
+from ..common import APITransport, JobEvent, KlippyState
 from ..utils import json_wrapper as jsonw
 
 from typing import (
@@ -580,16 +580,9 @@ class SimplyPrint(APITransport):
         if not sub_objs:
             return
         # Create our own subscription rather than use the host sub
-        args = {'objects': sub_objs}
-        klippy: KlippyConnection
-        klippy = self.server.lookup_component("klippy_connection")
-        try:
-            resp: Dict[str, Dict[str, Any]] = await klippy.request(
-                WebRequest("objects/subscribe", args, transport=self)
-            )
-            status: Dict[str, Any] = resp.get("status", {})
-        except self.server.error:
-            status = {}
+        status: Dict[str, Any] = await self.klippy_apis.subscribe_from_transport(
+            sub_objs, self, default={}
+        )
         if status:
             logging.debug(f"SimplyPrint: Got Initial Status: {status}")
             self.printer_status = status

--- a/moonraker/components/simplyprint.py
+++ b/moonraker/components/simplyprint.py
@@ -17,7 +17,7 @@ import logging.handlers
 import tempfile
 from queue import SimpleQueue
 from ..loghelper import LocalQueueHandler
-from ..common import Subscribable, WebRequest, JobEvent, KlippyState
+from ..common import APITransport, WebRequest, JobEvent, KlippyState
 from ..utils import json_wrapper as jsonw
 
 from typing import (
@@ -58,7 +58,7 @@ PRE_SETUP_EVENTS = [
     "ping"
 ]
 
-class SimplyPrint(Subscribable):
+class SimplyPrint(APITransport):
     def __init__(self, config: ConfigHelper) -> None:
         self.server = config.get_server()
         self._logger = ProtoLogger(config)
@@ -585,7 +585,8 @@ class SimplyPrint(Subscribable):
         klippy = self.server.lookup_component("klippy_connection")
         try:
             resp: Dict[str, Dict[str, Any]] = await klippy.request(
-                WebRequest("objects/subscribe", args, conn=self))
+                WebRequest("objects/subscribe", args, transport=self)
+            )
             status: Dict[str, Any] = resp.get("status", {})
         except self.server.error:
             status = {}

--- a/moonraker/components/spoolman.py
+++ b/moonraker/components/spoolman.py
@@ -9,6 +9,7 @@ import asyncio
 import datetime
 import logging
 from typing import TYPE_CHECKING, Dict, Any
+from ..common import RequestType
 
 if TYPE_CHECKING:
     from typing import Optional
@@ -64,12 +65,12 @@ class SpoolManager:
     def _register_endpoints(self):
         self.server.register_endpoint(
             "/server/spoolman/spool_id",
-            ["GET", "POST"],
+            RequestType.GET | RequestType.POST,
             self._handle_spool_id_request,
         )
         self.server.register_endpoint(
             "/server/spoolman/proxy",
-            ["POST"],
+            RequestType.POST,
             self._proxy_spoolman_request,
         )
 
@@ -157,7 +158,7 @@ class SpoolManager:
                 self.extruded = 0
 
     async def _handle_spool_id_request(self, web_request: WebRequest):
-        if web_request.get_action() == "POST":
+        if web_request.get_request_type() == RequestType.POST:
             spool_id = web_request.get_int("spool_id", None)
             await self.set_active_spool(spool_id)
         # For GET requests we will simply return the spool_id

--- a/moonraker/components/update_manager/common.py
+++ b/moonraker/components/update_manager/common.py
@@ -9,7 +9,7 @@ import os
 import sys
 import copy
 import pathlib
-from enum import Enum
+from ...common import ExtendedEnum
 from ...utils import source_info
 from typing import (
     TYPE_CHECKING,
@@ -46,25 +46,13 @@ BASE_CONFIG: Dict[str, Dict[str, str]] = {
     }
 }
 
-class ExtEnum(Enum):
-    @classmethod
-    def from_string(cls, enum_name: str):
-        str_name = enum_name.upper()
-        for name, member in cls.__members__.items():
-            if name == str_name:
-                return cls(member.value)
-        raise ValueError(f"No enum member named {enum_name}")
-
-    def __str__(self) -> str:
-        return self._name_.lower()  # type: ignore
-
-class AppType(ExtEnum):
+class AppType(ExtendedEnum):
     NONE = 1
     WEB = 2
     GIT_REPO = 3
     ZIP = 4
 
-class Channel(ExtEnum):
+class Channel(ExtendedEnum):
     STABLE = 1
     BETA = 2
     DEV = 3

--- a/moonraker/components/update_manager/update_manager.py
+++ b/moonraker/components/update_manager/update_manager.py
@@ -17,6 +17,7 @@ from .git_deploy import GitDeploy
 from .zip_deploy import ZipDeploy
 from .system_deploy import PackageDeploy
 from .web_deploy import WebClientDeploy
+from ...common import RequestType
 
 # Annotation imports
 from typing import (
@@ -130,32 +131,32 @@ class UpdateManager:
                 self._handle_auto_refresh)
 
         self.server.register_endpoint(
-            "/machine/update/moonraker", ["POST"],
-            self._handle_update_request)
+            "/machine/update/moonraker", RequestType.POST, self._handle_update_request
+        )
         self.server.register_endpoint(
-            "/machine/update/klipper", ["POST"],
-            self._handle_update_request)
+            "/machine/update/klipper", RequestType.POST, self._handle_update_request
+        )
         self.server.register_endpoint(
-            "/machine/update/system", ["POST"],
-            self._handle_update_request)
+            "/machine/update/system", RequestType.POST, self._handle_update_request
+        )
         self.server.register_endpoint(
-            "/machine/update/client", ["POST"],
-            self._handle_update_request)
+            "/machine/update/client", RequestType.POST, self._handle_update_request
+        )
         self.server.register_endpoint(
-            "/machine/update/full", ["POST"],
-            self._handle_full_update_request)
+            "/machine/update/full", RequestType.POST, self._handle_full_update_request
+        )
         self.server.register_endpoint(
-            "/machine/update/status", ["GET"],
-            self._handle_status_request)
+            "/machine/update/status", RequestType.GET, self._handle_status_request
+        )
         self.server.register_endpoint(
-            "/machine/update/refresh", ["POST"],
-            self._handle_refresh_request)
+            "/machine/update/refresh", RequestType.POST, self._handle_refresh_request
+        )
         self.server.register_endpoint(
-            "/machine/update/recover", ["POST"],
-            self._handle_repo_recovery)
+            "/machine/update/recover", RequestType.POST, self._handle_repo_recovery
+        )
         self.server.register_endpoint(
-            "/machine/update/rollback", ["POST"],
-            self._handle_rollback)
+            "/machine/update/rollback", RequestType.POST, self._handle_rollback
+        )
         self.server.register_notification("update_manager:update_response")
         self.server.register_notification("update_manager:update_refreshed")
 

--- a/moonraker/components/wled.py
+++ b/moonraker/components/wled.py
@@ -16,6 +16,7 @@ import serial_asyncio
 from tornado.httpclient import AsyncHTTPClient
 from tornado.httpclient import HTTPRequest
 from ..utils import json_wrapper as jsonw
+from ..common import RequestType
 
 # Annotation imports
 from typing import (
@@ -388,23 +389,24 @@ class WLED:
         # As moonraker is about making things a web api, let's try it
         # Yes, this is largely a cut-n-paste from power.py
         self.server.register_endpoint(
-            "/machine/wled/strips", ["GET"],
-            self._handle_list_strips)
+            "/machine/wled/strips", RequestType.GET, self._handle_list_strips
+        )
         self.server.register_endpoint(
-            "/machine/wled/status", ["GET"],
-            self._handle_batch_wled_request)
+            "/machine/wled/status", RequestType.GET, self._handle_batch_wled_request
+        )
         self.server.register_endpoint(
-            "/machine/wled/on", ["POST"],
-            self._handle_batch_wled_request)
+            "/machine/wled/on", RequestType.POST, self._handle_batch_wled_request
+        )
         self.server.register_endpoint(
-            "/machine/wled/off", ["POST"],
-            self._handle_batch_wled_request)
+            "/machine/wled/off", RequestType.POST, self._handle_batch_wled_request
+        )
         self.server.register_endpoint(
-            "/machine/wled/toggle", ["POST"],
-            self._handle_batch_wled_request)
+            "/machine/wled/toggle", RequestType.POST, self._handle_batch_wled_request
+        )
         self.server.register_endpoint(
-            "/machine/wled/strip", ["GET", "POST"],
-            self._handle_single_wled_request)
+            "/machine/wled/strip", RequestType.GET | RequestType.POST,
+            self._handle_single_wled_request
+        )
 
     async def component_init(self) -> None:
         try:
@@ -521,19 +523,19 @@ class WLED:
         intensity: int = web_request.get_int('intensity', -1)
         speed: int = web_request.get_int('speed', -1)
 
-        req_action = web_request.get_action()
+        req_type = web_request.get_request_type()
         if strip_name not in self.strips:
             raise self.server.error(f"No valid strip named {strip_name}")
         strip = self.strips[strip_name]
-        if req_action == 'GET':
+        if req_type == RequestType.GET:
             return {strip_name: strip.get_strip_info()}
-        elif req_action == "POST":
+        elif req_type == RequestType.POST:
             action = web_request.get_str('action').lower()
             if action not in ["on", "off", "toggle", "control"]:
-                raise self.server.error(
-                    f"Invalid requested action '{action}'")
-            result = await self._process_request(strip, action, preset,
-                                                 brightness, intensity, speed)
+                raise self.server.error(f"Invalid requested action '{action}'")
+            result = await self._process_request(
+                strip, action, preset, brightness, intensity, speed
+            )
         return {strip_name: result}
 
     async def _handle_batch_wled_request(self: WLED,

--- a/moonraker/components/zeroconf.py
+++ b/moonraker/components/zeroconf.py
@@ -30,7 +30,6 @@ if TYPE_CHECKING:
     from ..confighelper import ConfigHelper
     from ..common import WebRequest
     from ..app import MoonrakerApp
-    from .authorization import Authorization
     from .machine import Machine
 
 ZC_SERVICE_TYPE = "_moonraker._tcp.local."
@@ -209,17 +208,14 @@ class SSDPServer(asyncio.protocols.DatagramProtocol):
         self.boot_id = int(eventloop.get_loop_time())
         self.config_id = 1
         self.ad_timer = eventloop.register_timer(self._advertise_presence)
-        auth: Optional[Authorization]
-        auth = self.server.load_component(config, "authorization", None)
-        if auth is not None:
-            auth.register_permited_path("/server/zeroconf/ssdp")
         self.server.register_endpoint(
             "/server/zeroconf/ssdp",
             RequestType.GET,
             self._handle_xml_request,
             transports=TransportType.HTTP,
             wrap_result=False,
-            content_type="application/xml"
+            content_type="application/xml",
+            auth_required=False
         )
 
     def _create_ssdp_socket(

--- a/moonraker/components/zeroconf.py
+++ b/moonraker/components/zeroconf.py
@@ -14,6 +14,7 @@ from itertools import cycle
 from email.utils import formatdate
 from zeroconf import IPVersion
 from zeroconf.asyncio import AsyncServiceInfo, AsyncZeroconf
+from ..common import RequestType, TransportType
 
 from typing import (
     TYPE_CHECKING,
@@ -214,9 +215,9 @@ class SSDPServer(asyncio.protocols.DatagramProtocol):
             auth.register_permited_path("/server/zeroconf/ssdp")
         self.server.register_endpoint(
             "/server/zeroconf/ssdp",
-            ["GET"],
+            RequestType.GET,
             self._handle_xml_request,
-            transports=["http"],
+            transports=TransportType.HTTP,
             wrap_result=False,
             content_type="application/xml"
         )

--- a/moonraker/klippy_connection.py
+++ b/moonraker/klippy_connection.py
@@ -14,7 +14,7 @@ import asyncio
 import pathlib
 from .utils import ServerError, get_unix_peer_credentials
 from .utils import json_wrapper as jsonw
-from .common import KlippyState
+from .common import KlippyState, RequestType
 
 # Annotation imports
 from typing import (
@@ -32,7 +32,6 @@ from typing import (
 )
 if TYPE_CHECKING:
     from .server import Server
-    from .app import MoonrakerApp
     from .common import WebRequest, Subscribable, BaseRemoteConnection
     from .confighelper import ConfigHelper
     from .components.klippy_apis import KlippyAPI
@@ -352,10 +351,12 @@ class KlippyConnection:
         if result is None:
             return
         endpoints = result.get('endpoints', [])
-        app: MoonrakerApp = self.server.lookup_component("application")
         for ep in endpoints:
             if ep not in RESERVED_ENDPOINTS:
-                app.register_remote_handler(ep)
+                self.server.register_endpoint(
+                    ep, RequestType.GET | RequestType.POST, self.request,
+                    is_remote=True
+                )
 
     async def _request_initial_subscriptions(self) -> None:
         try:

--- a/moonraker/klippy_connection.py
+++ b/moonraker/klippy_connection.py
@@ -32,7 +32,7 @@ from typing import (
 )
 if TYPE_CHECKING:
     from .server import Server
-    from .common import WebRequest, Subscribable, BaseRemoteConnection
+    from .common import WebRequest, APITransport, BaseRemoteConnection
     from .confighelper import ConfigHelper
     from .components.klippy_apis import KlippyAPI
     from .components.file_manager.file_manager import FileManager
@@ -80,7 +80,7 @@ class KlippyConnection:
         self.init_attempts: int = 0
         self._state: KlippyState = KlippyState.DISCONNECTED
         self._state.set_message("Klippy Disconnected")
-        self.subscriptions: Dict[Subscribable, Subscription] = {}
+        self.subscriptions: Dict[APITransport, Subscription] = {}
         self.subscription_cache: Dict[str, Dict[str, Any]] = {}
         # Setup remote methods accessable to Klippy.  Note that all
         # registered remote methods should be of the notification type,
@@ -657,7 +657,7 @@ class KlippyConnection:
         finally:
             self.pending_requests.pop(base_request.id, None)
 
-    def remove_subscription(self, conn: Subscribable) -> None:
+    def remove_subscription(self, conn: APITransport) -> None:
         self.subscriptions.pop(conn, None)
 
     def is_connected(self) -> bool:

--- a/moonraker/loghelper.py
+++ b/moonraker/loghelper.py
@@ -12,6 +12,7 @@ import os
 import sys
 import asyncio
 from queue import SimpleQueue as Queue
+from .common import RequestType
 
 # Annotation imports
 from typing import (
@@ -112,7 +113,7 @@ class LogManager:
     def set_server(self, server: Server) -> None:
         self.server = server
         self.server.register_endpoint(
-            "/server/logs/rollover", ['POST'], self._handle_log_rollover
+            "/server/logs/rollover", RequestType.POST, self._handle_log_rollover
         )
 
     def set_rollover_info(self, name: str, item: str) -> None:

--- a/moonraker/server.py
+++ b/moonraker/server.py
@@ -92,8 +92,8 @@ class Server:
 
         # Tornado Application/Server
         self.moonraker_app = app = MoonrakerApp(config)
-        self.register_endpoint = app.register_local_handler
-        self.register_debug_endpoint = app.register_debug_handler
+        self.register_endpoint = app.register_endpoint
+        self.register_debug_endpoint = app.register_debug_endpoint
         self.register_static_file_handler = app.register_static_file_handler
         self.register_upload_handler = app.register_upload_handler
         self.register_api_transport = app.register_api_transport

--- a/moonraker/server.py
+++ b/moonraker/server.py
@@ -368,9 +368,6 @@ class Server:
     def get_klippy_info(self) -> Dict[str, Any]:
         return self.klippy_connection.klippy_info
 
-    def get_klippy_state(self) -> str:
-        return self.klippy_connection.state
-
     def _handle_term_signal(self) -> None:
         logging.info("Exiting with signal SIGTERM")
         self.event_loop.register_callback(self._stop_server, "terminate")
@@ -447,7 +444,7 @@ class Server:
             ]
         return {
             'klippy_connected': self.klippy_connection.is_connected(),
-            'klippy_state': self.klippy_connection.state,
+            'klippy_state': str(self.klippy_connection.state),
             'components': list(self.components.keys()),
             'failed_components': self.failed_components,
             'registered_directories': reg_dirs,

--- a/moonraker/server.py
+++ b/moonraker/server.py
@@ -25,6 +25,7 @@ from .app import MoonrakerApp
 from .klippy_connection import KlippyConnection
 from .utils import ServerError, Sentinel, get_software_info, json_wrapper
 from .loghelper import LogManager
+from .common import RequestType
 
 # Annotation imports
 from typing import (
@@ -102,11 +103,14 @@ class Server:
             self.add_warning(warning)
 
         self.register_endpoint(
-            "/server/info", ['GET'], self._handle_info_request)
+            "/server/info", RequestType.GET, self._handle_info_request
+        )
         self.register_endpoint(
-            "/server/config", ['GET'], self._handle_config_request)
+            "/server/config", RequestType.GET, self._handle_config_request
+        )
         self.register_endpoint(
-            "/server/restart", ['POST'], self._handle_server_restart)
+            "/server/restart", RequestType.POST, self._handle_server_restart
+        )
         self.register_notification("server:klippy_ready")
         self.register_notification("server:klippy_shutdown")
         self.register_notification("server:klippy_disconnect",

--- a/moonraker/utils/__init__.py
+++ b/moonraker/utils/__init__.py
@@ -19,6 +19,7 @@ import re
 import struct
 import socket
 import enum
+import ipaddress
 from . import source_info
 from . import json_wrapper
 
@@ -39,6 +40,7 @@ if TYPE_CHECKING:
 
 SYS_MOD_PATHS = glob.glob("/usr/lib/python3*/dist-packages")
 SYS_MOD_PATHS += glob.glob("/usr/lib/python3*/site-packages")
+IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
 
 class ServerError(Exception):
     def __init__(self, message: str, status_code: int = 400) -> None:
@@ -264,3 +266,9 @@ def pretty_print_time(seconds: int) -> str:
             continue
         fmt_list.append(f"{val} {ident}" if val == 1 else f"{val} {ident}s")
     return ", ".join(fmt_list)
+
+def parse_ip_address(address: str) -> Optional[IPAddress]:
+    try:
+        return ipaddress.ip_address(address)
+    except Exception:
+        return None

--- a/moonraker/websockets.py
+++ b/moonraker/websockets.py
@@ -57,7 +57,7 @@ class WebsocketManager:
         )
         self.server.register_endpoint(
             "/server/connection/identify", RequestType.POST, self._handle_identify,
-            TransportType.WEBSOCKET
+            TransportType.WEBSOCKET, auth_required=False
         )
         self.server.register_component("websockets", self)
 
@@ -321,7 +321,7 @@ class WebSocket(WebSocketHandler, BaseRemoteConnection):
         auth: AuthComp = self.server.lookup_component('authorization', None)
         if auth is not None:
             try:
-                self._user_info = auth.check_authorized(self.request)
+                self._user_info = auth.authenticate_request(self.request)
             except Exception as e:
                 logging.info(f"Websocket Failed Authentication: {e}")
                 self._user_info = None
@@ -461,7 +461,7 @@ class BridgeSocket(WebSocketHandler):
             )
         auth: AuthComp = self.server.lookup_component("authorization", None)
         if auth is not None:
-            self.current_user = auth.check_authorized(self.request)
+            self.current_user = auth.authenticate_request(self.request)
         kconn: Klippy = self.server.lookup_component("klippy_connection")
         try:
             reader, writer = await kconn.open_klippy_connection()


### PR DESCRIPTION
This pull request represents significant refactoring of some of Moonraker's internals.  The goal is to prepare Moonraker for future additions such as:

- Support for managing multiple connections to Klippy from one instance of moonraker
- Support for 3rd party extensions

An overview of the items changed:

1) Use Python enums and flags in place of strings where appropriate.  This includes HTTP request methods (ie: GET, POST), tranport types (HTTP, WEBSOCKET, etc), Klippy State, and Job State.

2) Emit a single internal event for job state changes.  The legacy events remain in place for now.

3) Optimize endpoint registration to use shared API Definitions for all transports.  Previously 

4) Use a single instance of the JsonRPC class across all transports.

I have been testing this branch for a few weeks and believe that I have squashed any outstanding issues/regressions.  That said, I only test against official Moonraker components.  Developers and users who use optional components such as timelapse may wish to test this branch. 

As of right now I intent to merge around the end of the week, presuming no regressions are discovered.