### PR TITLE
machine: add support for peripheral requests

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.11"
 
 mkdocs:
   configuration: mkdocs.yml

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog].
 - **build**: Added support for optional speedup dependencies `uvloop` and `msgspec`
 - **update_manager**: Added support for "zipped" application updates
 - **file_manager**: Added `enable_config_write_access` option
+- **machine**: Add support for system peripheral queries
 
 ### Fixed
 

--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,3 +1,2 @@
-mkdocs==1.5.3
-pymdown-extensions==10.7
+mkdocs-material==9.5.4
 compact_tables@git+https://github.com/Arksine/markdown-compact-tables@v1.0.0

--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,2 +1,3 @@
-mkdocs==1.4.2
-pymdown-extensions==10.0
+mkdocs==1.5.3
+pymdown-extensions==10.7
+compact_tables@git+https://github.com/Arksine/markdown-compact-tables@v1.0.0

--- a/docs/src/css/extras.css
+++ b/docs/src/css/extras.css
@@ -1,0 +1,7 @@
+[data-md-color-scheme="slate"] {
+    --md-table-color: rgb(20, 20, 20);
+}
+
+thead th {
+    background-color: var(--md-table-color)
+}

--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -1219,7 +1219,7 @@ Returns:
 
 `ok`
 
-### Machine Commands
+### Machine Requests
 
 #### Get System Info
 HTTP request:
@@ -1692,6 +1692,537 @@ An object in the following format:
 
 This request will return an error if the supplied password is
 incorrect or if any pending sudo requests fail.
