### PR TITLE
metadata: balanced quoted string split

### DIFF
--- a/moonraker/components/file_manager/metadata.py
+++ b/moonraker/components/file_manager/metadata.py
@@ -71,11 +71,19 @@ def regex_find_ints(pattern: str, data: str) -> List[int]:
 
 def regex_find_strings(pattern: str, separators: str, data: str) -> List[str]:
     pattern = pattern.replace(r"(%S)", r"(.*)")
-    separators = re.escape(separators)
-    delimiters = rf"[{separators}]"
     match = re.search(pattern, data)
     if match and match.group(1):
-        return re.split(delimiters, match.group(1).strip('"'))
+        separators = re.escape(separators)
+        pattern = rf'\s*(")(?:\\"|[^"])*"\s*|[^{separators}]+'
+        parsed_matches: List[str] = []
+        for m in re.finditer(pattern, match.group(1)):
+            (val, sep) = m.group(0, 1)
+            val = val.strip()
+            if sep:
+                val = val[1:-1].replace(rf'\{sep}', sep).strip()
+            if val:
+                parsed_matches.append(val)
+        return parsed_matches
     return []
 
 def regex_find_float(pattern: str, data: str) -> Optional[float]:


### PR DESCRIPTION
This is a follow up on PR #962 as I just noticed that the split and then parse uses unbalanced regular expressions (so a string like `"bla;bla";"bla"` will produce `['"bla', 'bla"', '"bla"]` instead of `['"bla;bla"', '"bla"]`)

Regex is kind of a personal challenge, so I took a stab in rewriting the pattern with a balanced one!

The new method will accept values with properly balanced double quotes (including escaped double-quotes) or simple values followed by the separators!

Quotes will be stripped and then all spaces will be trimmed in the resulting values.