### PR TITLE
Allow default metadata parser timeout to be configurable

### DIFF
--- a/moonraker/components/file_manager/file_manager.py
+++ b/moonraker/components/file_manager/file_manager.py
@@ -2280,6 +2280,8 @@ class MetadataStorage:
         self.server = config.get_server()
         self.enable_object_proc = config.getboolean(
             'enable_object_processing', False)
+        self.default_metadata_parser_timeout = config.getfloat(
+            'default_metadata_parser_timeout', 20.)
         self.gc_path = ""
         db.register_local_namespace(METADATA_NAMESPACE)
         self.mddb = db.wrap_namespace(
@@ -2545,13 +2547,13 @@ class MetadataStorage:
         filename = filename.replace("\"", "\\\"")
         cmd = " ".join([sys.executable, METADATA_SCRIPT, "-p",
                         self.gc_path, "-f", f"\"{filename}\""])
-        timeout = 10.
+        timeout = self.default_metadata_parser_timeout
         if ufp_path is not None and os.path.isfile(ufp_path):
-            timeout = 300.
+            timeout = max(timeout, 300.)
             ufp_path.replace("\"", "\\\"")
             cmd += f" -u \"{ufp_path}\""
         if self.enable_object_proc:
-            timeout = 300.
+            timeout = max(timeout, 300.)
             cmd += " --check-objects"
         result = bytearray()
         sc: SCMDComp = self.server.lookup_component('shell_command')


### PR DESCRIPTION
Hi, I'm the author of Happy Hare - a MMU extension to Klipper.  Happy Hare adds a couple of pieces of functionality to Moonraker, one of which extends the metadata parsing to find and substitute placeholders in the gcode.  E.g. to assess the set of Tools used in a multi-color print.  The issue is that this adds a little extra processing time and the hard coded default of 10s is insufficient.  (I know that if "object processing" is enabled the default jumps to 300s which is a current workaround).

This PR adds the ability to optionally specify the default (minimum) timeout using an extra optional parameters under file_manager:
```
[file_manager]
default_metadata_parser_timeout: 30
```

Which replaces the old default if specified. This can also be used to push object_processing timeout higher if really necessary...

Finally, I increased the code default to 20s because it seems to make more sense in my testing for large gcode files even without the added Happy Hare option. This could remain 10 with the exposed config if necessary.

**Side note:** If the metadata parsing does fail, then there are bugs in other tools like KlipperScreen (I have a PR to fix as well) that will cause massive amount of errors being written to syslog which will usually lead to Timer to Close errors with Klipper.
