### PR TITLE
td1: Adding support for interfacing with TD1 devices

### DIFF
--- a/docs/external_api/integrations.md
+++ b/docs/external_api/integrations.md
@@ -169,11 +169,11 @@ Content-Type: application/json
 /// api-response-spec
     open: True
 
-| Field    |  Type  | Description                               |
-| -------- | :----: | ----------------------------------------- |
-| `status` | string | The status of the test result.  Currently |
-|          |        | will always be `success`.                 |^
-| `stats`  | object | A [Print Stats](#print-stats-spec) object.|                                          |
+| Field    |  Type  | Description                                |
+| -------- | :----: | ------------------------------------------ |
+| `status` | string | The status of the test result.  Currently  |
+|          |        | will always be `success`.                  |^
+| `stats`  | object | A [Print Stats](#print-stats-spec) object. |
 
 | Field            |  Type  | Description                                        |
 | ---------------- | :----: | -------------------------------------------------- |
@@ -1697,4 +1697,121 @@ Not Available
     }
 }
 ```
+///
+
+
+## TD-1
+[TD-1](https://ajax-3d.com) is a device designed to capture transmission distance(TD) and color from filament making it easier to add new material directly to your [HueForge](https://shop.thehueforge.com/) filament library. Moonraker has support for interfacing with multiple TD-1 devices(when using a filament changer) that are inline with your filament path to capture this data.
+
+The following endpoints are available when the `[td1]` component has been configured.
+
+### Get TD-1 Data
+Returns TD-1 data for all devices that are connected.
+```{.http .apirequest title="HTTP Request"}
+GET /machine/td1_data
+```
+```{.json .apirequest title="JSON-RPC Request"}
+{
+    "jsonrpc": "2.0",
+    "method": "machine.td1_data",
+    "id": 4654
+}
+```
+/// collapse-code
+```{.json .apiresponse title="Example Response"}
+{
+    "devices": {
+        "E6625877D318C430": {
+            "td": 4.0
+            "color": "122B44"
+            "scan_time": "2025-09-14T03:13:27.189383Z"
+            "error": <only shows up when errors exist>
+        }
+    }
+}
+```
+///
+
+/// api-response-spec
+    open: True
+//// note
+All TD-1 data fields return null after successful power on until first filament
+is scanned.
+////
+| Field     |   Type   | Description                        |
+| --------- | :------: | ---------------------------------- |
+| `devices` | [object] | An array of `TD-1 Serial` objects. |
+|           |          | #td1-serial-spec                   |+
+
+| Field           |   Type   | Description                                     |
+| --------------- | :------: | ----------------------------------------------- |
+| `<td-1 serial>` | [object] | Serial number for `TD-1 data` object containing |
+|                 |          | scan data.                                      |^
+|                 |          | #td1-data-spec                                  |+
+{ #td1-serial-spec} TD-1 Serial
+
+
+
+| Field       |      Type       | Description                                     |
+| ----------- | :-------------: | ----------------------------------------------- |
+| `td`        |      float      | Transmission distance(TD) value for scanned     |
+|             |                 | filament.                                       |^
+| `color`     |     string      | Color of scanned filament in Hex format.        |
+| `scan_time` | datetime string | Current time that filament was scanned          |
+| `error`     |     string      | Script checks for error upon first connecting   |
+|             |                 | to TD-1 device. If an error exists the error is |^
+|             |                 | displayed, if no error exists this field will   |^
+|             |                 | be null.
+{ #td1-data-spec} TD-1 Data
+
+///
+
+### Reset TD-1
+Gives ability to reboot TD-1 device remotely if an error exists when first powering on device.
+
+Example: User has filament inserted before power on TD-1 device, the following error occurs if
+this happens.
+```
+Measured Lux (6) less than 90% stored Lux (52868). If this error is triggered
+without a filament path obstruction, recalibrate the LEDs.
+```
+User can correct error by removing filament and then call this endpoint with provided serial to reboot TD-1 device.
+```{.http .apirequest title="HTTP Request"}
+POST /machine/td1_reboot
+Content-Type: application/json
+
+{
+    "serial": "E6625877D318C430"
+}
+```
+```{.json .apirequest title="JSON-RPC Request"}
+{
+    "jsonrpc": "2.0",
+    "method": "machine.td1_reboot",
+    "params": {
+        "serial": "E6625877D318C430"
+    },
+    "id": 4654
+}
+```
+/// api-parameters
+    open: True
+
+| Name     |  Type  | Default  | Description               |
+| -------- | :----: | -------- | ------------------------- |
+| `serial` | string | REQUIRED | The TD-1 serial to reboot |
+
+///
+
+```{.json .apiresponse title="Example Response"}
+{
+    "status": "ok"
+}
+```
+/// api-response-spec
+    open: True
+| Field    |  Type  | Description                                    |
+| -------- | :----: | ---------------------------------------------- |
+| `status` | string | Returns "ok" if reboot was initiated. Returns  |
+|          |        | "key_error" if provided serial ID is not valid |^
 ///

--- a/docs/external_api/integrations.md
+++ b/docs/external_api/integrations.md
@@ -1708,12 +1708,12 @@ The following endpoints are available when the `[td1]` component has been config
 ### Get TD-1 Data
 Returns TD-1 data for all devices that are connected.
 ```{.http .apirequest title="HTTP Request"}
