### PR TITLE
metadata: allow generating thumbnails for unknown slicer

### DIFF
--- a/moonraker/components/file_manager/metadata.py
+++ b/moonraker/components/file_manager/metadata.py
@@ -358,9 +358,6 @@ class UnknownSlicer(BaseSlicer):
     def parse_chamber_temp(self) -> Optional[float]:
         return regex_find_float(r"M191 S(%F)", self.header_data)
 
-    def parse_thumbnails(self) -> Optional[List[Dict[str, Any]]]:
-        return None
-
 class PrusaSlicer(BaseSlicer):
     def check_identity(self, data: str) -> bool:
         aliases = {


### PR DESCRIPTION
This will allow for less common or newly created slicers to attach thumbnails into gcode, without a need to report as being a different slicer.

As for example, OrcaSlicer was one of them in the past:
https://github.com/SoftFever/OrcaSlicer/issues/840#issuecomment-1527428054

I think this feature will be helpful, as `BaseSlicer` already contains all the universal logic for thumbnails, and PrusaSlicer forks won't stop being created.