### PR TITLE
docs: corrects canbus peripherals response example

### DIFF
--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -2215,7 +2215,12 @@ GET /machine/peripherals/canbus?interface=can0
 /// api-example-response
 ```json
 {
-    "can_uuids": ["11AABBCCDD"]
+    "can_uuids": [
+        {
+            "uuid": "11AABBCCDD",
+            "application": "Klipper"
+        }
+    ]
 }
 ```
 ///


### PR DESCRIPTION
The current example shows `can_uuids` as an array of strings, when in fact this is an array of objects with `uuid` and `application` properties.