### PR TITLE
Spoolman: Cache active spool data and expose to Klipper macros

### DIFF
--- a/moonraker/components/spoolman.py
+++ b/moonraker/components/spoolman.py
@@ -66,6 +66,7 @@ class SpoolManager:
         self.is_closing: bool = False
         self.spool_id: Optional[int] = None
         self.spool_data: Optional[Dict[str, Any]] = None
+        self._macro_variables: Optional[set] = None
         self._error_logged: bool = False
         self._highest_epos: float = 0
         self._last_epos: float = 0
@@ -108,6 +109,9 @@ class SpoolManager:
     def _register_listeners(self):
         self.server.register_event_handler(
             "server:klippy_ready", self._handle_klippy_ready
+        )
+        self.server.register_event_handler(
+            "server:klippy_disconnect", self._handle_klippy_disconnect
         )
 
     def _register_endpoints(self):
@@ -276,9 +280,24 @@ class SpoolManager:
         else:
             logging.error("Spoolman integration unable to subscribe to epos")
             raise self.server.error("Unable to subscribe to e position")
+        try:
+            obj_list = await self.klippy_apis.get_object_list()
+            macro_key = f"gcode_macro {KLIPPER_MACRO}"
+            if macro_key in obj_list:
+                result = await self.klippy_apis.query_objects(
+                    {macro_key: None}
+                )
+                self._macro_variables = set(
+                    result.get(macro_key, {}).keys()
+                )
+        except Exception:
+            self._macro_variables = None
         if self.spool_data is not None:
             variables = self._extract_spool_variables(self.spool_data)
             await self._push_klipper_variables(variables)
+
+    def _handle_klippy_disconnect(self) -> None:
+        self._macro_variables = None
 
     def _get_response_error(self, response: HttpResponse) -> str:
         err_msg = f"HTTP error: {response.status_code} {response.error}"
@@ -479,7 +498,11 @@ class SpoolManager:
     async def _push_klipper_variables(
         self, variables: Dict[str, Any]
     ) -> None:
+        if self._macro_variables is None:
+            return
         for var_name, value in variables.items():
+            if var_name not in self._macro_variables:
+                continue
             if isinstance(value, str):
                 safe = value.replace("'", "").replace('"', "")
                 gcode = (


### PR DESCRIPTION
## Summary

This PR adds optional spool/filament data caching to the Spoolman integration and the ability to push that data into Klipper gcode macro variables. This allows users to access filament metadata (material, temperatures, color, etc.) synchronously from within gcode macros... something not previously possible since Klipper macros cannot make asynchronous API calls.

## Problem

Currently, the Spoolman module only stores the active `spool_id` (an integer) and tracks extrusion. No filament metadata is cached. Users who want to use filament-specific settings in their macros (e.g., automatically setting extruder/bed temperatures based on the loaded filament) have no way to access this data from within Klipper's gcode macro system.

I have used this core logic with my own extension script here: [Spoolman Macro Extension](https://github.com/BlueBell-XA/Spoolman_Macro_Extension)
Now though, I'd like to bring the functionality to mainline Moonraker so everyone can opt into using this (also also so my update manager stops complaining about a 'dirty' repo :satisfied:)

## Changes

All changes are additive and non-invasive to the existing module logic:

### New constants
- `KLIPPER_MACRO`: name of the target Klipper macro (`"SPOOLMAN"`)
- `SPOOL_VARS_DEFAULT`: default/null values for all supported variables

### New instance state
- `self.spool_data`: cached full spool response from the Spoolman API (`None` when no spool is active)
- `self._macro_variables`: set of variable names defined in the user's Klipper macro (`None` when macro is absent or Klipper is disconnected)

### Modified methods (minimal changes)
- **`_register_listeners`**: added `klippy_disconnect` event handler
- **`_handle_klippy_ready`**: queries Klipper's object list to detect whether the `[gcode_macro SPOOLMAN]` macro exists and which variables it defines; pushes cached spool data if available
- **`_decode_message`**: added handling for `"updated"` websocket events to refresh the cache and push updated variables to Klipper
- **`_check_spool_deleted`**: caches the spool API response on successful check and pushes variables to Klipper
- **`set_active_spool`**: schedules an async task to fetch and push spool data (or reset to defaults when clearing)

### New methods
- **`_handle_klippy_disconnect`**: resets `_macro_variables` so detection re-runs on next connect
- **`_extract_spool_variables`**: extracts a flat dict of relevant fields from a Spoolman spool API response
- **`_update_klipper_spool_data`**: fetches spool data from the Spoolman API and pushes to Klipper; resets to defaults when spool is cleared
- **`_push_klipper_variables`**: sends `SET_GCODE_VARIABLE` commands to Klipper for each variable; silently skips if the macro or individual variables don't exist

## Exposed variables

| Variable | Type | Description | Default |
|---|---|---|---|
| `spool_id` | int | Active spool ID | `-1` |
| `filament_name` | string | Filament name | `""` |
| `material` | string | Material type (e.g. PLA, PETG) | `""` |
| `vendor` | string | Vendor/manufacturer name | `""` |
| `color` | string | Hex color code (e.g. FF0000) | `""` |
| `extruder_temp` | int | Recommended extruder temperature (°C) | `0` |
| `bed_temp` | int | Recommended bed temperature (°C) | `0` |
| `diameter` | float | Filament diameter (mm) | `0.0` |
| `density` | float | Filament density (g/cm³) | `0.0` |
| `remaining_weight` | float | Remaining filament weight (g) | `0.0` |
| `filament_weight` | float | Full spool net filament weight (g) | `0.0` |

## User setup

This feature is entirely opt-in. Users add a macro to their Klipper config with whichever variables they want to use:

```ini
[gcode_macro SPOOLMAN]
variable_spool_id: -1
variable_filament_name: "''"
variable_material: "''"
variable_vendor: "''"
variable_color: "''"
variable_extruder_temp: 0
variable_bed_temp: 0
variable_diameter: 0
variable_density: 0
variable_remaining_weight: 0
variable_filament_weight: 0
gcode:
  {action_respond_info("Spoolman data holder macro")}
```

Variables are then accessible from any other macro:

```ini
[gcode_macro PRINT_START]
gcode:
  {% set spool = printer["gcode_macro SPOOLMAN"] %}
  {% if spool.extruder_temp > 0 %}
    M104 S{spool.extruder_temp}
  {% endif %}
  {% if spool.bed_temp > 0 %}
    M140 S{spool.bed_temp}
  {% endif %}
```

## Error handling / non-invasive design

- If the `[gcode_macro SPOOLMAN]` macro is **not defined** in Klipper config, no `SET_GCODE_VARIABLE` commands are sent and **no errors or warnings appear**.
- If the macro exists but only defines a **subset** of the variables, only those variables are updated... the rest are silently skipped.
- All API fetch and gcode push operations are wrapped in exception handlers that silently continue on failure.
- When a spool is **cleared or deleted**, all variables are reset to their default values.
- On **Klipper restart**, macro detection re-runs automatically via the `klippy_ready` event.
- On **Spoolman reconnect**, cached data is refreshed from the API.
- **Spoolman websocket `updated` events** for the active spool automatically refresh the cache and push updated values.

## Testing notes

- Tested with macro defined: variables populate correctly on spool set
- Tested without macro defined: no console errors, no warnings
- Tested spool clear: variables reset to defaults
- Tested Klipper restart: macro re-detected, variables re-pushed