-GET /machine/td1_data
+GET /machine/td1/data
 ```
 ```{.json .apirequest title="JSON-RPC Request"}
 {
     "jsonrpc": "2.0",
-    "method": "machine.td1_data",
+    "method": "machine.td1.data",
     "id": 4654
 }
 ```
@@ -1777,7 +1777,7 @@ without a filament path obstruction, recalibrate the LEDs.
 ```
 User can correct error by removing filament and then call this endpoint with provided serial to reboot TD-1 device.
 ```{.http .apirequest title="HTTP Request"}
-POST /machine/td1_reboot
+POST /machine/td1/reboot
 Content-Type: application/json
 
 {
@@ -1787,7 +1787,7 @@ Content-Type: application/json
 ```{.json .apirequest title="JSON-RPC Request"}
 {
     "jsonrpc": "2.0",
-    "method": "machine.td1_reboot",
+    "method": "machine.td1.reboot",
     "params": {
         "serial": "E6625877D318C430"
     },

--- a/moonraker/components/td1.py
+++ b/moonraker/components/td1.py
@@ -296,7 +296,7 @@ class TD1:
                 self.logger.error(
                     f"Failed to open port:{port} for TD1 serial {serial_number}")
 
-        except serial.serialutil.SerialException as e:
+        except serial.SerialException as e:
             self.logger.error(f"Failed to open serial port {port}: {e}")
             raise
         except asyncio.CancelledError as e:

--- a/moonraker/components/td1.py
+++ b/moonraker/components/td1.py
@@ -6,7 +6,6 @@
 # This file may be distributed under the terms of the GNU GPLv3 license
 
 import asyncio
-import serial_asyncio
 import serial
 import serial.tools.list_ports
 import logging
@@ -14,61 +13,221 @@ import datetime
 
 from ..common import RequestType
 from ..common import WebRequest
+from ..utils import async_serial
 
 class TD1Protocol(asyncio.Protocol):
-    def __init__(self, serial_number, callback, logger):
+    def __init__(self, config, serial_number, port, logger):
+        self.config = config
+        self.server = config.get_server()
         self.serial_number = serial_number
-        self.callback = callback
+        # Setting port in config file
+        self.config.source.config.set('td1', 'serial', port)
         self.logger = logger
         self.buffer = ""
+        self.error_state = False
+        self.serial = async_serial.AsyncSerialConnection(config,
+                                                         config.get("baudrate", 115200))
+        self.serial_task = None
+        self.enabled = True
 
-    def connection_made(self, transport):
-        self.transport = transport
-        self.loop = asyncio.get_event_loop()
+        # Values to return back for td1_data endpoint
+        self._td = None
+        self._color = None
+        self._scan_time = datetime.datetime.utcnow().isoformat() + "Z"
+        self._error = None
+        self.done_initializing = False
 
-    def data_received(self, data):
-        self.buffer += data.decode("utf-8")
-        while "\n" in self.buffer:
-            line, self.buffer = self.buffer.split("\n", 1)
-            line = line.strip()
-            if line:
-                self.callback(self.serial_number, line)
+    async def initialize(self) -> None:
+        self.serial_task = self.server.get_event_loop().create_task(self.run_serial())
+
+        for _ in range(5):
+            await asyncio.sleep(.01)
+            if self.serial.connected:
+                break
+
+    async def run_serial(self) -> None:
+        try:
+            self.serial.open(timeout=10)
+        except (self.serial.error, OSError):
+            self.error_state = True
+            self.logger.exception(
+                f"Error trying to open TD1 serial: {self.serial_number}"
+            )
+            return
+
+        await self.check_error_file()
+
+        self.done_initializing = True
+
+        while self.enabled:
+            async for line in self.serial.reader:
+                self.buffer += line.decode("utf-8")
+                while "\n" in self.buffer:
+                    line, self.buffer = self.buffer.split("\n", 1)
+                    line = line.strip()
+                    if line:
+                        self._parse_line(line)
+                        self.logger.debug(f"Serial: {self.serial_number} Line: {line}")
+
+            if self.enabled:
+                await asyncio.sleep(0.5)
+
+    def _parse_line(self, line):
+        try:
+            parts = line.split(",")
+            if len(parts) >= 6:
+                self._td = float(parts[4])
+                self._color = parts[5].strip()
+                self._scan_time = datetime.datetime.utcnow().isoformat() + "Z"
+        except Exception as e:
+            self.logger.error(f"Parse error from {self.serial_number}: {e}")
+
+    async def check_error_file(self):
+        """
+        Requests error file from TD1
+
+        :return: Returns empty string if no error.txt file exists, returns error.txt
+                 content if it exists so error can be displayed to user.
+        """
+        file_name = "errors.txt"
+
+        # Wait for acknowledgment from the Raspberry Pi Pico
+        ack = ''
+        while ack != 'ready' and ack != 'No file named errors.txt':
+            # Send the file request command
+            await self.serial.send(b'retrieve file\n')
+            await self.serial.send(f"{file_name}\n".encode('utf-8'))
+            line = await self.serial.reader.readuntil(b'\n')
+            ack = line.decode('utf-8').strip()
+
+        if ack == 'No file named errors.txt':
+            return
+
+        # Receive file size and block count
+        data = await self.serial.reader.readline()
+        file_size = int(data.decode('utf-8').strip())
+        data = await self.serial.reader.readline()
+        blk_count = int(data.decode('utf-8').strip())
+
+        self.logger.info(
+            f"Receiving file: {file_name}, Size: {file_size} bytes, Blocks: {blk_count}"
+        )
+
+        remaining_bytes = file_size
+        block_content = ''
+        for _ in range(blk_count):
+            # Receive a block size
+            data = await self.serial.reader.readuntil(b'\n')
+            block_size = int(data.decode('utf-8').strip())
+
+            # Receive the block content
+            data = await self.serial.reader.readuntil(b'\n')
+            block_content += data.decode()
+
+            remaining_bytes -= block_size
+
+            # Send acknowledgment to the Raspberry Pi Pico
+            await self.serial.send(b'ready\n')
+
+        self.logger.info(f"Error file content: {block_content}")
+        self.logger.info(f"File '{file_name}' received successfully.")
+        self._error = block_content
+
+    async def close(self):
+        self.enabled = False
+        await self.serial.close()
+        try:
+            if self.serial_task is not None or not self.serial_task.done():
+                await self.serial_task
+        except asyncio.CancelledError:
+            self.logger.debug(f"TD1 {self.serial_number} task was already canceled")
+
+    async def reboot(self):
+        self.logger.info(f"Rebooting {self.serial_number}")
+        self.enabled = False
+        self.serial_task.cancel()
+        await self.serial.send('change settings\n'.encode('utf-8'))
+
+        ack = await self.serial.reader.readuntil(b'\n')
+        ack = ack.decode('utf-8').strip()
+        if ack == 'ready':
+            await self.serial.send(b'RGB_Enabled = True\ndone\n')
+
+        ack = await self.serial.reader.readuntil(b'\n')
+        ack = ack.decode('utf-8').strip()
+
+    def get_data(self):
+        if not self.done_initializing:
+            return {}
+        return {
+            self.serial_number: {
+                "td": self._td,
+                "color": self._color,
+                "scan_time": self._scan_time,
+                "error": self._error
+            }
+        }
 
 class TD1:
     def __init__(self, config):
+        self.server = config.get_server()
         self._config = config
-        self._loop = asyncio.get_event_loop()
-        self._logger = logging.getLogger("td1")
+        self._loop = self.server.get_event_loop()
+        self.logger = logging.getLogger("td1")
         self._server = config.get_server()
         self._baudrate = int(config.get('baudrate', 115200))
-        self._ports_by_serial = {}
-        self._latest_data = {}
         self._known_serials = []
         self._vid = 0xE4B2
         self._pid = 0x0045
+        self._enabled = True
+        self._watch_task = None
+        self._start_task = None
+        self.serial_tasks = {}
 
-    async def initialize(self):
+        self._register_endpoints()
+
+    def _register_endpoints(self):
         self._server.register_endpoint(
             "/machine/td1_data", RequestType.GET, self._handle_get_data
         )
         self._server.register_endpoint(
             "/machine/td1_reboot", RequestType.POST, self._handle_reboot
         )
-        await self._start_all_serial_tasks()
-        self._loop.create_task(self._watch_for_new_devices())
+
+    async def close_device(self, device):
+        ret = device.close()
+        if ret is not None:
+            await ret
+
+    async def close(self):
+        # Stop watching for new devices
+        self._enabled = False
+        if self._start_task is not None:
+            await self._start_task
+
+        if self._watch_task is not None:
+            await self._watch_task
+
+        for td1 in self.serial_tasks.values():
+            await self.close_device(td1)
+
+    async def component_init(self):
+        self.logger.debug("Initializing TD1")
+        self._start_task = self._loop.create_task(self._start_all_serial_tasks())
+        self._watch_task = self._loop.create_task(self._watch_for_new_devices())
 
     async def _start_all_serial_tasks(self):
         devices = self._find_td1_devices()
         if not devices:
-            self._logger.warning("No TD1 devices found.")
+            self.logger.warning("No TD1 devices found.")
             return
         for port, serial_number in devices:
             await self._start_serial_task(port, serial_number)
             await asyncio.sleep(0.5)
 
     async def _watch_for_new_devices(self):
-        self._known_serials = set(self._latest_data.keys())
-        while True:
+        self._known_serials = set(self.serial_tasks.keys())
+        while self._enabled:
             await asyncio.sleep(5)  # Scan every 5 seconds
 
             # Find currently connected devices
@@ -76,21 +235,19 @@ class TD1:
             for port, serial_number in self._find_td1_devices():
                 current_serials.add(serial_number)
                 if serial_number not in self._known_serials:
-                    self._logger.info(f"Hot-plugged TD1 detected: {serial_number}")
+                    self.logger.info(f"Hot-plugged TD1 detected: {serial_number}")
                     try:
                         await self._start_serial_task(port, serial_number)
-                        self._known_serials.add(serial_number)
                     except Exception:
                         pass
 
             # Detect disconnected devices
             disconnected_serials = self._known_serials - current_serials
-            self._logger.info(disconnected_serials, self._known_serials)
+            self.logger.info(disconnected_serials, self._known_serials)
             for serial_number in disconnected_serials:
-                self._logger.warning(f"TD1 device disconnected: {serial_number}")
-                if serial_number in self._latest_data:
-                    del self._latest_data[serial_number]
-                    del self._ports_by_serial[serial_number]
+                if serial_number in self.serial_tasks:
+                    await self.close_device(self.serial_tasks[serial_number])
+                    del self.serial_tasks[serial_number]
                 self._known_serials.remove(serial_number)
 
     def _find_td1_devices(self):
@@ -103,51 +260,32 @@ class TD1:
 
     async def _start_serial_task(self, port, serial_number):
         try:
-            # Gather error log
-            error_content = self.check_error_file(port)
-            # Pre-register empty entry so it's visible even before data arrives
-            if serial_number not in self._latest_data:
-                self._latest_data[serial_number] = {
-                    "td": None,
-                    "color": None,
-                    "scan_time": datetime.datetime.utcnow().isoformat() + "Z"
-                }
-                if error_content:
-                    self._latest_data[serial_number].update({"error": error_content})
-            transport, _ = await serial_asyncio.create_serial_connection(
-                asyncio.get_event_loop(),
-                lambda: TD1Protocol(serial_number, self._parse_and_store, self._logger),
-                port,
-                baudrate=self._baudrate
-            )
-            self._logger.info(f"TD1 listening on {port} (Serial: {serial_number})")
-            # Store port and transport so this information can be looked up later
-            # by serial
-            self._ports_by_serial[serial_number] = {
-                "port": port, "transport": transport
-            }
+            self.serial_tasks[serial_number] = TD1Protocol(self._config,
+                                                           serial_number,
+                                                           port,
+                                                           self.logger)
+            ret = self.serial_tasks[serial_number].initialize()
+            if ret is not None:
+                await ret
+
+            if not self.serial_tasks[serial_number].error_state:
+                self.logger.info(f"TD1 listening on {port} (Serial: {serial_number})")
+                self._known_serials.add(serial_number)
+            else:
+                self.logger.error(
+                    f"Failed to open port:{port} for TD1 serial {serial_number}")
 
         except Exception as e:
-            self._logger.error(f"Failed to open serial port {port}: {e}")
-
-    def _parse_and_store(self, serial_number, line):
-        try:
-            parts = line.split(",")
-            if len(parts) >= 6:
-                td = float(parts[4])
-                color = parts[5].strip()
-                self._latest_data[serial_number] = {
-                    "td": td,
-                    "color": color,
-                    "scan_time": datetime.datetime.utcnow().isoformat() + "Z"
-                }
-        except Exception as e:
-            self._logger.error(f"Parse error from {serial_number}: {e}")
+            self.logger.error(f"Failed to open serial port {port}: {e}")
 
     async def _handle_get_data(self, request):
+        latest_data = {}
+        for sn, task in self.serial_tasks.items():
+            latest_data.update(task.get_data())
+
         return {
             "status": "ok",
-            "devices": self._latest_data
+            "devices": latest_data
         }
 
     async def _handle_reboot(self, web_request: WebRequest):
@@ -156,100 +294,23 @@ class TD1:
         """
         serial_number = web_request.get_str("serial")
 
-        if not serial_number:
+        if not serial_number or serial_number not in self.serial_tasks:
             return {
                 "status": "serial_error"
             }
 
-        try:
-            port = self._ports_by_serial[serial_number]["port"]
-            # Close port so that change settings command can be sent to for a reboot
-            transport = self._ports_by_serial[serial_number]["transport"]
-            transport.close()
-        except KeyError as e:
-            self._logger.error(f"Error: {e}")
-            return {
-                "status": "key_error"
-            }
+        await self.serial_tasks[serial_number].reboot()
+        await self.close_device(self.serial_tasks[serial_number])
 
-        if port:
-            # Setting RGB_Enabled setting to True will cause TD-1 to reboot
-            ser = serial.Serial(port, self._baudrate, timeout=5)
-            ser.write('change settings\n'.encode('utf-8'))
-
-            ack = ser.readline().decode('utf-8').strip()
-            if ack == 'ready':
-                ser.write(b'RGB_Enabled = True\ndone\n')
-
-            ack = ser.readline().decode('utf-8').strip()
-            ser.close()
-
-        # Remove serial number from entries if they exist
-        if serial_number in self._latest_data:
-            del self._latest_data[serial_number]
-        if serial_number in self._ports_by_serial:
-            del self._ports_by_serial[serial_number]
+        # # Remove serial number from entries if they exist
+        if serial_number in self.serial_tasks:
+            del self.serial_tasks[serial_number]
         if serial_number in self._known_serials:
             self._known_serials.remove(serial_number)
+
         return {
             "status": "ok"
         }
 
-    def check_error_file(self, port):
-        """
-        Requests error file from TD1
-
-        :param port: Port to connect and read from TD1
-
-        :return: Returns empty string if no error.txt file exists, returns error.txt
-                 content if it exists so error can be displayed to user.
-        """
-        ser = serial.Serial(port, self._baudrate, timeout=5)
-        file_name = "errors.txt"
-        # Send the file request command
-        ser.write(b'retrieve file\n')
-        ser.write(f"{file_name}\n".encode('utf-8'))
-        # Wait for acknowledgment from the Raspberry Pi Pico
-        ack = ''
-        while ack != 'ready' and ack != 'No file named errors.txt':
-            ack = ser.readline().decode('utf-8').strip()
-            self._logger.info(f"ACK: {ack}")
-
-            # Timeout might have occurred, re-request errors file
-            if not ack:
-                ser.write(b'retrieve file\n')
-                ser.write(f"{file_name}\n".encode('utf-8'))
-
-        if ack == 'No file named errors.txt':
-            return ''
-
-        # Receive file size and block count
-        file_size = int(ser.readline().decode('utf-8').strip())
-        blk_count = int(ser.readline().decode('utf-8').strip())
-
-        self._logger.info(
-            f"Receiving file: {file_name}, Size: {file_size} bytes, Blocks: {blk_count}"
-        )
-
-        remaining_bytes = file_size
-        block_content = ''
-        for _ in range(blk_count):
-            # Receive a block size
-            block_size = int(ser.readline().decode('utf-8').strip())
-
-            # Receive the block content
-            block_content += ser.read(block_size).decode()
-
-            remaining_bytes -= block_size
-
-            # Send acknowledgment to the Raspberry Pi Pico
-            ser.write(b'ready\n')
-        ser.close()
-        self._logger.info(f"Error file content: {block_content}")
-        self._logger.info(f"File '{file_name}' received successfully.")
-        return block_content
-
 def load_component(config):
-    component = TD1(config)
-    asyncio.get_event_loop().create_task(component.initialize())
-    return component
+    return TD1(config)

--- a/moonraker/components/td1.py
+++ b/moonraker/components/td1.py
@@ -1,0 +1,255 @@
+# Support for interfacing with TD-1 devices to assist in filament changers grabbing TD
+# and color for all filament loaded.
+#
+# Copyright (C) 2025 AJAX3D and Jim Madill <jcmadill1@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license
+
+import asyncio
+import serial_asyncio
+import serial
+import serial.tools.list_ports
+import logging
+import datetime
+
+from ..common import RequestType
+from ..common import WebRequest
+
+class TD1Protocol(asyncio.Protocol):
+    def __init__(self, serial_number, callback, logger):
+        self.serial_number = serial_number
+        self.callback = callback
+        self.logger = logger
+        self.buffer = ""
+
+    def connection_made(self, transport):
+        self.transport = transport
+        self.loop = asyncio.get_event_loop()
+
+    def data_received(self, data):
+        self.buffer += data.decode("utf-8")
+        while "\n" in self.buffer:
+            line, self.buffer = self.buffer.split("\n", 1)
+            line = line.strip()
+            if line:
+                self.callback(self.serial_number, line)
+
+class TD1:
+    def __init__(self, config):
+        self._config = config
+        self._loop = asyncio.get_event_loop()
+        self._logger = logging.getLogger("td1")
+        self._server = config.get_server()
+        self._baudrate = int(config.get('baudrate', 115200))
+        self._ports_by_serial = {}
+        self._latest_data = {}
+        self._known_serials = []
+        self._vid = 0xE4B2
+        self._pid = 0x0045
+
+    async def initialize(self):
+        self._server.register_endpoint(
+            "/machine/td1_data", RequestType.GET, self._handle_get_data
+        )
+        self._server.register_endpoint(
+            "/machine/td1_reboot", RequestType.POST, self._handle_reboot
+        )
+        await self._start_all_serial_tasks()
+        self._loop.create_task(self._watch_for_new_devices())
+
+    async def _start_all_serial_tasks(self):
+        devices = self._find_td1_devices()
+        if not devices:
+            self._logger.warning("No TD1 devices found.")
+            return
+        for port, serial_number in devices:
+            await self._start_serial_task(port, serial_number)
+            await asyncio.sleep(0.5)
+
+    async def _watch_for_new_devices(self):
+        self._known_serials = set(self._latest_data.keys())
+        while True:
+            await asyncio.sleep(5)  # Scan every 5 seconds
+
+            # Find currently connected devices
+            current_serials = set()
+            for port, serial_number in self._find_td1_devices():
+                current_serials.add(serial_number)
+                if serial_number not in self._known_serials:
+                    self._logger.info(f"Hot-plugged TD1 detected: {serial_number}")
+                    try:
+                        await self._start_serial_task(port, serial_number)
+                        self._known_serials.add(serial_number)
+                    except Exception:
+                        pass
+
+            # Detect disconnected devices
+            disconnected_serials = self._known_serials - current_serials
+            self._logger.info(disconnected_serials, self._known_serials)
+            for serial_number in disconnected_serials:
+                self._logger.warning(f"TD1 device disconnected: {serial_number}")
+                if serial_number in self._latest_data:
+                    del self._latest_data[serial_number]
+                    del self._ports_by_serial[serial_number]
+                self._known_serials.remove(serial_number)
+
+    def _find_td1_devices(self):
+        found = []
+        for port in serial.tools.list_ports.comports():
+            if port.vid == self._vid and port.pid == self._pid:
+                if port.serial_number:
+                    found.append((port.device, port.serial_number))
+        return found
+
+    async def _start_serial_task(self, port, serial_number):
+        try:
+            # Gather error log
+            error_content = self.check_error_file(port)
+            # Pre-register empty entry so it's visible even before data arrives
+            if serial_number not in self._latest_data:
+                self._latest_data[serial_number] = {
+                    "td": None,
+                    "color": None,
+                    "scan_time": datetime.datetime.utcnow().isoformat() + "Z"
+                }
+                if error_content:
+                    self._latest_data[serial_number].update({"error": error_content})
+            transport, _ = await serial_asyncio.create_serial_connection(
+                asyncio.get_event_loop(),
+                lambda: TD1Protocol(serial_number, self._parse_and_store, self._logger),
+                port,
+                baudrate=self._baudrate
+            )
+            self._logger.info(f"TD1 listening on {port} (Serial: {serial_number})")
+            # Store port and transport so this information can be looked up later
+            # by serial
+            self._ports_by_serial[serial_number] = {
+                "port": port, "transport": transport
+            }
+
+        except Exception as e:
+            self._logger.error(f"Failed to open serial port {port}: {e}")
+
+    def _parse_and_store(self, serial_number, line):
+        try:
+            parts = line.split(",")
+            if len(parts) >= 6:
+                td = float(parts[4])
+                color = parts[5].strip()
+                self._latest_data[serial_number] = {
+                    "td": td,
+                    "color": color,
+                    "scan_time": datetime.datetime.utcnow().isoformat() + "Z"
+                }
+        except Exception as e:
+            self._logger.error(f"Parse error from {serial_number}: {e}")
+
+    async def _handle_get_data(self, request):
+        return {
+            "status": "ok",
+            "devices": self._latest_data
+        }
+
+    async def _handle_reboot(self, web_request: WebRequest):
+        """
+        Reboots TD1 device by serial when requested
+        """
+        serial_number = web_request.get_str("serial")
+
+        if not serial_number:
+            return {
+                "status": "serial_error"
+            }
+
+        try:
+            port = self._ports_by_serial[serial_number]["port"]
+            # Close port so that change settings command can be sent to for a reboot
+            transport = self._ports_by_serial[serial_number]["transport"]
+            transport.close()
+        except KeyError as e:
+            self._logger.error(f"Error: {e}")
+            return {
+                "status": "key_error"
+            }
+
+        if port:
+            # Setting RGB_Enabled setting to True will cause TD-1 to reboot
+            ser = serial.Serial(port, self._baudrate, timeout=5)
+            ser.write('change settings\n'.encode('utf-8'))
+
+            ack = ser.readline().decode('utf-8').strip()
+            if ack == 'ready':
+                ser.write(b'RGB_Enabled = True\ndone\n')
+
+            ack = ser.readline().decode('utf-8').strip()
+            ser.close()
+
+        # Remove serial number from entries if they exist
+        if serial_number in self._latest_data:
+            del self._latest_data[serial_number]
+        if serial_number in self._ports_by_serial:
+            del self._ports_by_serial[serial_number]
+        if serial_number in self._known_serials:
+            self._known_serials.remove(serial_number)
+        return {
+            "status": "ok"
+        }
+
+    def check_error_file(self, port):
+        """
+        Requests error file from TD1
+
+        :param port: Port to connect and read from TD1
+
+        :return: Returns empty string if no error.txt file exists, returns error.txt
+                 content if it exists so error can be displayed to user.
+        """
+        ser = serial.Serial(port, self._baudrate, timeout=5)
+        file_name = "errors.txt"
+        # Send the file request command
+        ser.write(b'retrieve file\n')
+        ser.write(f"{file_name}\n".encode('utf-8'))
+        # Wait for acknowledgment from the Raspberry Pi Pico
+        ack = ''
+        while ack != 'ready' and ack != 'No file named errors.txt':
+            ack = ser.readline().decode('utf-8').strip()
+            self._logger.info(f"ACK: {ack}")
+
+            # Timeout might have occurred, re-request errors file
+            if not ack:
+                ser.write(b'retrieve file\n')
+                ser.write(f"{file_name}\n".encode('utf-8'))
+
+        if ack == 'No file named errors.txt':
+            return ''
+
+        # Receive file size and block count
+        file_size = int(ser.readline().decode('utf-8').strip())
+        blk_count = int(ser.readline().decode('utf-8').strip())
+
+        self._logger.info(
+            f"Receiving file: {file_name}, Size: {file_size} bytes, Blocks: {blk_count}"
+        )
+
+        remaining_bytes = file_size
+        block_content = ''
+        for _ in range(blk_count):
+            # Receive a block size
+            block_size = int(ser.readline().decode('utf-8').strip())
+
+            # Receive the block content
+            block_content += ser.read(block_size).decode()
+
+            remaining_bytes -= block_size
+
+            # Send acknowledgment to the Raspberry Pi Pico
+            ser.write(b'ready\n')
+        ser.close()
+        self._logger.info(f"Error file content: {block_content}")
+        self._logger.info(f"File '{file_name}' received successfully.")
+        return block_content
+
+def load_component(config):
+    component = TD1(config)
+    asyncio.get_event_loop().create_task(component.initialize())
+    return component


### PR DESCRIPTION
Feature was requested by AJAX3D(designer of TD1) to add the ability into AFC-Klipper-Add-On to have the ability to automatically collect data from TD1 that are connected inline with filament paths.

So this PR adds a new TD1 module which can automatically connect and interface with multiple TD1s that are connected to a printer. The purpose of this is to be used with filament changers(or standalone) so that color and TD values can be grabbed for each filament that's loaded. This has initially been integrated into a [development branch](https://github.com/jimmyjon711/AFC-Klipper-Add-On/tree/td1) of AFC-Klipper-Add-On and tested by multiple testers. 

Signed-off-by: Jim Madill <jcmadill1@gmail.com>