### PR TITLE
simplyprint: increase connect timeout from 5.0 to 15.0 seconds

### DIFF
--- a/moonraker/components/simplyprint.py
+++ b/moonraker/components/simplyprint.py
@@ -200,7 +200,7 @@ class SimplyPrint(APITransport):
                 log_connect = False
             try:
                 self.ws = await tornado.websocket.websocket_connect(
-                    url, connect_timeout=5.,
+                    url, connect_timeout=15.,
                 )
                 setattr(self.ws, "on_ping", self._on_ws_ping)
                 cur_time = self.eventloop.get_loop_time()
@@ -1507,7 +1507,8 @@ class PrintHandler:
             logging.debug(f"Downloading URL: {url}")
             tmp_path = await client.download_file(
                 url, accept, progress_callback=self._on_download_progress,
-                request_timeout=3600.
+                connect_timeout=15.,
+                request_timeout=3600.,
             )
         except asyncio.TimeoutError:
             raise


### PR DESCRIPTION
Increase the connection timeout to match the OctoPrint implementation, not sure if there was any historical reason for it to be 5 seconds, which we have had reports on not being sufficient in some cases / places on earth.

TBT, needs testing before being merged in, these two places should be the only "hot" paths, but perhaps somehow we can augment the clients default connect timeout, that would be a preferred solution.