### PR TITLE
Support Hubitat for power device

### DIFF
--- a/moonraker/components/http_client.py
+++ b/moonraker/components/http_client.py
@@ -80,7 +80,8 @@ class HttpClient:
         retry_pause_time: float = .1,
         enable_cache: bool = False,
         send_etag: bool = True,
-        send_if_modified_since: bool = True
+        send_if_modified_since: bool = True,
+        validate_ssl_cert: bool = True
     ) -> HttpResponse:
         cache_key = url.split("?", 1)[0]
         method = method.upper()
@@ -105,7 +106,8 @@ class HttpClient:
         timeout = 1 + connect_timeout + request_timeout
         request = HTTPRequest(url, method, headers, body=body,
                               request_timeout=request_timeout,
-                              connect_timeout=connect_timeout)
+                              connect_timeout=connect_timeout,
+                              validate_cert=validate_ssl_cert)
         err: Optional[BaseException] = None
         for i in range(attempts):
             if i:

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -1185,9 +1185,15 @@ class Hubitat(HTTPDevice):
 
     async def _send_hubitat_command(self, command: str) -> Dict[str, Any]:
         if command in ["on", "off"]:
-            out_cmd = f"apps/api/{self.maker_id}/devices/{self.device_id}/{command}?access_token={self.token}"
+            out_cmd = (
+                f"apps/api/{self.maker_id}/devices/"
+                f"{self.device_id}/{command}?access_token={self.token}"
+            )
         elif command == "info":
-            out_cmd = f"apps/api/{self.maker_id}/devices/{self.device_id}?access_token={self.token}"
+            out_cmd = (
+                f"apps/api/{self.maker_id}/devices/"
+                f"{self.device_id}?access_token={self.token}"
+            )
         else:
             raise self.server.error(f"Invalid hubitat command: {command}")
         url = f"{self.protocol}://{quote(self.addr)}:{self.port}/{out_cmd}"
@@ -1460,7 +1466,9 @@ class HueDevice(HTTPDevice):
             f"{self.protocol}://{quote(self.addr)}:{self.port}/api/{quote(self.user)}"
             f"/{self.device_type}s/{quote(self.device_id)}"
         )
-        ret = await self.client.request("GET", url, validate_ssl_cert=self.validate_ssl_cert)
+        ret = await self.client.request(
+            "GET", url, validate_ssl_cert=self.validate_ssl_cert
+        )
         resp = cast(Dict[str, Dict[str, Any]], ret.json())
         return "on" if resp["state"][self.on_state] else "off"
 


### PR DESCRIPTION
This PR adds support for setting up a Hubitat connected smart switch as a power device. It requires the following config parameters:
- `device_id`: ID of the smart switch device
- `maker_id`: ID of the Maker API application. Maker API is the Rest API server for Hubitat. 
- `token`: Access token for Maker API
- `status_delay`: Delay between controlling the smart switch and refreshing its state

I have my Hubitat hub set up with a self-signed certificate, so I also needed to disable certificate verification for it to work. This PR also adds an universal `validate_ssl_cert` config parameter that disables ssl cert verification for power device requests. 