### PR TITLE
mqtt: add support for configurable TLS CA and client certificates

### DIFF
--- a/moonraker/components/mqtt.py
+++ b/moonraker/components/mqtt.py
@@ -318,6 +318,9 @@ class MQTTClient(APITransport):
         self.address: str = config.get('address')
         self.port: int = config.getint('port', 1883)
         self.tls_enabled: bool = config.getboolean("enable_tls", False)
+        self.tls_ca_certs: Optional[str] = config.get('tls_ca_certs', None)
+        self.tls_certfile: Optional[str] = config.get('tls_certfile', None)
+        self.tls_keyfile: Optional[str]  = config.get('tls_keyfile', None)
         user = config.gettemplate('username', None)
         self.user_name: Optional[str] = None
         if user:
@@ -444,7 +447,11 @@ class MQTTClient(APITransport):
                              payload=jsonw.dumps({'server': 'offline'}),
                              qos=self.qos, retain=True)
         if self.tls_enabled:
-            self.client.tls_set()
+            self.client.tls_set(
+                ca_certs=self.tls_ca_certs,
+                certfile=self.tls_certfile,
+                keyfile=self.tls_keyfile
+            )
         self.client.connect_async(self.address, self.port)
         self.connect_task = self.eventloop.create_task(
             self._do_reconnect(first=True)


### PR DESCRIPTION
## Summary
This PR extends the MQTT client configuration to support explicit TLS certificate paths in `moonraker.conf`.  
It enables Moonraker to connect to MQTT brokers that use private/self-signed CAs or require mutual TLS authentication without modifying the system-wide CA store.

## New configuration options (in the `[mqtt]` section)
- `tls_ca_certs`: Path to a CA certificate bundle or file (PEM) used to validate the broker’s certificate.
- `tls_certfile`: Optional client certificate (PEM) for mutual TLS authentication.
- `tls_keyfile`: Optional private key (PEM) for mutual TLS authentication.

## Behavior
- TLS setup is performed **only** if `enable_tls: true` is set.
- All new options are optional.
- If no certificate paths are provided, the client falls back to the system CA store and default behavior.
- Existing configurations remain unaffected.

## Example configuration
```
[mqtt]
address: broker.example.lan
port: 8883
enable_tls: true
tls_ca_certs: /etc/ssl/certs/my_ca_bundle.pem
# Optional (for mutual TLS):
# tls_certfile: /etc/ssl/mqtt/client.crt
# tls_keyfile:  /etc/ssl/mqtt/client.key
```