+
+#### List USB Devices
+
+Returns a list of all USB devices currently detected on the system.
+
+HTTP request:
+```http
+GET /machine/peripherals/usb
+```
+
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "machine.peripherals.usb",
+    "id": 7896
+}
+```
+
+Returns:
+
+An object containing a list of attached USB device info:
+
+```json
+{
+    "usb_devices": [
+        {
+            "device_num": 1,
+            "bus_num": 1,
+            "vendor_id": "1d6b",
+            "product_id": "0002",
+            "usb_location": "1:1",
+            "manufacturer": "Linux 6.1.0-rpi7-rpi-v8 dwc_otg_hcd",
+            "product": "DWC OTG Controller",
+            "serial": "3f980000.usb",
+            "class": "Hub",
+            "subclass": null,
+            "protocol": "Single TT",
+            "description": "Linux Foundation 2.0 root hub"
+        },
+        {
+            "device_num": 3,
+            "bus_num": 1,
+            "vendor_id": "046d",
+            "product_id": "0825",
+            "usb_location": "1:3",
+            "manufacturer": "Logitech, Inc.",
+            "product": "Webcam C270",
+            "serial": "<unique serial number>",
+            "class": "Miscellaneous Device",
+            "subclass": null,
+            "protocol": "Interface Association",
+            "description": "Logitech, Inc. Webcam C270"
+        },
+        {
+            "device_num": 2,
+            "bus_num": 1,
+            "vendor_id": "1a40",
+            "product_id": "0101",
+            "usb_location": "1:2",
+            "manufacturer": "Terminus Technology Inc.",
+            "product": "USB 2.0 Hub",
+            "serial": null,
+            "class": "Hub",
+            "subclass": null,
+            "protocol": "Single TT",
+            "description": "Terminus Technology Inc. Hub"
+        },
+        {
+            "device_num": 5,
+            "bus_num": 1,
+            "vendor_id": "0403",
+            "product_id": "6001",
+            "usb_location": "1:5",
+            "manufacturer": "FTDI",
+            "product": "FT232R USB UART",
+            "serial": "<unique serial number>",
+            "class": null,
+            "subclass": null,
+            "protocol": null,
+            "description": "Future Technology Devices International, Ltd FT232 Serial (UART) IC"
+        },
+        {
+            "device_num": 4,
+            "bus_num": 1,
+            "vendor_id": "1d50",
+            "product_id": "614e",
+            "usb_location": "1:4",
+            "manufacturer": "Klipper",
+            "product": "stm32f407xx",
+            "serial": "<unique serial number>",
+            "class": "Communications",
+            "subclass": null,
+            "protocol": null,
+            "description": "OpenMoko, Inc. Klipper 3d-Printer Firmware"
+        }
+    ]
+}
+```
+
+Response Schema:
+
+| Field         | Type  | Description                                            |
+| ------------- | :---: | ------------------------------------------------------ |
+| `usb_devices` | array | An array of objects containing USB device information. |
+
+USB Device Schema:
+
+| Field          |  Type   | Description                                         |
+| -------------- | :-----: | --------------------------------------------------- |
+| `bus_num`      |   int   | The USB bus number as reported by the host.         |
+| `device_num`   |   int   | The USB device number as reported by the host.      |
+| `usb_location` | string  | A combination of the bus number and device number,  |
+|                |         | yielding a unique location ID on the host system.   |^
+| `vendor_id`    | string  | The vendor ID as reported by the driver.            |
+| `product_id`   | string  | The product ID as reported by the driver.           |
+| `manufacturer` | string? | The manufacturer name as reported by the driver.    |
+|                |         | This will be `null` if no manufacturer is found.    |^
+| `product`      | string? | The product description as reported by the driver.  |
+|                |         | This will be `null` if no description is found.     |^
+| `class`        | string? | The class description as reported by the driver.    |
+|                |         | This will be `null` if no description is found.     |^
+| `subclass`     | string? | The subclass description as reported by the driver. |
+|                |         | This will be `null` if no description is found.     |^
+| `protocol`     | string? | The protocol description as reported by the driver. |
+|                |         | This will be `null` if no description is found.     |^
+| `description`  | string? | The full device description string as reported by   |
+|                |         | the usb.ids file. This will be `null` if no         |^
+|                |         | description is found.                               |^
+
+#### List Serial Devices
+
+Returns a list of all serial devices detected on the system.  These may be USB
+CDC-ACM devices or hardware UARTs.
+
+HTTP request:
+```http
+GET /machine/peripherals/serial
+```
+
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "machine.peripherals.serial",
+    "id": 7896
+}
+```
+
+Returns:
+
+```json
+{
+    "serial_devices": [
+        {
+            "device_type": "hardware_uart",
+            "device_path": "/dev/ttyS0",
+            "device_name": "ttyS0",
+            "driver_name": "serial8250",
+            "path_by_hardware": null,
+            "path_by_id": null,
+            "usb_location": null
+        },
+        {
+            "device_type": "usb",
+            "device_path": "/dev/ttyACM0",
+            "device_name": "ttyACM0",
+            "driver_name": "cdc_acm",
+            "path_by_hardware": "/dev/serial/by-path/platform-3f980000.usb-usb-0:1.2:1.0",
+            "path_by_id": "/dev/serial/by-id/usb-Klipper_stm32f407xx_unique_serial-if00",
+            "usb_location": "1:4"
+        },
+        {
+            "device_type": "usb",
+            "device_path": "/dev/ttyUSB0",
+            "device_name": "ttyUSB0",
+            "driver_name": "ftdi_sio",
+            "path_by_hardware": "/dev/serial/by-path/platform-3f980000.usb-usb-0:1.4:1.0-port0",
+            "path_by_id": "/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_unique_serial-if00-port0",
+            "usb_location": "1:5"
+        },
+        {
+            "device_type": "hardware_uart",
+            "device_path": "/dev/ttyAMA0",
+            "device_name": "ttyAMA0",
+            "driver_name": "uart-pl011",
+            "path_by_hardware": null,
+            "path_by_id": null,
+            "usb_location": null
+        }
+    ]
+}
+```
+
+Response Schema:
+
+| Field            | Type  | Description                                               |
+| ---------------- | ----- | --------------------------------------------------------- |
+| `serial_devices` | array | An array of objects containing serial device information. |
+
+
+Serial Device Schema:
+
+| Field              |  Type   | Description                                                         |
+| ------------------ | :-----: | ------------------------------------------------------------------- |
+| `device_type`      | string  | The type of serial device. Can be `hardware_uart` or `usb`.         |
+| `device_path`      | string  | The absolute file path to the device.                               |
+| `device_name`      | string  | The device file name as reported by sysfs.                          |
+| `driver_name`      | string  | The name of the device driver.                                      |
+| `path_by_hardware` | string? | A symbolic link to the device based on its physical connection,     |
+|                    |         | ie: usb port.  Will be `null` if no matching link exists.           |^
+| `path_by_id`       | string? | A symbolic link the the device based on its reported IDs. Will be   |
+|                    |         | `null` if no matching link exists.                                  |^
+| `usb_location`     | string? | An identifier derived from the reported usb bus and device numbers. |
+|                    |         | Can be used to match results from `/machine/peripherals/usb`. Will  |^
+|                    |         | be `null` for non-usb devices.                                      |^
+
+
+#### List Video Capture Devices
+
+Retrieves a list of V4L2 video capture devices on the system.  If
+the python3-libcamera system package is installed this request will
+also return libcamera devices.
+
+```http
+GET /machine/peripherals/video
+```
+
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "machine.peripherals.video",
+    "id": 7896
+}
+```
+
+Returns:
+
+```json
+{
+    "v4l2_devices": [
+        {
+            "device_name": "video0",
+            "device_path": "/dev/video0",
+            "camera_name": "unicam",
+            "driver_name": "unicam",
+            "hardware_bus": "platform:3f801000.csi",
+            "capabilities": [
+                "VIDEO_CAPTURE",
+                "EXT_PIX_FORMAT",
+                "READWRITE",
+                "STREAMING",
+                "IO_MC"
+            ],
+            "version": "6.1.63",
+            "path_by_hardware": "/dev/v4l/by-path/platform-3f801000.csi-video-index0",
+            "path_by_id": null,
+            "alt_name": "unicam-image",
+            "usb_location": null
+        },
+        {
+            "device_name": "video1",
+            "device_path": "/dev/video1",
+            "camera_name": "UVC Camera (046d:0825)",
+            "driver_name": "uvcvideo",
+            "hardware_bus": "usb-3f980000.usb-1.1",
+            "capabilities": [
+                "VIDEO_CAPTURE",
+                "EXT_PIX_FORMAT",
+                "STREAMING"
+            ],
+            "version": "6.1.63",
+            "path_by_hardware": "/dev/v4l/by-path/platform-3f980000.usb-usb-0:1.1:1.0-video-index0",
+            "path_by_id": "/dev/v4l/by-id/usb-046d_0825_66EF0390-video-index0",
+            "alt_name": "UVC Camera (046d:0825)",
+            "usb_location": "1:3"
+        },
+        {
+            "device_name": "video14",
+            "device_path": "/dev/video14",
+            "camera_name": "bcm2835-isp",
+            "driver_name": "bcm2835-isp",
+            "hardware_bus": "platform:bcm2835-isp",
+            "capabilities": [
+                "VIDEO_CAPTURE",
+                "EXT_PIX_FORMAT",
+                "STREAMING"
+            ],
+            "version": "6.1.63",
+            "path_by_hardware": null,
+            "path_by_id": null,
+            "alt_name": "bcm2835-isp-capture0",
+            "usb_location": null
+        },
+        {
+            "device_name": "video15",
+            "device_path": "/dev/video15",
+            "camera_name": "bcm2835-isp",
+            "driver_name": "bcm2835-isp",
+            "hardware_bus": "platform:bcm2835-isp",
+            "capabilities": [
+                "VIDEO_CAPTURE",
+                "EXT_PIX_FORMAT",
+                "STREAMING"
+            ],
+            "version": "6.1.63",
+            "path_by_hardware": null,
+            "path_by_id": null,
+            "alt_name": "bcm2835-isp-capture1",
+            "usb_location": null
+        },
+        {
+            "device_name": "video21",
+            "device_path": "/dev/video21",
+            "camera_name": "bcm2835-isp",
+            "driver_name": "bcm2835-isp",
+            "hardware_bus": "platform:bcm2835-isp",
+            "capabilities": [
+                "VIDEO_CAPTURE",
+                "EXT_PIX_FORMAT",
+                "STREAMING"
+            ],
+            "version": "6.1.63",
+            "path_by_hardware": "/dev/v4l/by-path/platform-bcm2835-isp-video-index1",
+            "path_by_id": null,
+            "alt_name": "bcm2835-isp-capture0",
+            "usb_location": null
+        },
+        {
+            "device_name": "video22",
+            "device_path": "/dev/video22",
+            "camera_name": "bcm2835-isp",
+            "driver_name": "bcm2835-isp",
+            "hardware_bus": "platform:bcm2835-isp",
+            "capabilities": [
+                "VIDEO_CAPTURE",
+                "EXT_PIX_FORMAT",
+                "STREAMING"
+            ],
+            "version": "6.1.63",
+            "path_by_hardware": "/dev/v4l/by-path/platform-bcm2835-isp-video-index2",
+            "path_by_id": null,
+            "alt_name": "bcm2835-isp-capture1",
+            "usb_location": null
+        }
+    ],
+    "libcamera_devices": [
+        {
+            "libcamera_id": "/base/soc/i2c0mux/i2c@1/ov5647@36",
+            "model": "ov5647",
+            "modes": [
+                {
+                    "format": "SGBRG10_CSI2P",
+                    "resolutions": [
+                        "640x480",
+                        "1296x972",
+                        "1920x1080",
+                        "2592x1944"
+                    ]
+                }
+            ]
+        },
+        {
+            "libcamera_id": "/base/soc/usb@7e980000/usb-port@1/usb-port@1-1.1:1.0-046d:0825",
+            "model": "UVC Camera (046d:0825)",
+            "modes": [
+                {
+                    "format": "MJPEG",
+                    "resolutions": [
+                        "160x120",
+                        "176x144",
+                        "320x176",
+                        "320x240",
+                        "352x288",
+                        "432x240",
+                        "544x288",
+                        "640x360",
+                        "640x480",
+                        "752x416",
+                        "800x448",
+                        "864x480",
+                        "800x600",
+                        "960x544",
+                        "1024x576",
+                        "960x720",
+                        "1184x656",
+                        "1280x720",
+                        "1280x960"
+                    ]
+                },
+                {
+                    "format": "YUYV",
+                    "resolutions": [
+                        "160x120",
+                        "176x144",
+                        "320x176",
+                        "320x240",
+                        "352x288",
+                        "432x240",
+                        "544x288",
+                        "640x360",
+                        "640x480",
+                        "752x416",
+                        "800x448",
+                        "864x480",
+                        "800x600",
+                        "960x544",
+                        "1024x576",
+                        "960x720",
+                        "1184x656",
+                        "1280x720",
+                        "1280x960"
+                    ]
+                }
+            ]
+        }
+    ]
+}
+```
+
+Response Schema:
+
+| Field               | Type  | Description                           |
+| ------------------- | :---: | ------------------------------------- |
+| `v4l2_devices`      | array | An array of V4L2 Device objects.      |
+| `libcamera_devices` | array | An array of Libcamera Device objects. |
+
+V4L2 Device Schema:
+
+| Field              |  Type   | Description                                              |
+| ------------------ | :-----: | -------------------------------------------------------- |
+| `device_name`      | string  | The V4L2 name assigned to the device.  This is typically |
+|                    |         | the name of the file associated with the device.         |^
+| `device_path`      | string  | The absolute system path to the device file.             |
+| `camera_name`      | string  | The camera name reported by the device driver.           |
+| `driver_name`      | string  | The name of the driver loaded for the device.            |
+| `alt_name`         | string? | An alternative device name optionally reported by        |
+|                    |         | sysfs.  Will be `null` if the name file does not exist.  |^
+| `hardware_bus`     | string  | A description of the hardware location of the device     |
+| `capabilities`     |  array  | An array of strings indicating the capabilities the      |
+|                    |         | device supports as reported by V4L2.                     |^
+| `version`          | string  | The device version as reported by V4L2.                  |
+| `path_by_hardware` | string? | A symbolic link to the device based on its physical      |
+|                    |         | connection, ie: usb port.. Will be  `null` if no         |^
+|                    |         | matching link exists.                                    |^
+| `path_by_id`       | string? | A symbolic link the the device based on its reported     |
+|                    |         | ID. Will be  `null` if no matching link exists.          |^
+| `usb_location`     | string? | An identifier derived from the reported usb bus and      |
+|                    |         | device numbers. Will be `null` for non-usb devices.      |^
+
+Libcamera Device Schema:
+
+| Field          |  Type  | Description                                             |
+| -------------- | :----: | ------------------------------------------------------- |
+| `libcamera_id` | string | The ID of the device as reported by libcamera.          |
+| `model`        | string | The model name of the device.                           |
+| `modes`        | array  | An array of `Libcamera Mode` objects, each describing a |
+|                |        | mode supported by the device.                           |^
+
+Libcamera Mode Schema:
+
+| Field         |  Type  | Description                                                 |
+| ------------- | :----: | ----------------------------------------------------------- |
+| `format`      | string | The pixel format of the mode.                               |
+| `resolutions` | array  | An array of strings describing the resolutions supported by |
+|               |        | the mode.  Each entry is reported as `<WIDTH>x<HEIGHT>`     |^
+
+#### Query Unassigned Canbus UUIDs
+
+Queries the provided canbus interface for unassigned Klipper or Katapult
+node IDs.
+
+!!! Warning
+    It is recommended that frontends provide users with an explanation
+    of how UUID queries work and the potential pitfalls when querying
+    a bus with multiple unassigned nodes.  An "unassigned" node is a
+    CAN node that has not been activated by Katapult or Klipper.  If
+    either Klipper or Katapult has connected to the node, it will be
+    assigned a Node ID and therefore will no longer respond to queries.
+    A device reset is required to remove the assignment.
+
+    When multiple unassigned nodes are on the network, each responds to
+    the query at roughly the same time.  This results in arbitration
+    errors.  Nodes will retry the send until the response reports success.
+    However, nodes track the count of arbitration errors, and once a
+    specific threshold is reached they will go into a "bus off" state. A
+    device reset is required to reset the counter and recover from "bus off".
+
+    For this reason, it is recommended that users only issue a query when
+    a single unassigned node is on the network.  If a user does wish to
+    query multiple unassigned nodes it is vital that they reset all nodes
+    on the network before running Klipper.
+
+HTTP Request:
+```http
+GET /machine/peripherals/canbus?interface=can0
+```
+
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "machine.peripherals.canbus",
+    "params": {
+        "interface": "can0"
+    },
+    "id": 7896
+}
+```
+
+Parameters:
+
+| Name        |  Type  | Description                                           |
+| ----------- | :----: | ----------------------------------------------------- |
+| `interface` | string | The cansocket interface to query.  Default is `can0`. |
+
+Returns:
+
+```json
+{
+    "can_uuids": ["11AABBCCDD"]
+}
+```
+
+Response Schema:
+
+| Field       | Type  | Description                                               |
+| ----------- | :---: | --------------------------------------------------------- |
+| `can_uuids` | array | An array of discovered UUIDs as strings.  If no UUIDS are |
+|             |       | found the result is an empty array.                       |^
 
 ### File Operations
 
