### PR TITLE
fix typos in git_deploy.py

### DIFF
--- a/moonraker/components/update_manager/git_deploy.py
+++ b/moonraker/components/update_manager/git_deploy.py
@@ -737,7 +737,7 @@ class GitRepo:
                 self.repo_warnings.append(msg)
         if self.is_dirty():
             self.repo_warnings.append(
-                "Repo is dirty.  Detected the following modifed files: "
+                "Repo is dirty.  Detected the following modified files: "
                 f"{self.modified_files}"
             )
         self._generate_warn_msg()

--- a/moonraker/components/update_manager/git_deploy.py
+++ b/moonraker/components/update_manager/git_deploy.py
@@ -720,7 +720,7 @@ class GitRepo:
             self.repo_anomalies.append(f"Unofficial remote url: {self.upstream_url}")
         if self.git_branch != self.primary_branch or self.git_remote != "origin":
             self.repo_anomalies.append(
-                "Repo not on offical remote/branch, expected: "
+                "Repo not on official remote/branch, expected: "
                 f"origin/{self.primary_branch}, detected: "
                 f"{self.git_remote}/{self.git_branch}")
         if self.untracked_files:
@@ -893,7 +893,7 @@ class GitRepo:
         reset_commit: Optional[str] = None
         async with self.git_operation_lock:
             if branch is None:
-                # No branch is specifed so we are checking out detached
+                # No branch is specified so we are checking out detached
                 if self.channel != Channel.DEV or self.pinned_commit is not None:
                     reset_commit = self.upstream_commit
                 branch = f"{self.git_remote}/{self.git_branch}"
@@ -1219,7 +1219,7 @@ class GitRepo:
                     fix_loose = False
                     attempts = 2
                 else:
-                    # since the attept to repair failed, bypass attempts
+                    # since the attempt to repair failed, bypass attempts
                     # and immediately raise an exception
                     raise self.server.error(
                         "Unable to repair loose objects, use hard recovery"


### PR DESCRIPTION
found this typo while using fluidd:

<img width="624" height="89" alt="Screenshot 2025-07-24 at 21 16 55" src="https://github.com/user-attachments/assets/110278ce-b3bf-4b38-8547-6b072c033e79" />
