### PR TITLE
metadata: filament_name and filament_type as array

### DIFF
--- a/moonraker/components/file_manager/metadata.py
+++ b/moonraker/components/file_manager/metadata.py
@@ -429,14 +429,24 @@ class PrusaSlicer(BaseSlicer):
         return None
 
     def parse_filament_type(self) -> Optional[str]:
-        return regex_find_string(
-            r";\sfilament_type\s=\s(%S)", self.footer_data
+        result = regex_find_strings(
+            r";\sfilament_type\s=\s(%S)", ",;", self.footer_data
         )
+        if len(result) > 1:
+            return json.dumps(result)
+        elif result:
+            return result[0]
+        return None
 
     def parse_filament_name(self) -> Optional[str]:
-        return regex_find_string(
-            r";\sfilament_settings_id\s=\s(%S)", self.footer_data
+        result = regex_find_strings(
+            r";\sfilament_settings_id\s=\s(%S)", ",;", self.footer_data
         )
+        if len(result) > 1:
+            return json.dumps(result)
+        elif result:
+            return result[0]
+        return None
 
     def parse_filament_colors(self) -> Optional[List[str]]:
         return regex_find_strings(


### PR DESCRIPTION
Following up on #975, this does exactly what we discussed!

For `filament_name` and `filament_type` fields, we now search for multiple strings and then:

- if no value was found, return `None` (current behavior)
- if a single value was found, we return the value (current behavior)
- if more than one value was found, return all values as a serialized JSON blob (new behavior)

I've ran a couple of tests in Fluidd, this seems to work fine!