### PR TITLE
power: removes extra space from command

### DIFF
--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -617,7 +617,7 @@ class KlipperDevice(PowerDevice):
         self.timer_handle: Optional[asyncio.TimerHandle] = None
         self.object_name = config.get('object_name')
         obj_parts = self.object_name.split()
-        self.gc_cmd = f"SET_PIN PIN={obj_parts[-1]} "
+        self.gc_cmd = f"SET_PIN PIN={obj_parts[-1]}"
         if obj_parts[0] == "gcode_macro":
             self.gc_cmd = obj_parts[-1]
         elif obj_parts[0] != "output_pin":


### PR DESCRIPTION
Really minor fix: Moonraker `[power]` component when pointing to a Klipper pin sends 2 spaces instead of a single one, this fixed it:

![image](https://github.com/user-attachments/assets/2cd37423-80f0-448c-9f04-fa1d5f145271)

On that screenshot, the top of is from Moonraker, the bottom one is from Fluidd)