### PR TITLE
updated depencies to run on Mint LInux

### DIFF
--- a/scripts/system-dependencies.json
+++ b/scripts/system-dependencies.json
@@ -1,5 +1,17 @@
 {
-    "debian": [
+     "debian": [
+        "python3-virtualenv",
+        "python3-dev",
+        "libopenjp2-7",
+        "libsodium-dev",
+        "zlib1g-dev",
+        "libjpeg-dev",
+        "packagekit",
+        "wireless-tools",
+        "curl",
+        "build-essential"
+    ],
+    "linuxmint": [
         "python3-virtualenv",
         "python3-dev",
         "libopenjp2-7",

--- a/scripts/system-dependencies.json
+++ b/scripts/system-dependencies.json
@@ -1,5 +1,5 @@
 {
-     "debian": [
+    "debian": [
         "python3-virtualenv",
         "python3-dev",
         "libopenjp2-7",


### PR DESCRIPTION
Moonraker used to run on LInux Mint, my son ran into issues last night installing it on his workbench.

Updated system dependencies to allow for Linux Mint install 