### PR TITLE
power: in process_request replace notify_power_changed with process_power_changed

### DIFF
--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -402,7 +402,7 @@ class PowerDevice:
                 if req == cur_state:
                     # device is already in requested state, do nothing
                     if base_state != cur_state:
-                        self.notify_power_changed()
+                        await self.process_power_changed()
                     return cur_state
                 if not force:
                     kconn: KlippyConnection


### PR DESCRIPTION
When the powerstate was changed by third party, and a power on request is sent, moonraker is now able to start klippy properly.

My previous workflow was: 
I go to the printer, check if it has power and see that it doesn't have power. 
Therefore, I push the button on wireless socket thingy, which makes my printer light up and pull up Mainsail on my Laptop/Phone.
There is the popup to toggle to power on the printer, because it didn't notice that it was switched on manually (which is fine).
So I press the "power on" button in the UI, it displays the "moonraker can't connect" and stays at this screen, because it is stuck in the codepath where it just sent a notification, but doesn't try to restart klippy. 
In that case the button to power on or off isn't displayed at all anymore and there is no obvious way to get out of this, other than restarting the moonraker systemd-service.

process_power_changed should call notify_power_changed as well, I don't see incompatibilities, but I am new to the codebase :)
I tested this on my printer.

Thank you very much for this awesome piece of software in the open-source 3D-printing-stack!!
MrSmör ^^