### PR TITLE
Bump preprocess_cancellation to 0.2.1

### DIFF
--- a/scripts/moonraker-requirements.txt
+++ b/scripts/moonraker-requirements.txt
@@ -14,7 +14,7 @@ inotify-simple==1.3.5
 libnacl==2.1.0
 paho-mqtt==1.6.1
 zeroconf==0.131.0
-preprocess-cancellation==0.2.0
+preprocess-cancellation==0.2.1
 jinja2==3.1.3
 dbus-next==0.2.3
 apprise==1.7.1


### PR DESCRIPTION
0.2.1 ensures that the exclude_object markers are the first
 non-comment g-code in the files, fixing issues with klipper adaptive
 meshing