### PR TITLE
Fix filament accounting with spoolman on mmu setups (happy hare, afc)

### DIFF
--- a/moonraker/components/spoolman.py
+++ b/moonraker/components/spoolman.py
@@ -53,6 +53,7 @@ class SpoolManager:
         self.spool_id: Optional[int] = None
         self._error_logged: bool = False
         self._highest_epos: float = 0
+        self._last_epos: float = 0
         self._current_extruder: str = "extruder"
         self.spool_history = HistoryFieldData(
             "spool_ids", "spoolman", "Spool IDs used", "collect",
@@ -262,6 +263,7 @@ class SpoolManager:
         if toolhead is None:
             return
         epos: float = toolhead.get("position", [0, 0, 0, self._highest_epos])[3]
+        self._last_epos = epos
         extr = toolhead.get("extruder", self._current_extruder)
         if extr != self._current_extruder:
             self._highest_epos = epos
@@ -285,6 +287,7 @@ class SpoolManager:
         self.spool_history.tracker.update(spool_id)
         self.spool_id = spool_id
         self.database.insert_item(DB_NAMESPACE, ACTIVE_SPOOL_KEY, spool_id)
+        self._highest_epos = self._last_epos
         self.server.send_event(
             "spoolman:active_spool_set", {"spool_id": spool_id}
         )


### PR DESCRIPTION
### Summary:
Rebase E high-water mark on active spool change to prevent spoolman undercount after tool changes

### Issue description:
The spoolman integration tracks filament usage using a global “high-water mark” of toolhead E position (_highest_epos). This works for single-material prints, but in MMU (filament swap) scenarios, the E position can be lower than the previous peak at the moment a new spool is activated. This happens due to retract/state-restore/unload sequencing and extruder moves split between macros (for unloading) and direct extruder control in the MMU control software python files.

As a result, the first portion of extrusion on the new spool (often ~tens of mm) only brings E back up to the old peak and is therefore not counted, leading to consistent undercounting on the newly activated spool (e.g. ~45mm missing after a 336mm purge).

### Data gathered:

By adding the below statement at the def set_active_spool(self, spool_id: Union[int, None]) function we can track whether there is any deviation between the high water mark e position (_highest_epos) and the last observed e position (_last_epos)
`logging.info(f"Spool change: new={spool_id}, last_epos={self._last_epos:.3f}, highest={self._highest_epos:.3f}")`

![image](https://github.com/user-attachments/assets/b17e50b0-b7bd-4b55-a90b-5cca6fd5ae57)

### Fix:
Track the latest observed E position (_last_epos) and rebase _highest_epos to the current E whenever the active spool changes. This ensures usage accounting for a new spool starts immediately from the activation point rather than being blocked by an old E peak.

### Implementation details

- Add self._last_epos to SpoolManager.
- Update _last_epos on every toolhead status update.
- Initialize _last_epos alongside _highest_epos in _handle_klippy_ready (so spool activation cannot rebase to 0 before the first status callback).
- In set_active_spool(), after updating self.spool_id, set: self._highest_epos = self._last_epos 
