### PR TITLE
Send Spoolman spool info to klipper

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3287,6 +3287,22 @@ With the above configuration it is possible to run the `SET_ACTIVE_SPOOL ID=1`
 command to set the currently tracked spool ID to `1`, and the `CLEAR_ACTIVE_SPOOL`
 to clear spool tracking (useful when unloading filament for example).
 
+#### Sending spool info to Klipper
+
+When changing the spool id, spoolman will fetch info about the spool
+from Spoolman and it can send that info to Klipper.
+
+Moonraker does that by running gcode like this:
+"`_SPOOLMAN_SET_FIELD_name VALUE=val`".
+where name is the field's name. For nestled fields, the names are separated by '_'.
+
+Ie if the spool has a filament id of 2, it will run:
+`_SPOOLMAN_SET_FIELD_filament_id VALUE=2`.
+
+When the spool id is cleared, it will run:
+`_SPOOLMAN_CLEAR_FIELDS`.
+
+
 ## Include directives
 
 It is possible to include configuration from other files via include


### PR DESCRIPTION
This is a fix for  #702 and #877

## Description

I have a very shallow knowledge of python, klipper's gcode templates and the moonraker codebase so don't hesitate to suggest better ways I can do this.

This changes the spoolman integration so that when the spool id is changed, moonraker will lookup
the new spool's data from spoolman. For every field in the spool's data, it checks if there is a gcode macro
in Klipoper with the name `_SPOOLMAN_SET_FIELD_<fieldname>`. If there is, it will be called
 with `VALUE=<value>` as argument.

For nested fields, the field names are separated by underscore, ie it can call:
`_SPOOLMAN_SET_FIELD_filament_vendor_name VALUE="Funky Filament Factory"`

When the spool id is cleared, it will instead call `_SPOOLMAN_CLEAR_FIELDS`, if available.

## Testing

I've tested it on my own printer because I want to store the filemant.id in a variable.
That works fine. I've tested without these gcode macros, with just one for setting or clearing and with both macros for setting and clearing the fields.

## Backwards compatibility

This should not affect old installs, if they don't configure any `_SPOOLMAN_*` macros, nothing changes.