### PR TITLE
allow specifying HTTP port for Zigbee/Hue

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1266,6 +1266,10 @@ The following options are available for `hue` device types:
 address:
 #   A valid ip address or hostname of the Philips Hue Bridge. This
 #   parameter must be provided.
+port:
+#   A port number if an alternative Zigbee bridge is used on a HTTP port 
+#   different from the default 80/443
+#   
 user:
 #   The api key used for request authorization.  This option accepts
 #   Jinja2 Templates, see the [secrets] section for details.

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -1373,7 +1373,7 @@ class MQTTDevice(PowerDevice):
 class HueDevice(HTTPDevice):
 
     def __init__(self, config: ConfigHelper) -> None:
-        super().__init__(config)
+        super().__init__(config, default_port=80)
         self.device_id = config.get("device_id")
         self.device_type = config.get("device_type", "light")
         if self.device_type == "group":
@@ -1386,7 +1386,7 @@ class HueDevice(HTTPDevice):
     async def _send_power_request(self, state: str) -> str:
         new_state = True if state == "on" else False
         url = (
-            f"{self.protocol}://{quote(self.addr)}/api/{quote(self.user)}"
+            f"{self.protocol}://{quote(self.addr)}:{self.port}/api/{quote(self.user)}"
             f"/{self.device_type}s/{quote(self.device_id)}"
             f"/{quote(self.state_key)}"
         )
@@ -1402,7 +1402,7 @@ class HueDevice(HTTPDevice):
 
     async def _send_status_request(self) -> str:
         url = (
-            f"{self.protocol}://{quote(self.addr)}/api/{quote(self.user)}"
+            f"{self.protocol}://{quote(self.addr)}:{self.port}/api/{quote(self.user)}"
             f"/{self.device_type}s/{quote(self.device_id)}"
         )
         ret = await self.client.request("GET", url)


### PR DESCRIPTION
Some alternative Zigbee bridges (i.e. Phoscon) might be running on non-standard HTTP ports. This PR allows specifying a HTTP port so you can still use the Hue integration for these devices also. 

Committer: wollew