@@ -5335,7 +5866,7 @@ An object containing all measurements for every configured sensor:
 ### Spoolman APIs
 The following APIs are available to interact with the Spoolman integration:
 
-### Get Spoolman Status
+#### Get Spoolman Status
 Returns the current status of the spoolman module.
 
 HTTP request:

--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -1697,13 +1697,11 @@ incorrect or if any pending sudo requests fail.
 
 Returns a list of all USB devices currently detected on the system.
 
-HTTP request:
-```http
+```http title="HTTP Request"
 GET /machine/peripherals/usb
 ```
 
-JSON-RPC request:
-```json
+```json title="JSON-RPC Request"
 {
     "jsonrpc": "2.0",
     "method": "machine.peripherals.usb",
@@ -1711,10 +1709,7 @@ JSON-RPC request:
 }
 ```
 
-Returns:
-
-An object containing a list of attached USB device info:
-
+/// api-example-response
 ```json
 {
     "usb_devices": [
@@ -1791,14 +1786,18 @@ An object containing a list of attached USB device info:
     ]
 }
 ```
+///
 
-Response Schema:
+/// api-response-schema
+    open: True
+Response
 
 | Field         | Type  | Description                                            |
 | ------------- | :---: | ------------------------------------------------------ |
 | `usb_devices` | array | An array of objects containing USB device information. |
 
