### PR TITLE
Add support for 'png begin' and 'png end'

### DIFF
--- a/moonraker/components/file_manager/metadata.py
+++ b/moonraker/components/file_manager/metadata.py
@@ -208,7 +208,7 @@ class BaseSlicer(object):
     def parse_thumbnails(self) -> Optional[List[Dict[str, Any]]]:
         for data in [self.header_data, self.footer_data]:
             thumb_matches: List[str] = re.findall(
-                r"; thumbnail begin[;/\+=\w\s]+?; thumbnail end", data)
+                r"; (thumbnail|png) begin[;/\+=\w\s]+?; (thumbnail|png) end", data)
             if thumb_matches:
                 break
         else:


### PR DESCRIPTION
I have an Ender3 V3 KE, with testing I've found that the display will show thumbnails if the text "png begin" is used, but NOT if the text "thumbnail begin" is used.

I've changed my slicer to use "png begin" but now moonraker can't detect the images...

Can we add support for both specification of png thumbnails?