### PR TITLE
Home Assistant self-signed certificate support for integration with power component 

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1080,6 +1080,10 @@ status_delay: 1.0
 #   on/off and requesting its current status.  This is a workaround used
 #   to validate that Home Assistant has successfully toggled the device,
 #   as the API is currently broken on their end.  Default is 1 second.
+ca_certs:
+#   The filepath to the certificate used by Home Assistant. This can be useful
+#   when Home Assistant is configured with a self-signed certificate.
+#   Don't forget to set protocol to https. This parameter is optional.
 #
 ```
 

--- a/moonraker/components/http_client.py
+++ b/moonraker/components/http_client.py
@@ -80,7 +80,8 @@ class HttpClient:
         retry_pause_time: float = .1,
         enable_cache: bool = False,
         send_etag: bool = True,
-        send_if_modified_since: bool = True
+        send_if_modified_since: bool = True,
+        ca_certs: Optional[str] = None
     ) -> HttpResponse:
         cache_key = url.split("?", 1)[0]
         method = method.upper()
@@ -105,7 +106,8 @@ class HttpClient:
         timeout = 1 + connect_timeout + request_timeout
         request = HTTPRequest(url, method, headers, body=body,
                               request_timeout=request_timeout,
-                              connect_timeout=connect_timeout)
+                              connect_timeout=connect_timeout,
+                              ca_certs=ca_certs)
         err: Optional[BaseException] = None
         for i in range(attempts):
             if i:

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -1131,7 +1131,7 @@ class HomeAssistant(HTTPDevice):
         self.token: str = config.gettemplate("token").render()
         self.domain: str = config.get("domain", "switch")
         self.status_delay: float = config.getfloat("status_delay", 1.)
-        self.ca_certs: str = config.get("ca_certs", None)
+        self.ca_certs: Optional[str] = config.get("ca_certs", None)
 
     async def _send_homeassistant_command(self, command: str) -> Dict[str, Any]:
         body: Optional[Dict[str, Any]] = None

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -1131,6 +1131,7 @@ class HomeAssistant(HTTPDevice):
         self.token: str = config.gettemplate("token").render()
         self.domain: str = config.get("domain", "switch")
         self.status_delay: float = config.getfloat("status_delay", 1.)
+        self.ca_certs: str = config.get("ca_certs", None)
 
     async def _send_homeassistant_command(self, command: str) -> Dict[str, Any]:
         body: Optional[Dict[str, Any]] = None
@@ -1151,7 +1152,7 @@ class HomeAssistant(HTTPDevice):
         data: Dict[str, Any] = {}
         response = await self.client.request(
             method, url, body=body, headers=headers,
-            attempts=3, enable_cache=False
+            attempts=3, enable_cache=False, ca_certs=self.ca_certs
         )
         msg = f"Error sending homeassistant command: {command}"
         response.raise_for_status(msg)


### PR DESCRIPTION
The current version of moonraker has integration with Home Assistant allowing to control remote switches. There is the option to set the authentication protocol to HTTPS, but there was no option to define a certificate (.crt) to be used. This is required when using self-signed certificates, otherwise validation will fail and moonraker.log will log following error:

`[iostream.py:_do_ssl_handshake()] - SSL Error on 12 ('192.168.1.X', 8123): [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1123)`

This merge request allows a new variable called **ca_certs** (kept the same variable name used by the tornado httpclient library) to be defined inside the [power homeassistant_switch] config section, any request made to homeassistant will then use the certificate and succeed. 

```
[power homeassistant_switch]
type: homeassistant
address: homeassistant.local
protocol: https
port: 8123
device: switch.1234567890abcdefghij
token: home-assistant-very-long-token
domain: switch
ca_certs: /home/pi/homeassistant.crt
```

The **ca_certs** variable is optional and moonraker will behave the same if not defined. This variable should be used together with setting the **protocol** to https (instead of the default http).

PS: I tried appending the self-signed certificate directly into the system (wget starts working) and into python venv thru certifi (python requests lib starts working), but I could not make the tornado httpclient to work other than passing the certificate on the code.

Signed-off-by: Paulo Serrão <paulo.serrao@gmail.com>