### PR TITLE
fix: non-strict JSON decode for compat w/ klipper JSON output

### DIFF
--- a/moonraker/utils/json_wrapper.py
+++ b/moonraker/utils/json_wrapper.py
@@ -22,12 +22,16 @@ if _msgspc_var in ["y", "yes", "true"]:
         encoder = msgspec.json.Encoder()
         decoder = msgspec.json.Decoder()
         dumps = encoder.encode  # noqa: F811
-        loads = decoder.decode  # noqa: F811
+
+        def loads(data: str | bytes | bytearray) -> Any:  # noqa: F811
+            return decoder.decode(data, strict=False)
+
         MSGSPEC_ENABLED = True
+
 if not MSGSPEC_ENABLED:
     import json
     from json import JSONDecodeError  # type: ignore # noqa: F401,F811
-    loads = json.loads  # type: ignore
+    loads = json.loads  # type: ignore # noqa: F811
 
     def dumps(obj) -> bytes:  # type: ignore # noqa: F811
         return json.dumps(obj).encode("utf-8")


### PR DESCRIPTION
Klipper uses the std lib JSON module when `msgspec` is not installed.
This encoder produces non-strict JSON, notably supporting inf/NaN.

Run the `msgspec` JSON decoder in non-strict mode for out-of-the-box compatibility.
This also fixes divergence in behaviour between different settings for `MOONRAKER_ENABLE_MSGSPEC`. If disabled, then the std lib JSON module is used, which non-strict.

See [here](https://jcristharif.com/msgspec/supported-types.html) for details regarding what `strict=False` enables.