### PR TITLE
Read MQTT clientId from config 'client_id' param, with default value …

### DIFF
--- a/moonraker/components/mqtt.py
+++ b/moonraker/components/mqtt.py
@@ -340,6 +340,7 @@ class MQTTClient(APITransport):
                 f"Invalid value '{protocol}' for option 'mqtt_protocol' "
                 "in section [mqtt]. Must be one of "
                 f"{MQTT_PROTOCOLS.values()}")
+        self.client_id = config.get('client_id', socket.gethostname())
         self.instance_name = config.get('instance_name', socket.gethostname())
         if '+' in self.instance_name or '#' in self.instance_name:
             raise config.error(


### PR DESCRIPTION
Read MQTT clientId configuration option from moonraker.conf. Default value is socket hostname.