-USB Device Schema:
+
+ USB Device
 
 | Field          |  Type   | Description                                         |
 | -------------- | :-----: | --------------------------------------------------- |
@@ -1821,19 +1820,18 @@ USB Device Schema:
 | `description`  | string? | The full device description string as reported by   |
 |                |         | the usb.ids file. This will be `null` if no         |^
 |                |         | description is found.                               |^
+///
 
 #### List Serial Devices
 
 Returns a list of all serial devices detected on the system.  These may be USB
 CDC-ACM devices or hardware UARTs.
 
-HTTP request:
-```http
+```http title="HTTP Request"
 GET /machine/peripherals/serial
 ```
 
-JSON-RPC request:
-```json
+```json title="JSON-RPC Request"
 {
     "jsonrpc": "2.0",
     "method": "machine.peripherals.serial",
@@ -1841,8 +1839,7 @@ JSON-RPC request:
 }
 ```
 
-Returns:
-
+/// api-example-response
 ```json
 {
     "serial_devices": [
@@ -1885,30 +1882,35 @@ Returns:
     ]
 }
 ```
+///
 
-Response Schema:
+/// api-response-schema
+    open: True
+Response
 
 | Field            | Type  | Description                                               |
 | ---------------- | ----- | --------------------------------------------------------- |
 | `serial_devices` | array | An array of objects containing serial device information. |
 
 
-Serial Device Schema:
+Serial Device
 
-| Field              |  Type   | Description                                                         |
-| ------------------ | :-----: | ------------------------------------------------------------------- |
-| `device_type`      | string  | The type of serial device. Can be `hardware_uart` or `usb`.         |
-| `device_path`      | string  | The absolute file path to the device.                               |
-| `device_name`      | string  | The device file name as reported by sysfs.                          |
-| `driver_name`      | string  | The name of the device driver.                                      |
-| `path_by_hardware` | string? | A symbolic link to the device based on its physical connection,     |
-|                    |         | ie: usb port.  Will be `null` if no matching link exists.           |^
-| `path_by_id`       | string? | A symbolic link the the device based on its reported IDs. Will be   |
-|                    |         | `null` if no matching link exists.                                  |^
-| `usb_location`     | string? | An identifier derived from the reported usb bus and device numbers. |
-|                    |         | Can be used to match results from `/machine/peripherals/usb`. Will  |^
-|                    |         | be `null` for non-usb devices.                                      |^
-
+| Field              |  Type   | Description                                                 |
+| ------------------ | :-----: | ----------------------------------------------------------- |
+| `device_type`      | string  | The type of serial device. Can be `hardware_uart` or `usb`. |
+| `device_path`      | string  | The absolute file path to the device.                       |
+| `device_name`      | string  | The device file name as reported by sysfs.                  |
+| `driver_name`      | string  | The name of the device driver.                              |
+| `path_by_hardware` | string? | A symbolic link to the device based on its physical         |
+|                    |         | connection, ie: usb port.  Will be `null` if no             |^
+|                    |         | matching link exists.                                       |^
+| `path_by_id`       | string? | A symbolic link the the device based on its reported IDs.   |
+|                    |         | Will be `null` if no matching link exists.                  |^
+| `usb_location`     | string? | An identifier derived from the reported usb bus and .       |
+|                    |         | device numbers Can be used to match results from            |^
+|                    |         | `/machine/peripherals/usb`. Will be `null` for non-usb      |^
+|                    |         | devices.                                                    |^
+///
 
 #### List Video Capture Devices
 
@@ -1916,12 +1918,11 @@ Retrieves a list of V4L2 video capture devices on the system.  If
 the python3-libcamera system package is installed this request will
 also return libcamera devices.
 
-```http
+```http title="HTTP Request"
 GET /machine/peripherals/video
 ```
 
-JSON-RPC request:
-```json
+```json title="JSON-RPC Request"
 {
     "jsonrpc": "2.0",
     "method": "machine.peripherals.video",
@@ -1929,8 +1930,7 @@ JSON-RPC request:
 }
 ```
 
-Returns:
-
+/// api-example-response
 ```json
 {
     "v4l2_devices": [
@@ -2112,15 +2112,18 @@ Returns:
     ]
 }
 ```
+///
 
-Response Schema:
+/// api-response-schema
+    open: True
+Response
 
 | Field               | Type  | Description                           |
 | ------------------- | :---: | ------------------------------------- |
 | `v4l2_devices`      | array | An array of V4L2 Device objects.      |
 | `libcamera_devices` | array | An array of Libcamera Device objects. |
 
-V4L2 Device Schema:
+V4L2 Device
 
 | Field              |  Type   | Description                                              |
 | ------------------ | :-----: | -------------------------------------------------------- |
@@ -2143,7 +2146,7 @@ V4L2 Device Schema:
 | `usb_location`     | string? | An identifier derived from the reported usb bus and      |
 |                    |         | device numbers. Will be `null` for non-usb devices.      |^
 
-Libcamera Device Schema:
+Libcamera Device
 
 | Field          |  Type  | Description                                             |
 | -------------- | :----: | ------------------------------------------------------- |
@@ -2152,13 +2155,14 @@ Libcamera Device Schema:
 | `modes`        | array  | An array of `Libcamera Mode` objects, each describing a |
 |                |        | mode supported by the device.                           |^
 
-Libcamera Mode Schema:
+Libcamera Mode
 
 | Field         |  Type  | Description                                                 |
 | ------------- | :----: | ----------------------------------------------------------- |
 | `format`      | string | The pixel format of the mode.                               |
 | `resolutions` | array  | An array of strings describing the resolutions supported by |
 |               |        | the mode.  Each entry is reported as `<WIDTH>x<HEIGHT>`     |^
+///
 
 #### Query Unassigned Canbus UUIDs
 
@@ -2186,13 +2190,11 @@ node IDs.
     query multiple unassigned nodes it is vital that they reset all nodes
     on the network before running Klipper.
 
-HTTP Request:
-```http
+```http title="HTTP Request"
 GET /machine/peripherals/canbus?interface=can0
 ```
 
-JSON-RPC request:
-```json
+```json title="JSON-RPC Request"
 {
     "jsonrpc": "2.0",
     "method": "machine.peripherals.canbus",
@@ -2203,26 +2205,38 @@ JSON-RPC request:
 }
 ```
 
-Parameters:
-
+/// api-parameters
+    open: True
 | Name        |  Type  | Description                                           |
 | ----------- | :----: | ----------------------------------------------------- |
 | `interface` | string | The cansocket interface to query.  Default is `can0`. |
+///
 
-Returns:
-
+/// api-example-response
 ```json
 {
     "can_uuids": ["11AABBCCDD"]
 }
 ```
+///
 
-Response Schema:
+/// api-response-schema
+    open: True
+Response
 
