### PR TITLE
database: migrate from lmdb to sqlite3

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -61,15 +61,15 @@ The format is based on [Keep a Changelog].
 
 ### Changed
 
-- **build**: Bumped apprise to version `1.7.0`.
+- **build**: Bumped apprise to version `1.8.0`.
 - **build**: Bumped lmdb to version `1.4.1`
 - **build**: Bumped tornado to version `6.4.0`
-- **build**: Bumped jinja2 to version `3.1.3`
+- **build**: Bumped jinja2 to version `3.1.4`
 - **build**: Bumped zeroconf to version `0.131.0`
 - **build**: Bumped libnacl to version `2.1.0`
 - **build**: Bumped distro to version `1.9.0`
 - **build**: Bumped pillow to version `10.3.0`
-- **build**: Bumped streaming-form-data to version `1.13.0`
+- **build**: Bumped streaming-form-data to version `1.15.0`
 - **machine**: Added `ratos-configurator` to list of default allowed services
 - **update_manager**:  It is now required that an application be "allowed"
   for Moonraker to restart it after an update.
@@ -91,6 +91,9 @@ The format is based on [Keep a Changelog].
 - **gpio**:  Migrate from libgpiod to python-periphery
 - **authorization**:  The authorization module is now loaded as part of Moonraker's
   core.
+- **database**: Migrated the underlying database from LMDB to Sqlite.
+- **history**: Use dedicated SQL tables to store job history and job totals.
+- **authorization**: Use a dedicated SQL table to store user data.
 
 ## [0.8.0] - 2023-02-23
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -202,8 +202,7 @@ structure using the default data path of `$HOME/printer_data`.
 │   ├── moonraker.conf
 │   └── printer.cfg
 ├── database
-│   ├── data.mdb
-│   └── lock.mdb
+│   └── moonraker-sql.db
 ├── gcodes
 │   ├── test_gcode_one.gcode
 │   └── test_gcode_two.gcode
@@ -216,7 +215,7 @@ structure using the default data path of `$HOME/printer_data`.
 └── moonraker.asvc
 ```
 
-If it is not desirible for the files and folders to exist in these specific
+If it is not desirable for the files and folders to exist in these specific
 locations it is acceptable to use symbolic links.  For example, it is common
 for the gcode folder to be located at `$HOME/gcode_files`.  Rather than
 reconfigure Klipper's `virtual_sdcard` it may be desirable to create a
@@ -566,14 +565,29 @@ Retrieve the API Key via the browser from a trusted client:
 
         {"result": "8ce6ae5d354a4365812b83140ed62e4b"}
 
-### LMDB Database Backup and Restore
+### Database Backup and Restore
 
-Moonraker uses a [LMDB Database](http://www.lmdb.tech/doc/) for persistent
-storage of procedurally generated data.  LMDB database files are platform
-dependent, and thus cannot be easily transferred between different machines.
-A file generated on a Raspberry Pi cannot be directly transferred to an x86
-machine.  Likewise, a file generated on a 32-bit version of Linux cannot
-be transferred to a 64-bit machine.
+Moonraker stores persistent data using an Sqlite database.  By default
+the database file is located at `<data_folder>/database/moonraker-sql.db`.
+API Endpoints are available to backup and restore the database.  All
+backups are stored at `<data_folder>/backup/database/<backup_name>` and
+restored from the same location.  Database files may contain sensitive
+information, therefore they are not served by Moonraker.  Another protocol
+such as SCP, SMB, etc is required to transfer a backup off of the host.
+
+Alternatively it is possible to perform a manual backup by copying the
+existing database file when the Moonraker service has been stopped.
+Restoration can be performed by stopping the Moonraker service and
+overwriting the existing database with the backup.
+
+#### LDMB Database (deprecated)
+
+Previous versions of Moonraker used a [LMDB Database](http://www.lmdb.tech/doc/)
+for persistent storage of procedurally generated data.  LMDB database files are
+platform dependent, and thus cannot be easily transferred between different
+machines. A file generated on a Raspberry Pi cannot be directly transferred
+to an x86 machine.  Likewise, a file generated on a 32-bit version of Linux
+cannot be transferred to a 64-bit machine.
 
 Moonraker includes two scripts, `backup-database.sh` and `restore-database.sh`
 to help facilitate database backups and transfers.

--- a/docs/web_api.md
+++ b/docs/web_api.md
@@ -3555,8 +3555,10 @@ the request.  The entire settings object could be accessed by providing
 may be read by omitting the `key` argument, however as explained below it
 is not possible to modify a namespace without specifying a key.
 
-#### List namespaces
-Lists all available namespaces.
+#### List Database Info
+
+Lists all namespaces with read and/or write access.  Also lists database
+backup files.
 
 HTTP request:
 ```http
