### PR TITLE
git_deploy: intialize in parallel

### DIFF
--- a/moonraker/components/update_manager/update_manager.py
+++ b/moonraker/components/update_manager/update_manager.py
@@ -185,8 +185,11 @@ class UpdateManager:
             if key not in self.updaters:
                 logging.info(f"Removing stale update_manager data: {key}")
                 await umdb.pop(key, None)
-        for updater in list(self.updaters.values()):
-            await updater.initialize()
+
+        # initialize all updaters in parallel
+        tasks = [updater.initialize() for updater in self.updaters.values()]
+        await asyncio.gather(*tasks)
+
         if self.refresh_timer is not None:
             self.refresh_timer.start()
         else:


### PR DESCRIPTION
Massively speeds up startup on setups with many git repos.

---

I cannot figure out what takes so long to `initialize()` the `GitDeploy` instances
and the `pyinstrument` lib doesn't work well with asyncio.

The fact is, running all initializers at once instead of waiting for one at a time
speeds up my `server_init()` from ~6.5 seconds to ~3 seconds.

Relevant slice of my `moonraker.conf`:
```ini
[update_manager]
enable_auto_refresh = True
refresh_window = 19-7
refresh_interval = 12

[update_manager Klippain]
type = git_repo
path = ~/klippain_config
channel = beta
origin = https://github.com/Frix-x/klippain.git
primary_branch = main
managed_services = moonraker klipper
install_script = install.sh

[update_manager fluidd]
type = web
channel = stable
repo = fluidd-core/fluidd
path = ~/fluidd

[update_manager sonar]
type = git_repo
path = ~/sonar
origin = https://github.com/mainsail-crew/sonar.git
primary_branch = main
managed_services = sonar
install_script = tools/install.sh

[update_manager led_effect]
type = git_repo
primary_branch = master
path = ~/klipper-led_effect
origin = https://github.com/julianschill/klipper-led_effect.git
is_system_service = False

[update_manager happy-hare]
type = git_repo
path = ~/Happy-Hare
origin = https://github.com/moggieuk/Happy-Hare.git
primary_branch = main
install_script = install.sh
managed_services = klipper

[update_manager crowsnest]
type = git_repo
path = ~/crowsnest
origin = https://github.com/mainsail-crew/crowsnest.git
managed_services = crowsnest
install_script = tools/install.sh                                                                                                                                                                                                                                           

[update_manager z_calibration]
type = git_repo
path = ~/klipper_z_calibration
origin = https://github.com/protoloft/klipper_z_calibration.git
primary_branch = master
managed_services = klipper
```