-| Field       | Type  | Description                                               |
-| ----------- | :---: | --------------------------------------------------------- |
-| `can_uuids` | array | An array of discovered UUIDs as strings.  If no UUIDS are |
-|             |       | found the result is an empty array.                       |^
+| Field       | Type  | Description                                                      |
+| ----------- | :---: | ---------------------------------------------------------------- |
+| `can_uuids` | array | An array of discovered CAN UUID objects, or an empty array if no |
+|             |       | unassigned CAN nodes are found.                                  |^
+
+Can UUID
+
+| Field         |  Type  | Description                                                 |
+| ------------- | :----: | ----------------------------------------------------------- |
+| `uuid`        | string | The UUID of the unassigned node.                            |
+| `application` | string | The name of the application running on the unassigned Node. |
+|               |        | Should be "Klipper" or "Katapult".                          |^
+///
 
 ### File Operations
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,3 +22,6 @@ markdown_extensions:
     - pymdownx.highlight:
         use_pygments: false
     - pymdownx.inlinehilite
+    - tables
+    - compact_tables:
+        auto_insert_break: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,45 @@ markdown_extensions:
     - pymdownx.tasklist:
         custom_checkbox: true
     - pymdownx.tilde
+    - pymdownx.blocks.details:
+        types:
+        - name: details-new
+          class: new
+        - name: details-settings
+          class: settings
+        - name: details-note
+          class: note
+        - name: details-abstract
+          class: abstract
+        - name: details-info
+          class: info
+        - name: details-tip
+          class: tip
+        - name: details-success
+          class: success
+        - name: details-question
+          class: question
+        - name: details-warning
+          class: warning
+        - name: details-failure
+          class: failure
+        - name: details-danger
+          class: danger
+        - name: details-bug
+          class: bug
+        - name: details-example
+          class: example
+        - name: details-quote
+          class: quote
+        - name: api-example-response
+          class: example
+          title: "Example Response"
+        - name: api-response-schema
+          class: info
+          title: "Response Schema"
+        - name: api-parameters
+          class: info
+          title: "Parameters"
     - tables
     - compact_tables:
         auto_insert_break: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,26 +2,77 @@ site_name: Moonraker
 site_url: https://moonraker.readthedocs.io
 repo_url: https://github.com/Arksine/moonraker
 nav:
-    - 'User Documentation':
-        - Installation: installation.md
-        - Configuration : configuration.md
+    - Installation: installation.md
+    - Configuration : configuration.md
     - 'Developer Documentation':
         - Remote API: web_api.md
         - Printer Objects: printer_objects.md
         - Components: components.md
-    - 'Miscellaneous':
-        - Contributing: contributing.md
-        - Changelog: changelog.md
+        - Contribution Guidelines: contributing.md
+    - Changelog: changelog.md
 theme:
-    name: readthedocs
+    name: material
+    palette:
+        - scheme: default
+          primary: blue grey
+          accent: light blue
+          toggle:
+            icon: material/weather-sunny
+            name: Switch to Dark Mode
+        - scheme: slate
+          primary: black
+          accent: light blue
+          toggle:
+            icon: material/weather-night
+            name: Switch to Light Mode
+    font:
+        text: Roboto
+        code: Roboto Mono
+    features:
+        - navigation.top
+        - navigation.instant
+        - navigation.indexes
+        - navigation.expand
+        - toc.follow
+        - content.tabs.link
+        - search.share
+        - search.highlight
+        - search.suggest
+        - content.code.copy
+        - content.code.annotations
 plugins:
     - search
 markdown_extensions:
+    - abbr
     - admonition
-    - pymdownx.superfences
-    - pymdownx.highlight:
-        use_pygments: false
+    - attr_list
+    - def_list
+    - footnotes
+    - md_in_html
+    - toc:
+        permalink: true
+    - pymdownx.arithmatex:
+        generic: true
+    - pymdownx.betterem:
+        smart_enable: all
+    - pymdownx.caret
+    - pymdownx.details
+    - pymdownx.emoji:
+        emoji_index: !!python/name:materialx.emoji.twemoji
+        emoji_generator: !!python/name:materialx.emoji.to_svg
+    - pymdownx.highlight
     - pymdownx.inlinehilite
+    - pymdownx.keys
+    - pymdownx.mark
+    - pymdownx.smartsymbols
+    - pymdownx.superfences
+    - pymdownx.tabbed:
+        alternate_style: true
+    - pymdownx.tasklist:
+        custom_checkbox: true
+    - pymdownx.tilde
     - tables
     - compact_tables:
         auto_insert_break: true
+extra_css:
+    - src/css/extras.css

--- a/moonraker/components/machine.py
+++ b/moonraker/components/machine.py
@@ -284,7 +284,8 @@ class Machine:
             pass
 
     async def component_init(self) -> None:
-        await self.update_usb_ids()
+        eventloop = self.server.get_event_loop()
+        eventloop.create_task(self.update_usb_ids())
         await self.validator.validation_init()
         await self.sys_provider.initialize()
         if not self.inside_container:
@@ -849,6 +850,7 @@ class Machine:
                 headers["If-None-Match"] = etag
             if last_modified is not None and usb_ids_path.is_file():
                 headers["If-Modified-Since"] = last_modified
+            logging.info("Fetching latest usb.ids file...")
             resp = await client.get(
                 USB_IDS_URL, headers, enable_cache=False
             )

--- a/moonraker/server.py
+++ b/moonraker/server.py
@@ -608,6 +608,9 @@ def main(from_package: bool = True) -> None:
         if not comms_dir.exists():
             comms_dir.mkdir()
         unix_sock = str(comms_dir.joinpath("moonraker.sock"))
