### PR TITLE
power: support TP-Link Tapo Smart Plug

### DIFF
--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -1,0 +1,25 @@
+The following component is licensed under the MIT License:
+
+Component: tapo
+
+MIT License
+
+Copyright (c) 2022-2025 Mihai Dinculescu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -724,8 +724,8 @@ The following configuration options are available for all power device types:
 [power device_name]
 type:
 #   The type of device.  Can be either gpio, klipper_device, rf,
-#   tplink_smartplug, tasmota, shelly, homeseer, homeassistant, loxonev1,
-#   smartthings, mqtt, hue, http or uhubctl.
+#   tplink_smartplug, tplink_tapo, tasmota, shelly, homeseer, homeassistant,
+#   loxonev1, smartthings, mqtt, hue, http or uhubctl.
 #   This parameter must be provided.
 initial_state: off
 #    The state the power device should be initialized to.  May be on or
@@ -1015,6 +1015,70 @@ Example:
 [power printer_plug]
 type: tplink_smartplug
 address: 192.168.1.123
+```
+
+#### TP-Link Tapo Configuration
+
+/// Note
+This feature added in Dec. 2025 as a replacement for `tplink_smartplug`.
+This feature uses Unofficial Tapo API Client. For more information, see
+[GitHub](https://github.com/mihai-dinculescu/tapo)
+and [PyPI](https://pypi.org/project/tapo/).
+The library is licensed under the MIT license.
+Copyright (c) 2022-2025 Mihai Dinculescu
+///
+/// Note
+This feature requires Python 3.11 or later. moonraker must be running on
+Python 3.11 or later.
+To install:
+$ ~/moonraker-env/bin/pip install -r ~/moonraker/scripts/moonraker-tapo.txt
+$ sudo systemctl restart moonraker
+///
+
+The following options are available for `tplink_tapo` device types:
+
+```ini {title="Moonraker Config Specification"}
+# moonraker.conf
+
+address:
+#   A valid ip address or hostname for the tplink tapo device.  For example:
+#     192.168.1.127
+#   This parameter must be provided.
+user:
+#   The user name to use for request authentication. The user must be the
+#   same as the one specified when registering the device in the tplink tapo
+#   mobile application. This parameter accepts Jinja2 Templates, see the
+#   [secrets] section for details. This parameter must be provided.
+password:
+#   The password to use for request authentication. The password must be the
+#   same as the one specified when registering the device in the tplink tapo
+#   mobile application. This parameter accepts Jinja2 Templates, see the
+#   [secrets] section for details. This parameter must be provided.
+power_strip:
+#   For power strip which has multiple plugs, This option has to be True.
+#   Default is False which indicate the device is not a power strip.
+device_id:
+nickname:
+output_id:
+#   For power strips, at least one of the above three options must be provided.
+#   These options will be ignored when power_strip is False.
+#   device_id is a 40-digit hex value initialized with the tplink tapo mobile
+#   application.
+#   nickname is a string registrated within the tplink tapo mobile application.
+#   output_id is the socket index to use.
+#   Identify priority is 1:device_id, 2:nickname, and 3:output_id.
+```
+
+Example:
+
+```ini {title="Moonraker Config Example"}
+# moonraker.conf
+
+[power printer_plug]
+type: tplink_tapo
+address: 192.168.1.123
+user: youremailusedwhenyouregisteredtheplug
+password: yourpasswordusedwhenyouregisteredtheplug
 ```
 
 #### Tasmota Configuration

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -187,6 +187,9 @@ particularly for those upgrading:
 - `-s`:
   Installs Moonraker's [speedup](#optional-speedups) Python packages in the
   Python environment.
+- `-t`:
+  Installs Moonraker's [tapo](#optional-tapo) Python package in the Python
+  environment.
 
 Additionally, installation may be customized with the following environment
 variables:
@@ -200,6 +203,7 @@ variables:
 - `MOONRAKER_LOG_PATH`
 - `MOONRAKER_DATA_PATH`
 - `MOONRAKER_SPEEDUPS`
+- `MOONRAKER_TAPO`
 
 When the script completes it should start the Moonraker system service. If Klipper
 is running and Moonraker is able to establish a connection the following log entry
@@ -478,6 +482,26 @@ environment variables in [moonraker.env](#the-environment-file):
 
 - `MOONRAKER_ENABLE_MSGSPEC="n"`
 - `MOONRAKER_ENABLE_UVLOOP="n"`
+
+
+## Optional Tapo
+
+Moonraker supports an optional Python package that can be used to control
+TP-Link Tapo smart plug and power strip:
+
+- [tapo](https://github.com/mihai-dinculescu/tapo): Unofficial Tapo API Client.
+  Requires Python >= 3.11.
+
+If this package is installed in Moonraker's python environment, Moonraker power
+management component will load it.  For existing installations this can be done
+manually with a command
+like:
+
+```
+~/moonraker-env/bin/pip install -r ~/moonraker/scripts/moonraker-tapo.txt
+```
+
+Please see [configuration documentation](./configuration.md) for details.
 
 
 ## PolicyKit Permissions

--- a/moonraker/components/power.py
+++ b/moonraker/components/power.py
@@ -13,6 +13,7 @@ import asyncio
 import time
 import re
 import shutil
+import sys
 from urllib.parse import quote, urlencode
 from ..utils import json_wrapper as jsonw
 from ..common import RequestType, KlippyState
@@ -50,6 +51,7 @@ class PrinterPower:
             "gpio": GpioDevice,
             "klipper_device": KlipperDevice,
             "tplink_smartplug": TPLinkSmartPlug,
+            "tplink_tapo": TPLinkTapo,
             "tasmota": Tasmota,
             "shelly": Shelly,
             "homeseer": HomeSeer,
@@ -1057,6 +1059,124 @@ class TPLinkSmartPlug(PowerDevice):
             raise self.server.error(
                 f"Error Toggling Device Power: {self.name}")
         self.state = state
+
+
+# using Mihai Dinculescu's Unofficial Tapo API Client.
+# https://github.com/mihai-dinculescu/tapo
+# https://pypi.org/project/tapo/
+# Copyright (c) 2022-2025 Mihai Dinculescu
+class TPLinkTapo(PowerDevice):
+    def __init__(self, config: ConfigHelper) -> None:
+        super().__init__(config)
+
+        if sys.version_info < (3, 11):
+            raise config.error(
+                f"[{config.get_name()}]: Tapo support skipped: requires Python 3.11+")
+
+        try:
+            import tapo
+        except ImportError:
+            raise config.error(
+                f"[{config.get_name()}]: Import Error:"
+                " Tapo power device support unavailable."
+                " Install 'tapo' for support.\nexsample:\n"
+                "$ ~/moonraker-env/bin/pip install"
+                " -r ~/moonraker/scripts/moonraker-tapo.txt\n"
+                "$ sudo systemctl restart moonraker\n"
+            )
+        logging.info("Tapo power device support enabled.")
+
+        self.addr: str = config.get("address")
+        self.user: str = config.load_template("user").render()
+        self.password: str = config.load_template("password").render()
+        self.power_strip: bool = config.getboolean("power_strip", False)
+        self.device_id: Optional[str] = config.get("device_id", None)
+        self.nickname: Optional[str] = config.get("nickname", None)
+        self.output_id: Optional[int] = config.getint("output_id", None)
+
+        self._api_client: tapo.ApiClient = tapo.ApiClient(self.user, self.password)
+
+        logging.info(
+            f"Tapo SmartPlug initialized for {self.name} at {self.addr}"
+            f" power_strip:{self.power_strip} device_id:{self.device_id}"
+            f" nickname:{self.nickname} output_id:{self.output_id}"
+        )
+
+        if (self.power_strip
+            and (self.device_id is None
+                 and self.nickname is None
+                 and self.output_id is None)):
+            raise config.error(
+                f"[{config.get_name()}]: Configuration Error:"
+                " Missing required identifier."
+                " If power_strip is true, one of device_id, nickname,"
+                " or output_id must be defined."
+            )
+
+    async def _get_device(self) -> Any:
+        try:
+            if not self.power_strip:
+                # Smart Plug
+                plug_device = await self._api_client.generic_device(self.addr)
+            else:
+                # Smart Power Strip which has multiple plugs
+                power_strip_device = await self._api_client.p300(self.addr)
+                # device_id: Optional[str]
+                #     The Device ID of the device. (40-digits hex str)
+                # nickname:  Optional[str]
+                #     The Nickname of the device. (User specified str with Tapo app.)
+                # position: Optional[int]
+                #     The Position of the device (Position Index)
+                # Identify Priority: 1.device_id, 2.nickname, 3.position
+                plug_device = await power_strip_device.plug(
+                    device_id=self.device_id,
+                    nickname=self.nickname,
+                    position=self.output_id
+                )
+            return plug_device
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            self.state = "error"
+            logging.exception(f"Error Get Tapo Device: {self.name}{e}")
+            raise
+
+    async def init_state(self) -> None:
+        await self.refresh_status()
+
+    async def refresh_status(self) -> None:
+        try:
+            device = await self._get_device()
+            device_info = await device.get_device_info()
+            device_on: bool = device_info.device_on
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            self.state = "error"
+            if self._should_log_error():
+                logging.exception(
+                    f"Error Refreshing Device Status: {self.name} {e}"
+                )
+        else:
+            self.state = "on" if device_on else "off"
+
+    async def set_power(self, state) -> None:
+        try:
+            device = await self._get_device()
+            if state == "on":
+                await device.on()
+            else:
+                await device.off()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            self.state = "error"
+            msg = f"Error Toggling Device Power: {self.name} {e}"
+            if self._should_log_error():
+                logging.exception(msg)
+            raise self.server.error(msg)
+        else:
+            self.state = state
 
 
 class Tasmota(HTTPDevice):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ speedups = [
     "msgspec>=0.18.4 ; python_version>='3.8'",
     "uvloop>=0.17.0"
 ]
+tapo = ["tapo>=0.8.8 ; python_version>='3.11'"]
 dev = ["pre-commit"]
 
 [tool.pdm.version]

--- a/scripts/install-moonraker.sh
+++ b/scripts/install-moonraker.sh
@@ -12,6 +12,7 @@ LOG_PATH="${MOONRAKER_LOG_PATH}"
 DATA_PATH="${MOONRAKER_DATA_PATH}"
 INSTANCE_ALIAS="${MOONRAKER_ALIAS:-moonraker}"
 SPEEDUPS="${MOONRAKER_SPEEDUPS:-n}"
+TAPO="${MOONRAKER_TAPO:-n}"
 SERVICE_VERSION="1"
 DISTRIBUTION=""
 DISTRO_VERSION=""
@@ -296,10 +297,19 @@ create_virtualenv()
             report_status "Installing Speedups..."
             ${PYTHONDIR}/bin/pip install -r ${SRCDIR}/scripts/moonraker-speedups.txt
         fi
+        if [ ${TAPO} = "y" ]; then
+            report_status "Installing Tapo..."
+            ${PYTHONDIR}/bin/pip install -r ${SRCDIR}/scripts/moonraker-tapo.txt
+        fi
     else
         report_status "Installing Moonraker package via Pip..."
         if [ ${SPEEDUPS} = "y" ]; then
             ${PYTHONDIR}/bin/pip install -U moonraker[speedups]
+        else
+            ${PYTHONDIR}/bin/pip install -U moonraker
+        fi
+        if [ ${TAPO} = "y" ]; then
+            ${PYTHONDIR}/bin/pip install -U moonraker[tapo]
         else
             ${PYTHONDIR}/bin/pip install -U moonraker
         fi
@@ -466,13 +476,14 @@ verify_ready()
 }
 
 # Parse command line arguments
-while getopts "rfzxsc:l:d:a:" arg; do
+while getopts "rfzxstc:l:d:a:" arg; do
     case $arg in
         r) REBUILD_ENV="y";;
         f) FORCE_SYSTEM_INSTALL="y";;
         z) DISABLE_SYSTEMCTL="y";;
         x) SKIP_POLKIT="y";;
         s) SPEEDUPS="y";;
+        t) TAPO="y";;
         c) CONFIG_PATH=$OPTARG;;
         l) LOG_PATH=$OPTARG;;
         d) DATA_PATH=$OPTARG;;

--- a/scripts/moonraker-tapo.txt
+++ b/scripts/moonraker-tapo.txt
@@ -1,0 +1,1 @@
+tapo>=0.8.8 ; python_version>='3.11'

--- a/scripts/sync_dependencies.py
+++ b/scripts/sync_dependencies.py
@@ -159,6 +159,17 @@ def sync_requirements() -> int:
                 req_file.write(f"{requirement}\n")
     else:
         print("Speedup sequirements match")
+    # sync tapo
+    tapo_path = SCRIPTS_PATH.joinpath("moonraker-tapo.txt")
+    tapo_deps = optional_deps["tapo"]
+    if check_reqs_changed(tapo_path, tapo_deps):
+        print("Syncing tapo requirement...")
+        ret = 1
+        with tapo_path.open("w+") as req_file:
+            for requirement in tapo_deps:
+                req_file.write(f"{requirement}\n")
+    else:
+        print("Tapo requirement match")
     # sync dev dependencies
     dev_reqs_path = SCRIPTS_PATH.joinpath("moonraker-dev-reqs.txt")
     dev_deps = optional_deps["dev"]


### PR DESCRIPTION
Hello,

I developed this feature primarily for my own needs, so I integrated the TP-Link Tapo smart plug support into moonraker. What do you think?
I read past discussions and know moonraker doesn't accept TP-Link Tapo support that depends on external libraries.
I submitted it anyway, just in case.
I added code to `power.py` that calls the Unofficial Tapo API Client created by Mihai Dinculescu.
[GitHub](https://github.com/mihai-dinculescu/tapo) / [PyPI](https://pypi.org/project/tapo/).
- The client library is under the MIT license.
- The client library itself has no further dependencies on additional external third-party libraries or Python packages.
- The client library itself is written in Rust, and I didn't feel the need to touch Rust directly during the integration process at all.
- PyPI wheels are available for a wide range of architectures. (Supporting x86_64, arm64, aarch64, armv7l, i686, ppc64le, and s390x)
- All client API calls are asynchronous, which should prevent interference with moonraker's overall operation.
- Supported smart plugs: (P100, P105, P110, P110M, P115), power strips (P300, P304M, P316M)
  I have confirmed that it works with the P110M. We need to check with the other plugs and power strips.
- Since the client library supports Python 3.11+, to avoid conflicts with Moonraker running on 3.7<= and <3.11, I initially implemented it using dynamic imports to ensure it only activates for those who really need it. I understand this approach depends on design philosophy; it could be rewritten for static imports or made installable solely via `[project.optional-dependencies]` in pyproject.toml.

I appreciate you taking the time to review this. Any feedback on the approach or integration method is welcome, even if the feature ultimately isn't accepted.

Thank you.
