### PR TITLE
metadata: adds JPG and QOI thumbnails support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "apprise==1.9.2",
     "ldap3==2.9.1",
     "python-periphery==2.4.1",
+    "qoi==0.7.2",
     "importlib_metadata==6.7.0 ; python_version=='3.7'",
     "importlib_metadata==8.2.0 ; python_version>='3.8'"
 ]

--- a/scripts/moonraker-requirements.txt
+++ b/scripts/moonraker-requirements.txt
@@ -15,5 +15,6 @@ dbus-fast>=2.21.3, <=2.44.1
 apprise==1.9.2
 ldap3==2.9.1
 python-periphery==2.4.1
+qoi==0.7.2
 importlib_metadata==6.7.0 ; python_version=='3.7'
 importlib_metadata==8.2.0 ; python_version>='3.8'


### PR DESCRIPTION
This PR add support for JPG and QOI thumbnails, as Prusa Slicer (and derivatives) have support for these also and not only PNG.

<img width="936" height="713" alt="image" src="https://github.com/user-attachments/assets/2bd74ef4-effc-4bdf-a30c-9ef1fe1559ac" />

I have used these [samples files](https://github.com/user-attachments/files/22239701/samples.zip) to test these changes.
