### PR TITLE
metadata: improves Cura multi-extruder support

### DIFF
--- a/moonraker/components/file_manager/metadata.py
+++ b/moonraker/components/file_manager/metadata.py
@@ -581,13 +581,30 @@ class Cura(BaseSlicer):
         return regex_find_float(r";MAXZ:(%F)", self.header_data)
 
     def parse_filament_total(self) -> Optional[float]:
-        filament = regex_find_float(r";Filament\sused:\s(%F)m", self.header_data)
-        if filament is not None:
-            filament *= 1000
-        return filament
+        line = regex_find_string(r';Filament\sused:\s(%S)\n', self.header_data)
+        if line:
+            filament = regex_find_floats(
+                r"(%F)", line
+            )
+            if filament:
+                return sum(length * 1000 for length in filament)
+        return None
 
     def parse_filament_weight_total(self) -> Optional[float]:
-        return regex_find_float(r";Filament\sweight\s=\s.(%F).", self.header_data)
+        filament_weights = self.parse_filament_weights()
+        if filament_weights:
+            return sum(filament_weights)
+        return None
+
+    def parse_filament_weights(self) -> Optional[List[float]]:
+        line = regex_find_string(r';Filament\sweight\s=\s\[(%S)\]', self.header_data)
+        if line:
+            weights = regex_find_floats(
+                r"(%F)", line
+            )
+            if weights:
+                return weights
+        return None
 
     def parse_filament_type(self) -> Optional[str]:
         return regex_find_string(r";Filament\stype\s=\s(%S)", self.header_data)


### PR DESCRIPTION
Cura is horribly bad in providing metadata on the gcode files, but we can improve the parsing capability a bit by correctly handling `filament_total`, `filament_weight_total`, and `filament_weights`, as all of these are represented in the gcode as arrays!

I tested this myself with a couple of files, here's 2 header examples directly from Cura 5.9:

```text
;FLAVOR:Marlin
;TIME:4493
;Filament used: 0.500757m, 0.502888m, 0m
;Layer height: 0.1
;MINX:67.45
;MINY:66.199
;MINZ:0.3
;MAXX:132.551
;MAXY:133.751
;MAXZ:9
;TARGET_MACHINE.NAME:Unknown
;Generated with Cura_SteamEngine 5.9.1


; Pre-Processed for Cancel-Object support by preprocess_cancellation v0.2.0
; 2 known objects
EXCLUDE_OBJECT_DEFINE NAME=2040_MGN12_guide_stl_1 CENTER=100.947,113.723 POLYGON=[[67.45,66.199],[67.45,126.0],[132.551,126.0],[132.551,66.199]]
EXCLUDE_OBJECT_DEFINE NAME=2040_MGN12_guide_stl CENTER=101.060,88.426 POLYGON=[[75.2,73.948],[75.2,99.048],[124.8,99.048],[124.8,73.948]]
T0
M140 S85
M105
M190 S85
M104 S200
M104 T1 S145
M105
M109 S200
M105
M109 T1 S145
M82 ;absolute extrusion mode
;Nozzle diameter = 0.4
;Filament type = PLA
;Filament name = PLA
;Filament weight = [3.961216025390625, 3.528933471679688, 0.0] ; M190 S85
; M109 S200
G28 ;Home
```

```text
;FLAVOR:Marlin
;TIME:1954
;Filament used: 2.75583m
;Layer height: 0.2
;MINX:120.875
;MINY:119.625
;MINZ:0.2
;MAXX:179.125
;MAXY:180.325
;MAXZ:8.2
;TARGET_MACHINE.NAME:VORON Trident 300
;Generated with Cura_SteamEngine 5.9.1
M82 ;absolute extrusion mode
;Nozzle diameter = 0.4
;Filament type = ABS
;Filament name = ABS
;Filament weight = [7.2913983398437505]; M190 S80
; M109 S230
print_start EXTRUDER=230 BED=80 CHAMBER=36
```