### PR TITLE
proc_stats : Add support for cpu temperature readout on intel and amd

### DIFF
--- a/moonraker/components/proc_stats.py
+++ b/moonraker/components/proc_stats.py
@@ -41,9 +41,11 @@ STATM_FILE_PATH = "/proc/self/smaps_rollup"
 NET_DEV_PATH = "/proc/net/dev"
 TEMPERATURE_PATH = "/sys/class/thermal/thermal_zone0/temp"
 HWMON_ROOT_PATH = "/sys/class/hwmon/"
-HWMON_INTEL_NAME = "coretemp"
-HWMON_AMD_NAME = "k10temp"
-HWMON_RPI_NAME = "cpu_thermal"
+HWMON_PLATFORMS = {
+    "coretemp": "Intel",
+    "k10temp": "AMD",
+    "cpu_thermal": "Raspberry Pi"
+}
 CPU_STAT_PATH = "/proc/stat"
 MEM_AVAIL_PATH = "/proc/meminfo"
 STAT_UPDATE_TIME = 1.
@@ -307,13 +309,14 @@ class ProcStats:
                 hwmon_name = pathlib.Path(hwmon.path + "/name")
                 try:
                     name = hwmon_name.read_text().strip()
-                    if name == HWMON_AMD_NAME \
-                            or name == HWMON_INTEL_NAME \
-                            or name == HWMON_RPI_NAME:
+                    if name in HWMON_PLATFORMS:
+                        pf = HWMON_PLATFORMS[name]
+                        logging.info(f"Monitoring temperature for {pf} CPU")
                         return hwmon.path + "/temp1_input"
                 except Exception:
                     pass
 
+        logging.info("Monitoring temperature using default thermal zone")
         return TEMPERATURE_PATH
 
     def _format_stats(self, stats: Dict[str, Any]) -> str:


### PR DESCRIPTION
Hi,

I have a bit of niche issue, since most people are running on a raspberry pi.

It seems that on my Intel nuc the thermal_zone0 is not mapped to the cpu temp and is reporting -263.2°C

On my AMD cpu thermal zones don't even seem exist. Only cooling_deviceX

The goal of this change is to try to find the correct temperature file to monitor using hwmon names and matching AMD or Intel kernel drivers.
In case it doesn't match, fallback to the current behavior (the if condition on `cpu_thermal` is probably not needed since raspberry pi's only have one thermal zone, I can remove it if you prefer).

Small explanation where I got the code logic from :
- On AMD cpu's temp1_input is the temp of Tctl [(k10temp kernel documentation)](https://www.kernel.org/doc/html/latest/hwmon/k10temp.html)
- On Intel cpu's temp1_input is the temp of the package [(coretemp kernel documentation)](https://www.kernel.org/doc/html/latest/hwmon/coretemp.html)

A small gist you can fetch if you wanna test it locally : [Gist](https://gist.github.com/martijnvanduijneveldt/10eaef43ee32ef88b09c6145a0bb14ad)

Tested on the following hardware :
- NUC8i3BEK (Intel i3-8109U, Debian)
- PN51 (Ryzen 7 5700U, Debian)
- Raspberry Pi 2B (Raspbian 32bit)

Happy to make any changes upon review 😄 