### PR TITLE
spoolman: Include total count header

### DIFF
--- a/moonraker/components/spoolman.py
+++ b/moonraker/components/spoolman.py
@@ -373,6 +373,7 @@ class SpoolManager:
         else:
             return {
                 "response": response.json(),
+                "response_headers": dict(response.headers.items()),
                 "error": None
             }
 


### PR DESCRIPTION
Closes #841.

As noted in the linked issue, spoolman uses the `x-total-count` header field in its response to indicate the total count, if appropriate, for a pagination result.

To also include this in the proxy I modified the returned JSON of the V2 response to not only return the `response` but also a `response_header` field with all custom headers (Headers starting with `x-`).

I am open to suggestions or alternative ideas on how to handle this change. I feel that adding it as part of the V2 is the safest and will not break any current implementations.