### PR TITLE
metadata: Add support to extract metadata from g-code files generated by QIDISlicer

### DIFF
--- a/moonraker/components/file_manager/metadata.py
+++ b/moonraker/components/file_manager/metadata.py
@@ -313,6 +313,7 @@ class PrusaSlicer(BaseSlicer):
             'SliCR-3D': r"SliCR-3D\s(.*)\son",
             'BambuStudio': r"BambuStudio[^ ]*\s(.*)\n",
             'A3dp-Slicer': r"A3dp-Slicer\s(.*)\son",
+            'QIDISlicer': r"QIDISlicer\s(.*)\son",
         }
         for name, expr in aliases.items():
             match = re.search(expr, data)


### PR DESCRIPTION
This PR adds support to extract metadata from the g-code files generated by [QIDISlicer](https://github.com/QIDITECH/QIDISlicer).