+    misc_dir = data_path.joinpath("misc")
+    if not misc_dir.exists():
+        misc_dir.mkdir()
     app_args = {
         "data_path": str(data_path),
         "is_default_data_path": cmd_line_args.datapath is None,

--- a/moonraker/server.py
+++ b/moonraker/server.py
@@ -132,6 +132,12 @@ class Server:
     def get_app_args(self) -> Dict[str, Any]:
         return dict(self.app_args)
 
+    def get_app_arg(self, key: str, default=Sentinel.MISSING) -> Any:
+        val = self.app_args.get(key, default)
+        if val is Sentinel.MISSING:
+            raise KeyError(f"No key '{key}' in Application Arguments")
+        return val
+
     def get_event_loop(self) -> EventLoop:
         return self.event_loop
 

--- a/moonraker/utils/__init__.py
+++ b/moonraker/utils/__init__.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
 
 SYS_MOD_PATHS = glob.glob("/usr/lib/python3*/dist-packages")
 SYS_MOD_PATHS += glob.glob("/usr/lib/python3*/site-packages")
+SYS_MOD_PATHS += glob.glob("/usr/lib/*-linux-gnu/python3*/site-packages")
 IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
 
 class ServerError(Exception):

--- a/moonraker/utils/cansocket.py
+++ b/moonraker/utils/cansocket.py
@@ -1,0 +1,199 @@
+# Async CAN Socket utility
+#
+# Copyright (C) 2023 Eric Callahan <arksine.code@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+
+from __future__ import annotations
+import socket
+import asyncio
+import errno
+import struct
+import logging
+from . import ServerError
+from typing import List, Dict, Optional, Union
+
+CAN_FMT = "<IB3x8s"
+CAN_READER_LIMIT = 1024 * 1024
+KLIPPER_ADMIN_ID = 0x3f0
+KLIPPER_SET_NODE_CMD = 0x01
+KATAPULT_SET_NODE_CMD = 0x11
+CMD_QUERY_UNASSIGNED = 0x00
+CANBUS_RESP_NEED_NODEID = 0x20
+
+class CanNode:
+    def __init__(self, node_id: int, cansocket: CanSocket) -> None:
+        self.node_id = node_id
+        self._reader = asyncio.StreamReader(CAN_READER_LIMIT)
+        self._cansocket = cansocket
+
+    async def read(
+        self, n: int = -1, timeout: Optional[float] = 2
+    ) -> bytes:
+        return await asyncio.wait_for(self._reader.read(n), timeout)
+
+    async def readexactly(
+        self, n: int, timeout: Optional[float] = 2
+    ) -> bytes:
+        return await asyncio.wait_for(self._reader.readexactly(n), timeout)
+
+    async def readuntil(
+        self, sep: bytes = b"\x03", timeout: Optional[float] = 2
+    ) -> bytes:
+        return await asyncio.wait_for(self._reader.readuntil(sep), timeout)
+
+    def write(self, payload: Union[bytes, bytearray]) -> None:
+        if isinstance(payload, bytearray):
+            payload = bytes(payload)
+        self._cansocket.send(self.node_id, payload)
+
+    async def write_with_response(
+        self,
+        payload: Union[bytearray, bytes],
+        resp_length: int,
+        timeout: Optional[float] = 2.
+    ) -> bytes:
+        self.write(payload)
+        return await self.readexactly(resp_length, timeout)
+
+    def feed_data(self, data: bytes) -> None:
+        self._reader.feed_data(data)
+
+    def close(self) -> None:
+        self._reader.feed_eof()
+
+class CanSocket:
+    def __init__(self, interface: str):
+        self._loop = asyncio.get_running_loop()
+        self.nodes: Dict[int, CanNode] = {}
+        self.cansock = socket.socket(socket.PF_CAN, socket.SOCK_RAW, socket.CAN_RAW)
+        self.input_buffer = b""
+        self.output_packets: List[bytes] = []
+        self.input_busy = False
+        self.output_busy = False
+        self.closed = True
+        try:
+            self.cansock.bind((interface,))
+        except Exception:
+            raise ServerError(f"Unable to bind socket to interface '{interface}'", 500)
+        self.closed = False
+        self.cansock.setblocking(False)
+        self._loop.add_reader(self.cansock.fileno(), self._handle_can_response)
+
+    def register_node(self, node_id: int) -> CanNode:
+        if node_id in self.nodes:
+            return self.nodes[node_id]
+        node = CanNode(node_id, self)
+        self.nodes[node_id + 1] = node
+        return node
+
+    def remove_node(self, node_id: int) -> None:
+        node = self.nodes.pop(node_id + 1, None)
+        if node is not None:
+            node.close()
+
+    def _handle_can_response(self) -> None:
+        try:
+            data = self.cansock.recv(4096)
+        except socket.error as e:
+            # If bad file descriptor allow connection to be
+            # closed by the data check
+            if e.errno == errno.EBADF:
+                logging.exception("Can Socket Read Error, closing")
+                data = b''
+            else:
+                return
+        if not data:
+            # socket closed
+            self.close()
+            return
+        self.input_buffer += data
+        if self.input_busy:
+            return
+        self.input_busy = True
+        while len(self.input_buffer) >= 16:
+            packet = self.input_buffer[:16]
+            self._process_packet(packet)
+            self.input_buffer = self.input_buffer[16:]
+        self.input_busy = False
+
+    def _process_packet(self, packet: bytes) -> None:
+        can_id, length, data = struct.unpack(CAN_FMT, packet)
+        can_id &= socket.CAN_EFF_MASK
+        payload = data[:length]
+        node = self.nodes.get(can_id)
+        if node is not None:
+            node.feed_data(payload)
+
+    def send(self, can_id: int, payload: bytes = b"") -> None:
+        if can_id > 0x7FF:
+            can_id |= socket.CAN_EFF_FLAG
+        if not payload:
+            packet = struct.pack(CAN_FMT, can_id, 0, b"")
+            self.output_packets.append(packet)
+        else:
+            while payload:
+                length = min(len(payload), 8)
+                pkt_data = payload[:length]
+                payload = payload[length:]
+                packet = struct.pack(
+                    CAN_FMT, can_id, length, pkt_data)
+                self.output_packets.append(packet)
+        if self.output_busy:
+            return
+        self.output_busy = True
+        asyncio.create_task(self._do_can_send())
+
+    async def _do_can_send(self):
+        while self.output_packets:
+            packet = self.output_packets.pop(0)
+            try:
+                await self._loop.sock_sendall(self.cansock, packet)
+            except socket.error:
+                logging.info("Socket Write Error, closing")
+                self.close()
+                break
+        self.output_busy = False
+
+    def close(self):
+        if self.closed:
+            return
+        self.closed = True
+        for node in self.nodes.values():
+            node.close()
+        self._loop.remove_reader(self.cansock.fileno())
+        self.cansock.close()
+
+async def query_klipper_uuids(can_socket: CanSocket) -> List[Dict[str, str]]:
+    loop = asyncio.get_running_loop()
+    admin_node = can_socket.register_node(KLIPPER_ADMIN_ID)
+    payload = bytes([CMD_QUERY_UNASSIGNED])
+    admin_node.write(payload)
+    curtime = loop.time()
+    endtime = curtime + 2.
+    uuids: List[Dict[str, str]] = []
+    while curtime < endtime:
+        timeout = max(.1, endtime - curtime)
+        try:
+            resp = await admin_node.read(8, timeout)
+        except asyncio.TimeoutError:
+            continue
+        finally:
+            curtime = loop.time()
+        if len(resp) < 7 or resp[0] != CANBUS_RESP_NEED_NODEID:
+            continue
+        app_names = {
+            KLIPPER_SET_NODE_CMD: "Klipper",
+            KATAPULT_SET_NODE_CMD: "Katapult"
+        }
+        app = "Unknown"
+        if len(resp) > 7:
+            app = app_names.get(resp[7], "Unknown")
+        data = resp[1:7]
+        uuids.append(
+            {
+                "uuid": data.hex(),
+                "application": app
+            }
+        )
+    return uuids

--- a/moonraker/utils/ioctl_macros.py
+++ b/moonraker/utils/ioctl_macros.py
@@ -14,7 +14,7 @@ This module contains of Python port of the macros avaialble in
 """
 
 if TYPE_CHECKING:
-    IOCParamSize = Union[int, str, Type[ctypes._SimpleCData]]
+    IOCParamSize = Union[int, str, Type[ctypes._CData]]
 
 _IOC_NRBITS = 8
 _IOC_TYPEBITS = 8

--- a/moonraker/utils/sysfs_devs.py
+++ b/moonraker/utils/sysfs_devs.py
@@ -1,0 +1,226 @@
+# Utilities for enumerating devices using sysfs
+#
+# Copyright (C) 2024 Eric Callahan <arksine.code@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license
+from __future__ import annotations
+import pathlib
+from typing import (
+    Dict,
+    List,
+    Any,
+    Union,
+    Optional
+)
+
+DEFAULT_USB_IDS_PATH = "/usr/share/misc/usb.ids"
+USB_DEVICE_PATH = "/sys/bus/usb/devices"
+TTY_PATH = "/sys/class/tty"
+SER_BYPTH_PATH = "/dev/serial/by-path"
+SER_BYID_PATH = "/dev/serial/by-id"
+
+OPTIONAL_USB_INFO = ["manufacturer", "product", "serial"]
+NULL_DESCRIPTIONS = [
+    "?", "none", "undefined", "reserved/undefined", "unused", "no subclass"
+]
+
+def read_item(parent: pathlib.Path, filename: str) -> str:
+    return parent.joinpath(filename).read_text().strip()
+
+class UsbIdData:
+    _usb_info_cache: Dict[str, str] = {
+        "DI:1d50": "OpenMoko, Inc",
+        "DI:1d50:614e": "Klipper 3d-Printer Firmware",
+        "DI:1d50:6177": "Katapult Bootloader (CDC_ACM)"
+    }
+
+    def __init__(self, usb_id_path: Union[str, pathlib.Path]) -> None:
+        if isinstance(usb_id_path, str):
+            usb_id_path = pathlib.Path(usb_id_path)
+        self.usb_id_path = usb_id_path.expanduser().resolve()
+        self.parsed: bool = False
+        self.usb_info: Dict[str, str] = {}
+
+    def _is_hex(self, item: str) -> bool:
+        try:
+            int(item, 16)
+        except ValueError:
+            return False
+        return True
+
+    def get_item(self, key: str, check_null: bool = False) -> Optional[str]:
+        item = self.usb_info.get(key, self._usb_info_cache.get(key))
+        if item is None:
+            if self.parsed:
+                return None
+            self.parse_usb_ids()
+            item = self.usb_info.get(key)
+            if item is None:
+                return None
+        self._usb_info_cache[key] = item
+        if check_null and item.lower() in NULL_DESCRIPTIONS:
+            return None
+        return item
+
+    def parse_usb_ids(self) -> None:
+        self.parsed = True
+        if not self.usb_id_path.is_file():
+            return
+        top_key: str = ""
+        sub_key: str = ""
+        with self.usb_id_path.open(encoding="latin-1") as f:
+            while True:
+                line = f.readline()
+                if not line:
+                    break
+                stripped_line = line.strip()
+                if not stripped_line or stripped_line[0] == "#":
+                    continue
+                if line[:2] == "\t\t":
+                    if not sub_key:
+                        continue
+                    tertiary_id, desc = stripped_line.split(maxsplit=1)
+                    self.usb_info[f"{sub_key}:{tertiary_id.lower()}"] = desc
+                elif line[0] == "\t":
+                    if not top_key:
+                        continue
+                    sub_id, desc = stripped_line.split(maxsplit=1)
+                    sub_key = f"{top_key}:{sub_id.lower()}"
+                    self.usb_info[sub_key] = desc
+                else:
+                    id_type, data = line.rstrip().split(maxsplit=1)
+                    if len(id_type) == 4 and self._is_hex(id_type):
+                        # This is a vendor ID
+                        top_key = f"DI:{id_type.lower()}"
+                        self.usb_info[top_key] = data
+                    elif id_type:
+                        # This is a subtype
+                        num_id, desc = data.split(maxsplit=1)
+                        top_key = f"{id_type}:{num_id.lower()}"
+                        self.usb_info[top_key] = desc
+                    else:
+                        break
+
+    def get_product_info(self, vendor_id: str, product_id: str) -> Dict[str, Any]:
+        vendor_name = self.get_item(f"DI:{vendor_id}")
+        if vendor_name is None:
+            return {
+                "description": None,
+                "manufacturer": None,
+                "product": None,
+            }
+        product_name = self.get_item(f"DI:{vendor_id}:{product_id}")
+        return {
+            "description": f"{vendor_name} {product_name or ''}".strip(),
+            "manufacturer": vendor_name,
+            "product": product_name,
+        }
+
+    def get_class_info(
+        self, cls_id: str, subcls_id: str, proto_id: str
+    ) -> Dict[str, Any]:
+        cls_desc = self.get_item(f"C:{cls_id}")
+        if cls_desc is None or cls_id == "00":
+            return {
+                "class": None,
+                "subclass": None,
+                "protocol": None
+            }
+        return {
+            "class": cls_desc,
+            "subclass": self.get_item(f"C:{cls_id}:{subcls_id}", True),
+            "protocol": self.get_item(f"C:{cls_id}:{subcls_id}:{proto_id}", True)
+        }
+
+def find_usb_devices() -> List[Dict[str, Any]]:
+    dev_folder = pathlib.Path(USB_DEVICE_PATH)
+    if not dev_folder.is_dir():
+        return []
+    usb_devs: List[Dict[str, Any]] = []
+    # Find sysfs usb device descriptors
+    for dev_cfg_path in dev_folder.glob("*/bDeviceClass"):
+        dev_folder = dev_cfg_path.parent
+        device_info: Dict[str, Any] = {}
+        try:
+            device_info["device_num"] = int(read_item(dev_folder, "devnum"))
+            device_info["bus_num"] = int(read_item(dev_folder, "busnum"))
+            device_info["vendor_id"] = read_item(dev_folder, "idVendor").lower()
+            device_info["product_id"] = read_item(dev_folder, "idProduct").lower()
+            usb_location = f"{device_info['bus_num']}:{device_info['device_num']}"
+            device_info["usb_location"] = usb_location
+            dev_cls = read_item(dev_folder, "bDeviceClass").lower()
+            dev_subcls = read_item(dev_folder, "bDeviceSubClass").lower()
+            dev_proto = read_item(dev_folder, "bDeviceProtocol").lower()
+            device_info["class_ids"] = [dev_cls, dev_subcls, dev_proto]
+            for field in OPTIONAL_USB_INFO:
+                if dev_folder.joinpath(field).is_file():
+                    device_info[field] = read_item(dev_folder, field)
+                elif field not in device_info:
+                    device_info[field] = None
+        except Exception:
+            continue
+        usb_devs.append(device_info)
+    return usb_devs
+
+def find_serial_devices() -> List[Dict[str, Any]]:
+    serial_devs: List[Dict[str, Any]] = []
+    usb_devs_by_path: Dict[str, str] = {}
+    usb_devs_by_id: Dict[str, str] = {}
+    usb_by_path_dir = pathlib.Path(SER_BYPTH_PATH)
+    usb_by_id_dir = pathlib.Path(SER_BYID_PATH)
+    dev_root_folder = pathlib.Path("/dev")
+    if usb_by_path_dir.is_dir():
+        usb_devs_by_path = {
+            dev.resolve().name: str(dev) for dev in usb_by_path_dir.iterdir()
+        }
+    if usb_by_id_dir.is_dir():
+        usb_devs_by_id = {
+            dev.resolve().name: str(dev) for dev in usb_by_id_dir.iterdir()
+        }
+    tty_dir = pathlib.Path(TTY_PATH)
+    for tty_path in tty_dir.iterdir():
+        device_folder = tty_path.joinpath("device")
+        if not device_folder.is_dir():
+            continue
+        uartclk_file = tty_path.joinpath("uartclk")
+        port_file = tty_path.joinpath("port")
+        device_name = tty_path.name
+        driver_name = device_folder.joinpath("driver").resolve().name
+        device_info: Dict[str, Any] = {
+            "device_type": "unknown",
+            "device_path": str(dev_root_folder.joinpath(device_name)),
+            "device_name": device_name,
+            "driver_name": driver_name
+        }
+        if uartclk_file.is_file() and port_file.is_file():
+            # This is a potential hardware uart.  Need to
+            # validate that "serial8250" devices have a port
+            # number of zero
+            if driver_name == "serial8250":
+                portnum = int(port_file.read_text().strip(), 16)
+                if portnum != 0:
+                    # Not a usable UART
+                    continue
+            device_info["device_type"] = "hardware_uart"
+        else:
+            usb_path = device_folder.resolve()
+            usb_location: Optional[str] = None
+            while usb_path.is_dir() and usb_path.name:
+                dnum_file = usb_path.joinpath("devnum")
+                bnum_file = usb_path.joinpath("busnum")
+                if not dnum_file.is_file() or not bnum_file.is_file():
+                    usb_path = usb_path.parent
+                    continue
+                devnum = int(dnum_file.read_text().strip())
+                busnum = int(bnum_file.read_text().strip())
+                usb_location = f"{busnum}:{devnum}"
+                break
+            device_info["path_by_hardware"] = usb_devs_by_path.get(device_name)
+            device_info["path_by_id"] = usb_devs_by_id.get(device_name)
+            device_info["usb_location"] = None
+            if usb_location is not None:
+                device_info["device_type"] = "usb"
+                device_info["usb_location"] = usb_location
+
+        serial_devs.append(device_info)
+    return serial_devs

--- a/moonraker/utils/sysfs_devs.py
+++ b/moonraker/utils/sysfs_devs.py
@@ -185,18 +185,18 @@ def find_usb_devices() -> List[Dict[str, Any]]:
 
 def find_serial_devices() -> List[Dict[str, Any]]:
     serial_devs: List[Dict[str, Any]] = []
-    usb_devs_by_path: Dict[str, str] = {}
-    usb_devs_by_id: Dict[str, str] = {}
-    usb_by_path_dir = pathlib.Path(SER_BYPTH_PATH)
-    usb_by_id_dir = pathlib.Path(SER_BYID_PATH)
+    devs_by_path: Dict[str, str] = {}
+    devs_by_id: Dict[str, str] = {}
+    by_path_dir = pathlib.Path(SER_BYPTH_PATH)
+    by_id_dir = pathlib.Path(SER_BYID_PATH)
     dev_root_folder = pathlib.Path("/dev")
-    if usb_by_path_dir.is_dir():
-        usb_devs_by_path = {
-            dev.resolve().name: str(dev) for dev in usb_by_path_dir.iterdir()
+    if by_path_dir.is_dir():
+        devs_by_path = {
+            dev.resolve().name: str(dev) for dev in by_path_dir.iterdir()
         }
-    if usb_by_id_dir.is_dir():
-        usb_devs_by_id = {
-            dev.resolve().name: str(dev) for dev in usb_by_id_dir.iterdir()
+    if by_id_dir.is_dir():
+        devs_by_id = {
+            dev.resolve().name: str(dev) for dev in by_id_dir.iterdir()
         }
     tty_dir = pathlib.Path(TTY_PATH)
     for tty_path in tty_dir.iterdir():
@@ -211,7 +211,10 @@ def find_serial_devices() -> List[Dict[str, Any]]:
             "device_type": "unknown",
             "device_path": str(dev_root_folder.joinpath(device_name)),
             "device_name": device_name,
-            "driver_name": driver_name
+            "driver_name": driver_name,
+            "path_by_hardware": devs_by_path.get(device_name),
+            "path_by_id": devs_by_id.get(device_name),
+            "usb_location": None
         }
         if uartclk_file.is_file() and port_file.is_file():
             # This is a potential hardware uart.  Need to
@@ -226,13 +229,9 @@ def find_serial_devices() -> List[Dict[str, Any]]:
         else:
             usb_path = device_folder.resolve()
             usb_location: Optional[str] = find_usb_folder(usb_path)
-            device_info["path_by_hardware"] = usb_devs_by_path.get(device_name)
-            device_info["path_by_id"] = usb_devs_by_id.get(device_name)
-            device_info["usb_location"] = None
             if usb_location is not None:
                 device_info["device_type"] = "usb"
                 device_info["usb_location"] = usb_location
-
         serial_devs.append(device_info)
     return serial_devs
 


### PR DESCRIPTION
This pull request adds the ability to query the local machine for the following peripherals:

- Serial Devices, including hardware UARTs
- Connected USB devices
- Video Devices (V4L2 and libcamera)
- Unassigned CAN Nodes running Klipper or Katapult

This is accomplished for the most part using sysfs and IOCTLs.  No external dependencies are added in this PR.  That said, it is necessary for the `python3-libcamera` package to be installed on the system to query libcamera devices.  Since this package is only widely available for RPi OS it can't be added to Moonraker as a system dependency as it would cause standard Debian/Ubuntu installs to fail.  That said, if the module is not available it will not cause an error.

This PR also marks the switch from the "readthedocs" theme to the "material" theme for Moonraker's documentation.  Given the complexity of the responses I wanted to try to introduce a better structure for the API documentation.  It won't be available on `readthedocs` until this PR is merged, however its generally possible to read the [API docs](https://github.com/Arksine/moonraker/blob/d401574f3ca595da5539efac44567f550aa2e752/docs/web_api.md#list-usb-devices) in the PR to get an idea of what the new APIs look like.

This resolves PR #658 and issue #768.
@meteyou This PR also addresses your request to query hardware devices.