### PR TITLE
metadata: add JusPrin slicer support

### DIFF
--- a/moonraker/components/file_manager/metadata.py
+++ b/moonraker/components/file_manager/metadata.py
@@ -369,6 +369,7 @@ class PrusaSlicer(BaseSlicer):
             'BambuStudio': r"BambuStudio[^ ]*\s(.*)\n",
             'A3dp-Slicer': r"A3dp-Slicer\s(.*)\son",
             'QIDISlicer': r"QIDISlicer\s(.*)\son",
+            'JusPrin': r"JusPrin\s(.*)\son",
         }
         for name, expr in aliases.items():
             match = re.search(expr, data)


### PR DESCRIPTION
## Summary
- Add JusPrin to the PrusaSlicer-compatible slicer aliases for metadata extraction

JusPrin is a fork of OrcaSlicer that uses the same gcode metadata format. Adding it to the PrusaSlicer aliases allows proper metadata extraction for files sliced with JusPrin.

## Test plan
- Sliced a file with JusPrin 1.4.0
- Before: metadata fields (layer height, nozzle diameter, filament) showed `--`
- After: all metadata fields correctly populated