### PR TITLE
power: support HTTP digest authentication for Shelly Gen 2+ devices

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1073,6 +1073,10 @@ Currently only Gen 1 Shelly devices support Authentication
 address:
 #   A valid ip address or hostname for the shelly device.  This parameter
 #   must be provided.
+auth_type:
+#   The type of HTTP authentication to use (if username and password are specified).
+#   Defaults to "basic" (for Gen 1 Shelly devices). For Gen 2 and later, "digest"
+#   has to be used.
 user:
 #   A user name to use for request authentication.  This option accepts
 #   Jinja2 Templates, see the [secrets] section for details.  If no password

--- a/moonraker/components/http_client.py
+++ b/moonraker/components/http_client.py
@@ -33,10 +33,9 @@ if TYPE_CHECKING:
     from io import BufferedWriter
     StrOrPath = Union[str, pathlib.Path]
 
-MAX_BODY_SIZE = 512 * 1024 * 1024
 AsyncHTTPClient.configure(
-    None, defaults=dict(user_agent="Moonraker"),
-    max_body_size=MAX_BODY_SIZE
+    "tornado.curl_httpclient.CurlAsyncHTTPClient",
+    defaults=dict(user_agent="Moonraker")
 )
 
 GITHUB_PREFIX = "https://api.github.com/"
@@ -82,7 +81,9 @@ class HttpClient:
         send_etag: bool = True,
         send_if_modified_since: bool = True,
         basic_auth_user: Optional[str] = None,
-        basic_auth_pass: Optional[str] = None
+        basic_auth_pass: Optional[str] = None,
+        digest_auth_user: Optional[str] = None,
+        digest_auth_pass: Optional[str] = None
     ) -> HttpResponse:
         cache_key = url.split("?", 1)[0]
         method = method.upper()
@@ -115,6 +116,11 @@ class HttpClient:
             req_args["auth_username"] = basic_auth_user
             req_args["auth_password"] = basic_auth_pass
             req_args["auth_mode"] = "basic"
+        if digest_auth_user is not None:
+            assert digest_auth_pass is not None
+            req_args["auth_username"] = digest_auth_user
+            req_args["auth_password"] = digest_auth_pass
+            req_args["auth_mode"] = "digest"
         request = HTTPRequest(url, method, headers, **req_args)
         err: Optional[BaseException] = None
         for i in range(attempts):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ dependencies = [
     "ldap3==2.9.1",
     "python-periphery==2.4.1",
     "importlib_metadata==6.7.0 ; python_version=='3.7'",
-    "importlib_metadata==8.2.0 ; python_version>='3.8'"
+    "importlib_metadata==8.2.0 ; python_version>='3.8'",
+    "pycurl==7.45.7"
 ]
 requires-python = ">=3.7"
 readme = "README.md"

--- a/scripts/moonraker-requirements.txt
+++ b/scripts/moonraker-requirements.txt
@@ -17,3 +17,4 @@ ldap3==2.9.1
 python-periphery==2.4.1
 importlib_metadata==6.7.0 ; python_version=='3.7'
 importlib_metadata==8.2.0 ; python_version>='3.8'
+pycurl==7.45.7


### PR DESCRIPTION
Starting with Gen 2, Shelly devices switched from Basic Auth to Digest Auth. This is now supported for all HTTPDevice subclasses.

To support Digest Auth, we have to switch from simple_httpclient to curl_httpclient.

I could successfully test this with my Shelly Plug. I don't have any devices that require Basic Auth, so I could only use log output to test that Basic Auth still works. Would be great if someone with a suitable device could verify that.

Fixes #774.