### PR TITLE
file_manager: add params to limit files count and include metadata

### DIFF
--- a/moonraker/components/file_manager/file_manager.py
+++ b/moonraker/components/file_manager/file_manager.py
@@ -420,8 +420,8 @@ class FileManager:
         from_i = web_request.get_int('from_i', 0)
         to_i = web_request.get_int('to_i', 2**32)
         metadata = web_request.get_boolean('metadata', False)
-        flist = self.get_file_list(root, list_format=True, metadata=metadata)[from_i: to_i]
-        return cast(List[Dict[str, Any]], flist)
+        flist = cast(List[Dict[str, Any]], self.get_file_list(root, list_format=True, metadata=metadata)[from_i: to_i])
+        return flist
 
     async def _handle_metadata_request(self,
                                        web_request: WebRequest


### PR DESCRIPTION
This is just a suggestion, a rough draft of an something that'd be nice to have. I'm not sure how open you are to modifying/adding to the API so for now I have written something rough so we can discuss it.

I'm writing a client for Moonraker and I'm not a fan of the `server.files.list` endpoint.
Client, in order to get a full list of files and the metadata, needs to first call `server.files.list`. It doesn't know how much data Moonraker will respond with and thus how much data it'll have to parse. That's not great. After receiving the files list, the client needs to iterate over it and send a metadata request for each file path. That's a lot of work on the client side. If someone has 100 Gcode files `server.files.list` would respond with roughly 11700 bytes of data. Next the client would need to perform 100 requests to complement that list with metadata.

It'd be nice if I could ask Moonraker to return files from index N to index M and at the same time ask Moonraker to return metadata included in that list.

I'm basically extending this:

```json
{
    "jsonrpc": "2.0",
    "method": "server.files.list",
    "params": {
        "root": "config"
    },
    "id": 4644
}
```

to

```json
{
    "jsonrpc": "2.0",
    "method": "server.files.list",
    "params": {
        "root": "config",
        "from_i": 0,
        "to_i": 32,
        "metadata": true
    },
    "id": 4644
}
```

And the response of `server.files.list` from:

```json
"result": [
    {
        "path": "3DBenchy_0.15mm_PLA_MK3S_2h6m.gcode",
        "modified": 1615077020.2025201,
        "size": 4926481,
        "permissions": "rw"
    },
    {
        "path": "Shape-Box_0.2mm_PLA_Ender2_20m.gcode",
        "modified": 1614910966.946807,
        "size": 324236,
        "permissions": "rw"
    }
]
```

to 

```json
"result": [
    {
        "path": "3DBenchy_0.15mm_PLA_MK3S_2h6m.gcode",
        "modified": 1615077020.2025201,
        "size": 4926481,
        "permissions": "rw"
    },
    {
        "path": "Shape-Box_0.2mm_PLA_Ender2_20m.gcode",
        "modified": 1614910966.946807,
        "size": 324236,
        "permissions": "rw"
    }
],
"count": 100
```

This however might be a bit tricky because `result` is an array, so it's a bit more difficult to squeeze in total `count` into `result`, right?

Anyways, I'd like to know your thoughts on this.