### PR TITLE
json_wrapper: don't include spaces in encoded json

### DIFF
--- a/moonraker/utils/json_wrapper.py
+++ b/moonraker/utils/json_wrapper.py
@@ -30,4 +30,4 @@ if not MSGSPEC_ENABLED:
     loads = json.loads  # type: ignore
 
     def dumps(obj) -> bytes:  # type: ignore # noqa: F811
-        return json.dumps(obj).encode("utf-8")
+        return json.dumps(obj, separators=(",", ":")).encode("utf-8")


### PR DESCRIPTION
msgspec doesn't encodes into compact JSON, without spaces. Make default json.dumps do the same.

---

Hello, I'm implementing my own client in C. I'm parsing the JSON myself and realized I don't need spaces in the received JSON. I don't think anyone needs them really. It will make my JSON parsing a bit simpler and for higher level languages this change shouldn't matter, since their JSON parsing is robust enough to not care about these spaces altogether.

Then I read that msgspec is encoding into a compact JSON, without spaces, by default. Thus maybe it's fair to make the default `json.dumps` encode a compact JSON, same as msgspec.