@@ -3574,14 +3576,21 @@ JSON-RPC request:
 
 Returns:
 
-An object containing an array of namespaces in the following format:
+An object containing an array of namespaces and an array of backup files.
 ```json
 {
     "namespaces": [
         "gcode_metadata",
-        "history",
-        "moonraker",
-        "test_namespace"
+        "webcams",
+        "update_manager",
+        "announcements",
+        "database",
+        "moonraker"
+    ],
+    "backups": [
+        "sqldb-backup-20240513-134542.db",
+        "testbackup.db",
+        "testbackup2.db"
     ]
 }
 ```
@@ -3698,6 +3707,180 @@ deleted item.
     "namespace": "test",
     "key": "settings.some_count",
     "value": 9001
+}
+```
+
+#### Compact Database
+
+Compacts and defragments the the sqlite database using the `VACUUM` command.
+This API cannot be requested when Klipper is printing.
+
+HTTP request:
+```http
+POST /server/database/compact
+```
+
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "server.database.compact",
+    "id": 4654
+}
+```
+Returns:
+An object containing the size of the database on disk before and after
+the database is compacted.
+```json
+{
+    "previous_size": 139264,
+    "new_size": 122880
+}
+```
+
+#### Backup Database
+
+Creates a backup of the current database.  The backup will be
+created in the `<data_path>/backup/database/<filename>`.
+
+This API cannot be requested when Klipper is printing.
+
+HTTP request:
+```http
+POST /server/database/backup
+Content-Type: application/json
+
+{
+    "filename": "sql-db-backup.db"
+}
+```
+
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "server.database.post_backup",
+    "params": {
+        "filename": "sql-db-backup.db"
+    },
+    "id": 4654
+}
+```
+
+Parameters:
+
+- `filename`: An optional file name for the backup file.  The default
+   is `sqldb-backup-<year><month><day>-<hour><minute><second>`.
+
+
+Returns:
+An object containing the path on disk to the backup.
+```json
+{
+    "backup_path": "/home/test/printer_data/backup/database/sql-db-backup.db"
+}
+```
+
+#### Delete a backup
+
+Deletes a previously backed up database.
+
+HTTP request:
+```http
+DELETE /server/database/backup
+Content-Type: application/json
+
+{
+    "filename": "sql-db-backup.db"
+}
+```
+
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "server.database.delete_backup",
+    "params": {
+        "filename": "sql-db-backup.db"
+    },
+    "id": 4654
+}
+```
+
+Parameters:
+
+- `filename`: The name of the backup file to delete.  Must be a valid
+  filename reported in by the [database list](#list-database-info) API.
+  This parameter must be provided.
+
+Returns:
+An object containing the path on disk to the backup file that was removed.
+```json
+{
+    "backup_path": "/home/test/printer_data/backup/database/sql-db-backup.db"
+}
+```
+
+#### Restore Database
+
+Restores a previously backed up sqlite database file. The backup
+must be located at `<data_path>/backup/database/<filename>`. The
+`<filename>` must be a valid filename reported in by the
+[database list](#list-database-info) API.
+
+This API cannot be requested when Klipper is printing.
+
+!!! Note
+    Moonraker will restart immediately after this request is processed.
+
+HTTP request:
+```http
+POST /server/database/restore
+Content-Type: application/json
+
+{
+    "filename": "sql-db-backup.db"
+}
+```
+
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "server.database.restore",
+    "params": {
+        "filename": "sql-db-backup.db"
+    },
+    "id": 4654
+}
+```
+
+Parameters:
+
+- `filename`: The name of the database file to restore.  Must be a valid
+  filename reported in by the [database list](#list-database-info) API.
+  This parameter must be provided.
+
+Returns:
+An object containing a list of restored namespaces and restored tables.
+```json
+{
+    "restored_tables": [
+        "table_registry",
+        "namespace_store",
+        "authorized_users",
+        "job_history",
+        "job_totals"
+    ],
+    "restored_namespaces": [
+        "database",
+        "fluidd",
+        "gcode_metadata",
+        "mainsail",
+        "moonraker",
+        "update_manager",
+        "webcams"
+    ]
 }
 ```
 
@@ -7123,7 +7306,7 @@ receive the following:
 ### Debug APIs
 
 The APIs in this section are available when Moonraker the debug argument
-(`-g`) has been supplied via the command line.  Some API may also depend
+(`-g`) has been supplied via the command line.  Some APIs may also depend
 on Moonraker's configuration, ie: an optional component may choose to
 register a debug API.
 
@@ -7131,11 +7314,11 @@ register a debug API.
     Debug APIs may expose security vulnerabilities.  They should only be
     enabled by developers on secured machines.
 
-#### List Database Namespaces (debug)
+#### List Database Info (debug)
 
-Debug version of [List Namespaces](#list-namespaces). Return value includes
-namespaces exlusively reserved for Moonraker. Only availble when Moonraker's
-debug features are enabled.
+Debug version of [List Database Info](#list-database-info). Returns
+all namespaces, including those exlusively reserved for Moonraker.
+In addition, registered SQL tables are reported.
 
 
 HTTP request:
@@ -7152,14 +7335,42 @@ JSON-RPC request:
 }
 ```
 
+Returns:
+
+An object containing an array of namespaces, an array of tables, and
+an array of backup files.
+```json
+{
+    "namespaces": [
+        "gcode_metadata",
+        "webcams",
+        "update_manager",
+        "announcements",
+        "database",
+        "moonraker"
+    ],
+    "backups": [
+        "sqldb-backup-20240513-134542.db",
+        "testbackup.db",
+        "testbackup2.db"
+    ],
+    "tables": [
+        "job_history",
+        "job_totals",
+        "namespace_store",
+        "table_registry",
+        "authorized_users"
+    ]
+}
+```
+
 #### Get Database Item (debug)
 
 Debug version of [Get Database Item](#get-database-item).  Keys within
-protected and forbidden namespaces are accessible. Only availble when
-Moonraker's debug features are enabled.
+protected and forbidden namespaces are accessible.
 
 !!! Warning
-    Moonraker's forbidden namespaces include items such as user credentials.
+    Moonraker's forbidden namespaces may include items such as user credentials.
     This endpoint should NOT be implemented in front ends directly.
 
 HTTP request:
@@ -7182,8 +7393,7 @@ JSON-RPC request:
 #### Add Database Item (debug)
 
 Debug version of [Add Database Item](#add-database-item).  Keys within
-protected and forbidden namespaces may be added. Only availble when
-Moonraker's debug features are enabled.
+protected and forbidden namespaces may be added.
 
 !!! Warning
     This endpoint should be used for testing/debugging purposes only.
@@ -7219,8 +7429,7 @@ JSON-RPC request:
 #### Delete Database Item (debug)
 
 Debug version of [Delete Database Item](#delete-database-item).  Keys within
-protected and forbidden namespaces may be removed. Only availble when
-Moonraker's debug features are enabled.
+protected and forbidden namespaces may be removed.
 
 !!! Warning
     This endpoint should be used for testing/debugging purposes only.
@@ -7244,6 +7453,93 @@ JSON-RPC request:
         "key": "{key}"
     },
     "id": 4654
+}
+```
+
+#### Get Database Table
+
+Requests all the contents of a specified table.
+
+HTTP request:
+```http
+GET /debug/database/table?table=job_history
+```
+
+JSON-RPC request:
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "debug.database.table",
+    "params": {
+        "table": "job_history"
+    },
+    "id": 4654
+}
+```
+
+Parameters:
+
+- `table`:  The name of the table to request.  This parameter must
+  be provided.
+
+Returns:
+
+An object with the table's name and a list of all rows contained
+within the table.  The `rowid` will always be included for each
+row, however it may be represented by an alias.  In the example
+below the alias for `rowid` is `job_id`.
+
+```json
+{
+    "table_name": "job_history",
+    "rows": [
+        {
+            "job_id": 1,
+            "user": "No User",
+            "filename": "active_test.gcode",
+            "status": "completed",
+            "start_time": 1690749153.2661753,
+            "end_time": 1690749173.076986,
+            "print_duration": 0.0,
+            "total_duration": 19.975574419135228,
+            "filament_used": 0.0,
+            "metadata": {
+                "size": 211,
+                "modified": 1635771217.0,
+                "uuid": "627371e0-faa5-4ced-8bb4-7017d29226fa",
+                "slicer": "Unknown",
+                "gcode_start_byte": 8,
+                "gcode_end_byte": 211
+            },
+            "auxiliary_data": [],
+            "instance_id": "default"
+        },
+        {
+            "job_id": 2,
+            "user": "No User",
+            "filename": "active_test.gcode",
+            "status": "completed",
+            "start_time": 1701262034.9242446,
+            "end_time": 1701262054.7332363,
+            "print_duration": 0.0,
+            "total_duration": 19.990913168992847,
+            "filament_used": 0.0,
+            "metadata": {
+                "size": 211,
+                "modified": 1635771217.0,
+                "uuid": "627371e0-faa5-4ced-8bb4-7017d29226fa",
+                "slicer": "Unknown",
+                "gcode_start_byte": 8,
+                "gcode_end_byte": 211
+            },
+            "auxiliary_data": {
+                "spool_ids": [
+                    2
+                ]
+            },
+            "instance_id": "default"
+        }
+    ]
 }
 ```
 

--- a/moonraker/common.py
+++ b/moonraker/common.py
@@ -10,8 +10,9 @@ import logging
 import copy
 import re
 import inspect
+import dataclasses
+import time
 from enum import Enum, Flag, auto
-from dataclasses import dataclass
 from abc import ABCMeta, abstractmethod
 from .utils import ServerError, Sentinel
 from .utils import json_wrapper as jsonw
@@ -177,7 +178,24 @@ class RenderableTemplate(metaclass=ABCMeta):
     async def render_async(self, context: Dict[str, Any] = {}) -> str:
         ...
 
-@dataclass(frozen=True)
+@dataclasses.dataclass
+class UserInfo:
+    username: str
+    password: str
+    created_on: float = dataclasses.field(default_factory=time.time)
+    salt: str = ""
+    source: str = "moonraker"
+    jwt_secret: Optional[str] = None
+    jwk_id: Optional[str] = None
+    groups: List[str] = dataclasses.field(default_factory=lambda: ["admin"])
+
+    def as_tuple(self) -> Tuple[Any, ...]:
+        return dataclasses.astuple(self)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return dataclasses.asdict(self)
+
+@dataclasses.dataclass(frozen=True)
 class APIDefinition:
     endpoint: str
     http_path: str

--- a/moonraker/common.py
+++ b/moonraker/common.py
@@ -224,7 +224,7 @@ class APIDefinition:
         request_type: RequestType,
         transport: Optional[APITransport] = None,
         ip_addr: Optional[IPAddress] = None,
-        user: Optional[Dict[str, Any]] = None
+        user: Optional[UserInfo] = None
     ) -> Coroutine:
         return self.callback(
             WebRequest(self.endpoint, args, request_type, transport, ip_addr, user)
@@ -313,7 +313,7 @@ class APITransport:
         return TransportType.INTERNAL
 
     @property
-    def user_info(self) -> Optional[Dict[str, Any]]:
+    def user_info(self) -> Optional[UserInfo]:
         return None
 
     @property
@@ -350,14 +350,14 @@ class BaseRemoteConnection(APITransport):
             "url": ""
         }
         self._need_auth: bool = False
-        self._user_info: Optional[Dict[str, Any]] = None
+        self._user_info: Optional[UserInfo] = None
 
     @property
-    def user_info(self) -> Optional[Dict[str, Any]]:
+    def user_info(self) -> Optional[UserInfo]:
         return self._user_info
 
     @user_info.setter
-    def user_info(self, uinfo: Dict[str, Any]) -> None:
+    def user_info(self, uinfo: UserInfo) -> None:
         self._user_info = uinfo
         self._need_auth = False
 
@@ -443,7 +443,7 @@ class BaseRemoteConnection(APITransport):
     def on_user_logout(self, user: str) -> bool:
         if self._user_info is None:
             return False
-        if user == self._user_info.get("username", ""):
+        if user == self._user_info.username:
             self._user_info = None
             return True
         return False
@@ -529,7 +529,7 @@ class WebRequest:
         request_type: RequestType = RequestType(0),
         transport: Optional[APITransport] = None,
         ip_addr: Optional[IPAddress] = None,
-        user: Optional[Dict[str, Any]] = None
+        user: Optional[UserInfo] = None
     ) -> None:
         self.endpoint = endpoint
         self.args = args
