### PR TITLE
Fix if spoolman spool is missing

### DIFF
--- a/moonraker/components/spoolman.py
+++ b/moonraker/components/spoolman.py
@@ -195,7 +195,14 @@ class SpoolManager:
             url=full_url,
             body=body,
         )
-        response.raise_for_status()
+
+        if (response._code == 404
+                and self.spool_id is not None
+                and dict(response.json()).get("message")
+                == ("No spool with ID %d found." % self.spool_id)):
+            await self.set_active_spool(None)
+        else:
+            response.raise_for_status()
 
         return response.json()
 


### PR DESCRIPTION
Currently if the last selected spool gets deleted from the spoolman database, the spoolman component fails to load. This fix sets the selected spool to None if that happens so the component can load