@@ -561,7 +561,7 @@ class WebRequest:
     def get_ip_address(self) -> Optional[IPAddress]:
         return self.ip_addr
 
-    def get_current_user(self) -> Optional[Dict[str, Any]]:
+    def get_current_user(self) -> Optional[UserInfo]:
         return self.current_user
 
     def _get_converted_arg(self,

--- a/moonraker/components/application.py
+++ b/moonraker/components/application.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
     from ..server import Server
     from ..eventloop import EventLoop
     from ..confighelper import ConfigHelper
+    from ..common import UserInfo
     from .klippy_connection import KlippyConnection as Klippy
     from ..utils import IPAddress
     from .websockets import WebsocketManager, WebSocket
@@ -160,10 +161,10 @@ class PrimaryRouter(MutableRouter):
         else:
             log_method = access_log.error
         request_time = 1000.0 * handler.request.request_time()
-        user = handler.current_user
+        user: Optional[UserInfo] = handler.current_user
         username = "No User"
-        if user is not None and 'username' in user:
-            username = user['username']
+        if user is not None:
+            username = user.username
         log_method(
             f"{status_code} {handler._request_summary()} "
             f"[{username}] {request_time:.2f}ms"
@@ -725,7 +726,7 @@ class RPCHandler(AuthorizedRequestHandler, APITransport):
         return TransportType.HTTP
 
     @property
-    def user_info(self) -> Optional[Dict[str, Any]]:
+    def user_info(self) -> Optional[UserInfo]:
         return self.current_user
 
     @property

--- a/moonraker/components/file_manager/file_manager.py
+++ b/moonraker/components/file_manager/file_manager.py
@@ -76,9 +76,8 @@ class FileManager:
         db_path = db.get_database_path()
         self.add_reserved_path("database", db_path, False)
         self.add_reserved_path("certs", self.datapath.joinpath("certs"), False)
-        self.add_reserved_path(
-            "systemd", self.datapath.joinpath("systemd"), False
-        )
+        self.add_reserved_path("systemd", self.datapath.joinpath("systemd"), False)
+        self.add_reserved_path("backup", self.datapath.joinpath("backup"), False)
         self.gcode_metadata = MetadataStorage(config, db)
         self.sync_lock = NotifySyncLock(config)
         avail_observers: Dict[str, Type[BaseFileSystemObserver]] = {

--- a/moonraker/components/file_manager/file_manager.py
+++ b/moonraker/components/file_manager/file_manager.py
@@ -615,6 +615,8 @@ class FileManager:
                     ):
                         action = "modify_file"
                     op_func = shutil.copy2
+            else:
+                raise self.server.error(f"Invalid endpoint {ep}")
             self.sync_lock.setup(action, dest_path, move_copy=True)
             try:
                 full_dest = await self.event_loop.run_in_thread(
@@ -1961,7 +1963,7 @@ class InotifyObserver(BaseFileSystemObserver):
     def _handle_move_timeout(self, cookie: int, is_dir: bool):
         if cookie not in self.pending_moves:
             return
-        parent_node, name, hdl = self.pending_moves.pop(cookie)
+        parent_node, name, _ = self.pending_moves.pop(cookie)
         item_path = os.path.join(parent_node.get_path(), name)
         root = parent_node.get_root()
         self.clear_metadata(root, item_path, is_dir)

--- a/moonraker/components/file_manager/file_manager.py
+++ b/moonraker/components/file_manager/file_manager.py
@@ -43,7 +43,7 @@ from typing import (
 if TYPE_CHECKING:
     from inotify_simple import Event as InotifyEvent
     from ...confighelper import ConfigHelper
-    from ...common import WebRequest
+    from ...common import WebRequest, UserInfo
     from ..klippy_connection import KlippyConnection
     from ..job_queue import JobQueue
     from ..job_state import JobState
@@ -902,7 +902,7 @@ class FileManager:
         started: bool = False
         queued: bool = False
         if upload_info['start_print']:
-            user: Optional[Dict[str, Any]] = upload_info.get("user")
+            user: Optional[UserInfo] = upload_info.get("user")
             if can_start:
                 kapis: APIComp = self.server.lookup_component('klippy_apis')
                 try:

--- a/moonraker/components/history.py
+++ b/moonraker/components/history.py
@@ -29,7 +29,7 @@ from typing import (
 
 if TYPE_CHECKING:
     from ..confighelper import ConfigHelper
-    from ..common import WebRequest
+    from ..common import WebRequest, UserInfo
     from .database import MoonrakerDatabase as DBComp
     from .job_state import JobState
     from .file_manager.file_manager import FileManager
@@ -372,8 +372,8 @@ class History:
             # `CLEAR_PAUSE/SDCARD_RESET_FILE` workflow
             await self.finish_job("cancelled", prev_stats)
 
-    def _on_job_requested(self, user: Optional[Dict[str, Any]]) -> None:
-        username = (user or {}).get("username", "No User")
+    def _on_job_requested(self, user: Optional[UserInfo]) -> None:
+        username = user.username if user is not None else "No User"
         self.job_user = username
         if self.current_job is not None:
             self.current_job.user = username

--- a/moonraker/components/job_queue.py
+++ b/moonraker/components/job_queue.py
@@ -21,7 +21,7 @@ from typing import (
 )
 if TYPE_CHECKING:
     from ..confighelper import ConfigHelper
-    from ..common import WebRequest
+    from ..common import WebRequest, UserInfo
     from .klippy_apis import KlippyAPI
     from .file_manager.file_manager import FileManager
 
@@ -168,7 +168,7 @@ class JobQueue:
                         filenames: Union[str, List[str]],
                         check_exists: bool = True,
                         reset: bool = False,
-                        user: Optional[Dict[str, Any]] = None
+                        user: Optional[UserInfo] = None
                         ) -> None:
         async with self.lock:
             # Make sure that the file exists
@@ -324,7 +324,7 @@ class JobQueue:
         await self.pause_queue()
 
 class QueuedJob:
-    def __init__(self, filename: str, user: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(self, filename: str, user: Optional[UserInfo] = None) -> None:
         self.filename = filename
         self.job_id = f"{id(self):016X}"
         self.time_added = time.time()
@@ -334,7 +334,7 @@ class QueuedJob:
         return self.filename
 
     @property
-    def user(self) -> Optional[Dict[str, Any]]:
+    def user(self) -> Optional[UserInfo]:
         return self._user
 
     def as_dict(self, cur_time: float) -> Dict[str, Any]:

--- a/moonraker/components/klippy_apis.py
+++ b/moonraker/components/klippy_apis.py
@@ -24,6 +24,7 @@ from typing import (
 )
 if TYPE_CHECKING:
     from ..confighelper import ConfigHelper
+    from ..common import UserInfo
     from .klippy_connection import KlippyConnection as Klippy
     Subscription = Dict[str, Optional[List[Any]]]
     SubCallback = Callable[[Dict[str, Dict[str, Any]], float], Optional[Coroutine]]
@@ -127,7 +128,7 @@ class KlippyAPI(APITransport):
         self,
         filename: str,
         wait_klippy_started: bool = False,
-        user: Optional[Dict[str, Any]] = None
+        user: Optional[UserInfo] = None
     ) -> str:
         # WARNING: Do not call this method from within the following
         # event handlers when "wait_klippy_started" is set to True:

--- a/moonraker/components/simplyprint.py
+++ b/moonraker/components/simplyprint.py
@@ -17,7 +17,7 @@ import logging.handlers
 import tempfile
 from queue import SimpleQueue
 from ..loghelper import LocalQueueHandler
-from ..common import APITransport, JobEvent, KlippyState
+from ..common import APITransport, JobEvent, KlippyState, UserInfo
 from ..utils import json_wrapper as jsonw
 
 from typing import (
@@ -1493,6 +1493,7 @@ class PrintHandler:
         self.download_progress: int = -1
         self.pending_file: str = ""
         self.last_started: str = ""
+        self.sp_user = UserInfo("SimplyPrint", "")
 
     def download_file(self, url: str, start: bool):
         coro = self._download_sp_file(url, start)
@@ -1598,7 +1599,7 @@ class PrintHandler:
         kapi: KlippyAPI = self.server.lookup_component("klippy_apis")
         data = {"state": "started"}
         try:
-            await kapi.start_print(pending, user={"username": "SimplyPrint"})
+            await kapi.start_print(pending, user=self.sp_user)
         except Exception:
             logging.exception("Print Failed to start")
             data["state"] = "error"

--- a/moonraker/eventloop.py
+++ b/moonraker/eventloop.py
@@ -32,6 +32,7 @@ if _uvl_var in ["y", "yes", "true"]:
         _uvl_enabled = True
 
 if TYPE_CHECKING:
+    from asyncio import AbstractEventLoop
     _T = TypeVar("_T")
     FlexCallback = Callable[..., Optional[Awaitable]]
     TimerCallback = Callable[[float], Union[float, Awaitable[float]]]
@@ -41,6 +42,10 @@ class EventLoop:
     TimeoutError = asyncio.TimeoutError
     def __init__(self) -> None:
         self.reset()
+
+    @property
+    def asyncio_loop(self) -> AbstractEventLoop:
+        return self.aioloop
 
     def reset(self) -> None:
         self.aioloop = self._create_new_loop()

--- a/moonraker/server.py
+++ b/moonraker/server.py
@@ -424,6 +424,12 @@ class Server:
         logging.info("Exiting with signal SIGTERM")
         self.event_loop.register_callback(self._stop_server, "terminate")
 
+    def restart(self, delay: Optional[float] = None) -> None:
+        if delay is None:
+            self.event_loop.register_callback(self._stop_server)
+        else:
+            self.event_loop.delay_callback(delay, self._stop_server)
+
     async def _stop_server(self, exit_reason: str = "restart") -> None:
         self.server_running = False
         # Call each component's "on_exit" method

--- a/moonraker/utils/filelock.py
+++ b/moonraker/utils/filelock.py
@@ -96,7 +96,8 @@ class AsyncExclusiveFileLock(contextlib.AbstractAsyncContextManager):
 
     def _release_file(self) -> None:
         with contextlib.suppress(OSError, PermissionError):
-            self.lock_path.unlink(missing_ok=True)
+            if self.lock_path.is_file():
+                self.lock_path.unlink()
         with contextlib.suppress(OSError, PermissionError):
             fcntl.flock(self.fd, fcntl.LOCK_UN)
         with contextlib.suppress(OSError, PermissionError):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,8 @@ dependencies = [
     "pyserial-asyncio==0.6",
     "pillow==9.5.0 ; python_version=='3.7'",
     "pillow==10.3.0 ; python_version>='3.8'",
-    "lmdb==1.4.1",
     "streaming-form-data==1.11.0 ; python_version=='3.7'",
-    "streaming-form-data==1.13.0 ; python_version>='3.8'",
+    "streaming-form-data==1.15.0 ; python_version>='3.8'",
     "distro==1.9.0",
     "inotify-simple==1.3.5",
     "libnacl==2.1.0",
@@ -23,10 +22,9 @@ dependencies = [
     "preprocess-cancellation==0.2.1",
     "jinja2==3.1.4",
     "dbus-next==0.2.3",
-    "apprise==1.7.0",
+    "apprise==1.8.0",
     "ldap3==2.9.1",
-    "python-periphery==2.4.1",
-    "smart_open<=6.4.0"
+    "python-periphery==2.4.1"
 ]
 requires-python = ">=3.7"
 readme = "README.md"

--- a/scripts/install-moonraker.sh
+++ b/scripts/install-moonraker.sh
@@ -55,7 +55,7 @@ install_packages()
 
     else
         echo "Error: system-dependencies.json not found, falling back to legacy pacakge list"
-        PKGLIST="${PKGLIST} python3-virtualenv python3-dev liblmdb-dev"
+        PKGLIST="${PKGLIST} python3-virtualenv python3-dev"
         PKGLIST="${PKGLIST} libopenjp2-7 libsodium-dev zlib1g-dev libjpeg-dev"
         PKGLIST="${PKGLIST} packagekit wireless-tools curl"
         PKGS=${PKGLIST}

--- a/scripts/moonraker-requirements.txt
+++ b/scripts/moonraker-requirements.txt
@@ -6,9 +6,8 @@ pyserial==3.4
 pyserial-asyncio==0.6
 pillow==9.5.0 ; python_version=='3.7'
 pillow==10.3.0 ; python_version>='3.8'
-lmdb==1.4.1
 streaming-form-data==1.11.0 ; python_version=='3.7'
-streaming-form-data==1.13.0 ; python_version>='3.8'
+streaming-form-data==1.15.0 ; python_version>='3.8'
 distro==1.9.0
 inotify-simple==1.3.5
 libnacl==2.1.0
@@ -17,7 +16,6 @@ zeroconf==0.131.0
 preprocess-cancellation==0.2.1
 jinja2==3.1.4
 dbus-next==0.2.3
-apprise==1.7.1
+apprise==1.8.0
 ldap3==2.9.1
 python-periphery==2.4.1
-smart_open<=6.4.0

--- a/scripts/system-dependencies.json
+++ b/scripts/system-dependencies.json
@@ -2,7 +2,6 @@
     "debian": [
         "python3-virtualenv",
         "python3-dev",
-        "liblmdb-dev",
         "libopenjp2-7",
         "libsodium-dev",
         "zlib1g-dev",


### PR DESCRIPTION
This series moves Moonraker's underlying database implementation from LMDB to Sqlite3.  This is essentially a rewrite of `database.py` and a significant refactor of `history.py` and `authorization.py`.   As such, I'm creating a pull request for these changes  before merging.   Users should see no difference, Moonraker will convert the existing lmdb database.  Moonraker will not delete the prior lmdb database in the event that a bug is discovered that I missed in testing.

In addition, this should not break frontends, nor should it impact any components using internal APIs.  This is accomplished by creating a `namespace_store` table, which is effectively a key-value store that mimics the way LMDB stores data.

The motivation for this change is several fold:
- LMDB databases are architecture dependent.  This has been an issue for users looking to transfer their database.  Sqlite databases have no such dependency.
- Sqlite backups don't require a special script.  Simply stop the Moonraker service, then copy or restore the database file.  Sqlite3 supports live backup and restore as well, which are implemented as API endpoints in this PR.
- Moonraker is beginning to outgrow the limitations imposed by the LMDB database.   The `/server/history/list` endpoints includes search/sort parameters that are easily applied using SQL.  Future components that need to store, categorize, and search data can create their own tables to simplify access.
- Sqlite3 is generally delivered as part of the standard python distribution, eliminating some external dependencies.

As mentioned above, this PR adds endpoints to backup and restore the sqlite database.  In addition an endpoint is available to delete backups.  Backups cannot be downloaded as they main contain sensitive information.  Users will need to use physical media or another protocol (SCP, SMB, etc) to transfer backups off the host.

The one change that *could* affect frontend developers is that the existing debug endpoints can no longer be used to manipulate the job history, job totals, or authorized users.  These items have been migrated from "namespaces" to tables, so `/debug/database/item` can't access them.   This PR does include code for debug endpoints to manipulate rows, however I decided against enabling them for the time being.   Given that SQL is ubiquitous, I think it might be easier for devs to write a script to manipulate these tables (ie: make fake entries) if the need arises.
