### PR TITLE
spoolman: add per-tool spool tracking for multi-tool printers

### DIFF
--- a/moonraker/components/spoolman.py
+++ b/moonraker/components/spoolman.py
@@ -532,10 +532,11 @@ class SpoolManager:
             spool_id = web_request.get_int("spool_id", None)
             tool = web_request.get_int("tool", 0)
             self.set_active_spool(spool_id, tool=tool)
-        else:
-            tool = web_request.get_int("tool", None)
-        # For GET requests (or after POST), return spool info
-        if tool is not None:
+            return {"spool_id": self._tool_spool_map.get(tool)}
+        # GET request
+        tool_val = web_request.get("tool", None)
+        if tool_val is not None:
+            tool = int(tool_val)
             return {"spool_id": self._tool_spool_map.get(tool)}
         # No tool specified: legacy response (tool 0)
         return {"spool_id": self.spool_id}

--- a/moonraker/components/spoolman.py
+++ b/moonraker/components/spoolman.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
 
 DB_NAMESPACE = "moonraker"
 ACTIVE_SPOOL_KEY = "spoolman.spool_id"
+TOOL_SPOOL_MAP_KEY = "spoolman.tool_spool_map"
 
 class SpoolManager:
     def __init__(self, config: ConfigHelper):
@@ -50,17 +51,27 @@ class SpoolManager:
         self.ws_connected: bool = False
         self.reconnect_delay: float = 2.
         self.is_closing: bool = False
-        self.spool_id: Optional[int] = None
         self._error_logged: bool = False
-        self._highest_epos: float = 0
+        # Per-tool spool mapping: tool_index -> spool_id
+        self._tool_spool_map: Dict[int, Optional[int]] = {}
+        # Per-tool extrusion tracking watermarks
+        self._highest_epos: Dict[int, float] = {}
         self._last_epos: float = 0
         self._current_extruder: str = "extruder"
+        # Extruder name -> tool index mapping
+        self._extruder_to_tool: Dict[str, int] = {}
+        self._current_tool: int = 0
         self.spool_history = HistoryFieldData(
             "spool_ids", "spoolman", "Spool IDs used", "collect",
             reset_callback=self._on_history_reset
         )
+        self.tool_spool_history = HistoryFieldData(
+            "tool_spool_map", "spoolman", "Tool-spool assignments", "collect",
+            reset_callback=self._on_tool_spool_history_reset
+        )
         history: History = self.server.lookup_component("history")
         history.register_auxiliary_field(self.spool_history)
+        history.register_auxiliary_field(self.tool_spool_history)
         self.klippy_apis: APIComp = self.server.lookup_component("klippy_apis")
         self.http_client: HttpClient = self.server.lookup_component("http_client")
         self.database: MoonrakerDatabase = self.server.lookup_component("database")
@@ -72,6 +83,11 @@ class SpoolManager:
         self.server.register_remote_method(
             "spoolman_set_active_spool", self.set_active_spool
         )
+
+    @property
+    def spool_id(self) -> Optional[int]:
+        """Backward-compatible property: returns the spool for tool 0."""
+        return self._tool_spool_map.get(0)
 
     def _get_spoolman_urls(self, config: ConfigHelper) -> None:
         orig_url = config.get('server')
@@ -117,11 +133,43 @@ class SpoolManager:
             return []
         return [self.spool_id]
 
+    def _on_tool_spool_history_reset(self) -> List[Dict[str, Any]]:
+        entries = []
+        for tool, sid in self._tool_spool_map.items():
+            if sid is not None:
+                entries.append({"tool": tool, "spool_id": sid})
+        return entries
+
     async def component_init(self) -> None:
-        self.spool_id = await self.database.get_item(
-            DB_NAMESPACE, ACTIVE_SPOOL_KEY, None
+        # Try loading new tool_spool_map format first
+        stored_map: Optional[Dict[str, Any]] = await self.database.get_item(
+            DB_NAMESPACE, TOOL_SPOOL_MAP_KEY, None
         )
+        if stored_map is not None:
+            self._tool_spool_map = {
+                int(k): v for k, v in stored_map.items()
+            }
+        else:
+            # Migrate from legacy single spool_id
+            legacy_id: Optional[int] = await self.database.get_item(
+                DB_NAMESPACE, ACTIVE_SPOOL_KEY, None
+            )
+            if legacy_id is not None:
+                self._tool_spool_map = {0: legacy_id}
+            else:
+                self._tool_spool_map = {}
+            # Write new format to DB
+            self._save_tool_spool_map()
         self.connection_task = self.eventloop.create_task(self._connect_websocket())
+
+    def _save_tool_spool_map(self) -> None:
+        """Persist tool_spool_map to DB. Also writes legacy key for tool 0."""
+        db_map = {str(k): v for k, v in self._tool_spool_map.items()}
+        self.database.insert_item(DB_NAMESPACE, TOOL_SPOOL_MAP_KEY, db_map)
+        # Write legacy key for rollback safety
+        self.database.insert_item(
+            DB_NAMESPACE, ACTIVE_SPOOL_KEY, self._tool_spool_map.get(0)
+        )
 
     async def _connect_websocket(self) -> None:
         log_connect: bool = True
@@ -164,15 +212,19 @@ class SpoolManager:
                 self.server.add_log_rollover_item(
                     "spoolman_connect", "Connected to Spoolman Spool Manager"
                 )
-                if self.spool_id is not None:
+                if self._has_any_spool():
                     self._cancel_spool_check_task()
-                    coro = self._check_spool_deleted()
+                    coro = self._check_spools_deleted()
                     self.spool_check_task = self.eventloop.create_task(coro)
                 self._send_status_notification()
                 await self._read_messages()
                 log_connect = True
             if not self.is_closing:
                 await asyncio.sleep(self.reconnect_delay)
+
+    def _has_any_spool(self) -> bool:
+        """Check if any tool has a spool assigned."""
+        return any(v is not None for v in self._tool_spool_map.values())
 
     async def _read_messages(self) -> None:
         message: Union[str, bytes, None]
@@ -202,32 +254,46 @@ class SpoolManager:
         event: Dict[str, Any] = jsonw.loads(message)
         if event.get("resource") != "spool":
             return
-        if self.spool_id is not None and event.get("type") == "deleted":
+        if event.get("type") == "deleted":
             payload: Dict[str, Any] = event.get("payload", {})
-            if payload.get("id") == self.spool_id:
-                self.pending_reports.pop(self.spool_id, None)
-                self.set_active_spool(None)
+            deleted_id = payload.get("id")
+            if deleted_id is not None:
+                # Check all tools for the deleted spool
+                for tool, sid in list(self._tool_spool_map.items()):
+                    if sid == deleted_id:
+                        self.pending_reports.pop(deleted_id, None)
+                        self.set_active_spool(None, tool=tool)
 
     def _cancel_spool_check_task(self) -> None:
         if self.spool_check_task is None or self.spool_check_task.done():
             return
         self.spool_check_task.cancel()
 
-    async def _check_spool_deleted(self) -> None:
-        if self.spool_id is not None:
+    async def _check_spools_deleted(self) -> None:
+        """Check all assigned spools for deletion on Spoolman."""
+        for tool, sid in list(self._tool_spool_map.items()):
+            if sid is None:
+                continue
             response = await self.http_client.get(
-                f"{self.spoolman_url}/v1/spool/{self.spool_id}",
+                f"{self.spoolman_url}/v1/spool/{sid}",
                 connect_timeout=1., request_timeout=2.
             )
             if response.status_code == 404:
-                logging.info(f"Spool ID {self.spool_id} not found, setting to None")
-                self.pending_reports.pop(self.spool_id, None)
-                self.set_active_spool(None)
+                logging.info(
+                    f"Spool ID {sid} (tool {tool}) not found, setting to None"
+                )
+                self.pending_reports.pop(sid, None)
+                self.set_active_spool(None, tool=tool)
             elif response.has_error():
                 err_msg = self._get_response_error(response)
-                logging.info(f"Attempt to check spool status failed: {err_msg}")
+                logging.info(
+                    f"Attempt to check spool status for tool {tool} "
+                    f"failed: {err_msg}"
+                )
             else:
-                logging.info(f"Found Spool ID {self.spool_id} on spoolman instance")
+                logging.info(
+                    f"Found Spool ID {sid} (tool {tool}) on spoolman instance"
+                )
         self.spool_check_task = None
 
     def connected(self) -> bool:
@@ -238,18 +304,115 @@ class SpoolManager:
 
     async def _handle_klippy_ready(self) -> None:
         result: Dict[str, Dict[str, Any]]
+        # Discover tools
+        await self._discover_tools()
+        # Subscribe to toolhead for position and extruder tracking
         result = await self.klippy_apis.subscribe_objects(
             {"toolhead": ["position", "extruder"]}, self._handle_status_update, {}
         )
         toolhead = result.get("toolhead", {})
         self._current_extruder = toolhead.get("extruder", "extruder")
+        self._current_tool = self._extruder_to_tool.get(
+            self._current_extruder, 0
+        )
         initial_e_pos = toolhead.get("position", [None]*4)[3]
         logging.debug(f"Initial epos: {initial_e_pos}")
         if initial_e_pos is not None:
-            self._highest_epos = initial_e_pos
+            self._highest_epos[self._current_tool] = initial_e_pos
+            self._last_epos = initial_e_pos
         else:
             logging.error("Spoolman integration unable to subscribe to epos")
             raise self.server.error("Unable to subscribe to e position")
+
+    async def _discover_tools(self) -> None:
+        """Discover tool-to-extruder mapping from Klipper objects."""
+        self._extruder_to_tool = {}
+        try:
+            obj_list: List[str] = await self.klippy_apis.get_object_list()
+        except Exception:
+            logging.info("Spoolman: unable to get object list, using defaults")
+            self._extruder_to_tool = {"extruder": 0}
+            return
+        if "toolchanger" in obj_list:
+            await self._discover_toolchanger_tools(obj_list)
+        else:
+            self._discover_extruder_tools(obj_list)
+        if not self._extruder_to_tool:
+            self._extruder_to_tool = {"extruder": 0}
+        logging.info(
+            f"Spoolman tool discovery: {self._extruder_to_tool}"
+        )
+
+    async def _discover_toolchanger_tools(
+        self, obj_list: List[str]
+    ) -> None:
+        """Discover tools via klipper_toolchanger plugin."""
+        try:
+            tc_result = await self.klippy_apis.query_objects(
+                {"toolchanger": None}
+            )
+            tc_data = tc_result.get("toolchanger", {})
+            tool_names = tc_data.get("tool_names", [])
+            tool_numbers = tc_data.get("tool_numbers", [])
+        except Exception:
+            logging.info(
+                "Spoolman: failed to query toolchanger, falling back"
+            )
+            self._discover_extruder_tools(obj_list)
+            return
+        if not tool_names or not tool_numbers:
+            logging.info(
+                "Spoolman: toolchanger has no tools, falling back"
+            )
+            self._discover_extruder_tools(obj_list)
+            return
+        # Query each tool object for its extruder field
+        # tool_names already contains full object names like "tool T0"
+        for name, number in zip(tool_names, tool_numbers):
+            tool_obj_name = name
+            if tool_obj_name not in obj_list:
+                continue
+            try:
+                tool_result = await self.klippy_apis.query_objects(
+                    {tool_obj_name: ["extruder"]}
+                )
+                tool_data = tool_result.get(tool_obj_name, {})
+                extruder = tool_data.get("extruder")
+                if extruder:
+                    tool_num = int(number)
+                    self._extruder_to_tool[extruder] = tool_num
+            except Exception:
+                logging.debug(
+                    f"Spoolman: failed to query tool '{name}'"
+                )
+        # Subscribe to toolchanger for runtime tool_number tracking
+        try:
+            await self.klippy_apis.subscribe_objects(
+                {"toolchanger": ["tool_number"]},
+                self._handle_toolchanger_update, {}
+            )
+        except Exception:
+            logging.debug("Spoolman: failed to subscribe to toolchanger")
+
+    def _handle_toolchanger_update(
+        self, status: Dict[str, Any], _: float
+    ) -> None:
+        """Handle toolchanger status updates for tool_number tracking."""
+        tc = status.get("toolchanger")
+        if tc is None:
+            return
+        tool_number = tc.get("tool_number")
+        if tool_number is not None:
+            self._current_tool = int(tool_number)
+
+    def _discover_extruder_tools(self, obj_list: List[str]) -> None:
+        """Fall back to parsing extruder names for tool mapping."""
+        for obj_name in obj_list:
+            if obj_name == "extruder":
+                self._extruder_to_tool["extruder"] = 0
+            elif obj_name.startswith("extruder") and obj_name[8:].isdigit():
+                idx = int(obj_name[8:])
+                self._extruder_to_tool[obj_name] = idx
 
     def _get_response_error(self, response: HttpResponse) -> str:
         err_msg = f"HTTP error: {response.status_code} {response.error}"
@@ -262,16 +425,27 @@ class SpoolManager:
         toolhead: Optional[Dict[str, Any]] = status.get("toolhead")
         if toolhead is None:
             return
-        epos: float = toolhead.get("position", [0, 0, 0, self._highest_epos])[3]
+        cur_tool = self._current_tool
+        epos: float = toolhead.get(
+            "position",
+            [0, 0, 0, self._highest_epos.get(cur_tool, 0)]
+        )[3]
         self._last_epos = epos
         extr = toolhead.get("extruder", self._current_extruder)
         if extr != self._current_extruder:
-            self._highest_epos = epos
+            # Extruder changed — resolve new tool
+            new_tool = self._extruder_to_tool.get(extr, self._current_tool)
+            self._highest_epos[new_tool] = epos
             self._current_extruder = extr
-        elif epos > self._highest_epos:
-            if self.spool_id is not None:
-                self._add_extrusion(self.spool_id, epos - self._highest_epos)
-            self._highest_epos = epos
+            self._current_tool = new_tool
+        elif epos > self._highest_epos.get(cur_tool, 0):
+            # Extrusion happened — attribute to current tool's spool
+            tool_spool = self._tool_spool_map.get(cur_tool)
+            if tool_spool is not None:
+                self._add_extrusion(
+                    tool_spool, epos - self._highest_epos.get(cur_tool, 0)
+                )
+            self._highest_epos[cur_tool] = epos
 
     def _add_extrusion(self, spool_id: int, used_length: float) -> None:
         if spool_id in self.pending_reports:
@@ -279,19 +453,35 @@ class SpoolManager:
         else:
             self.pending_reports[spool_id] = used_length
 
-    def set_active_spool(self, spool_id: Union[int, None]) -> None:
+    def set_active_spool(
+        self, spool_id: Union[int, None], tool: int = 0
+    ) -> None:
         assert spool_id is None or isinstance(spool_id, int)
-        if self.spool_id == spool_id:
-            logging.info(f"Spool ID already set to: {spool_id}")
+        current = self._tool_spool_map.get(tool)
+        if current == spool_id:
+            logging.info(
+                f"Spool ID already set to {spool_id} for tool {tool}"
+            )
             return
+        # Update history trackers
         self.spool_history.tracker.update(spool_id)
-        self.spool_id = spool_id
-        self.database.insert_item(DB_NAMESPACE, ACTIVE_SPOOL_KEY, spool_id)
-        self._highest_epos = self._last_epos
-        self.server.send_event(
-            "spoolman:active_spool_set", {"spool_id": spool_id}
+        self.tool_spool_history.tracker.update(
+            {"tool": tool, "spool_id": spool_id}
         )
-        logging.info(f"Setting active spool to: {spool_id}")
+        if spool_id is not None:
+            self._tool_spool_map[tool] = spool_id
+        else:
+            self._tool_spool_map.pop(tool, None)
+        self._save_tool_spool_map()
+        # Reset epos watermark for this tool
+        self._highest_epos[tool] = self._last_epos
+        self.server.send_event(
+            "spoolman:active_spool_set",
+            {"spool_id": spool_id, "tool": tool}
+        )
+        logging.info(
+            f"Setting active spool to {spool_id} for tool {tool}"
+        )
 
     async def report_extrusion(self, eventtime: float) -> float:
         if not self.ws_connected:
@@ -315,9 +505,14 @@ class SpoolManager:
                     # Since the spool is deleted we can remove any pending reports
                     # added while waiting for the request
                     self.pending_reports.pop(spool_id, None)
-                    if spool_id == self.spool_id:
-                        logging.info(f"Spool ID {spool_id} not found, setting to None")
-                        self.set_active_spool(None)
+                    # Find and clear any tools using this deleted spool
+                    for tool, sid in list(self._tool_spool_map.items()):
+                        if sid == spool_id:
+                            logging.info(
+                                f"Spool ID {spool_id} not found, "
+                                f"clearing tool {tool}"
+                            )
+                            self.set_active_spool(None, tool=tool)
                 else:
                     if not self._error_logged:
                         error_msg = self._get_response_error(response)
@@ -335,8 +530,14 @@ class SpoolManager:
     async def _handle_spool_id_request(self, web_request: WebRequest):
         if web_request.get_request_type() == RequestType.POST:
             spool_id = web_request.get_int("spool_id", None)
-            self.set_active_spool(spool_id)
-        # For GET requests we will simply return the spool_id
+            tool = web_request.get_int("tool", 0)
+            self.set_active_spool(spool_id, tool=tool)
+        else:
+            tool = web_request.get_int("tool", None)
+        # For GET requests (or after POST), return spool info
+        if tool is not None:
+            return {"spool_id": self._tool_spool_map.get(tool)}
+        # No tool specified: legacy response (tool 0)
         return {"spool_id": self.spool_id}
 
     async def _proxy_spoolman_request(self, web_request: WebRequest):
@@ -398,10 +599,13 @@ class SpoolManager:
             {"spool_id": sid, "filament_used": used} for sid, used in
             self.pending_reports.items()
         ]
+        # Build tool_spool_map with int keys for JSON response
+        tool_map: Dict[int, Optional[int]] = dict(self._tool_spool_map)
         return {
             "spoolman_connected": self.ws_connected,
             "pending_reports": pending,
-            "spool_id": self.spool_id
+            "spool_id": self.spool_id,
+            "tool_spool_map": tool_map,
         }
 
     def _send_status_notification(self) -> None:

--- a/moonraker/components/spoolman.py
+++ b/moonraker/components/spoolman.py
@@ -333,77 +333,12 @@ class SpoolManager:
             logging.info("Spoolman: unable to get object list, using defaults")
             self._extruder_to_tool = {"extruder": 0}
             return
-        if "toolchanger" in obj_list:
-            await self._discover_toolchanger_tools(obj_list)
-        else:
-            self._discover_extruder_tools(obj_list)
+        self._discover_extruder_tools(obj_list)
         if not self._extruder_to_tool:
             self._extruder_to_tool = {"extruder": 0}
         logging.info(
             f"Spoolman tool discovery: {self._extruder_to_tool}"
         )
-
-    async def _discover_toolchanger_tools(
-        self, obj_list: List[str]
-    ) -> None:
-        """Discover tools via klipper_toolchanger plugin."""
-        try:
-            tc_result = await self.klippy_apis.query_objects(
-                {"toolchanger": None}
-            )
-            tc_data = tc_result.get("toolchanger", {})
-            tool_names = tc_data.get("tool_names", [])
-            tool_numbers = tc_data.get("tool_numbers", [])
-        except Exception:
-            logging.info(
-                "Spoolman: failed to query toolchanger, falling back"
-            )
-            self._discover_extruder_tools(obj_list)
-            return
-        if not tool_names or not tool_numbers:
-            logging.info(
-                "Spoolman: toolchanger has no tools, falling back"
-            )
-            self._discover_extruder_tools(obj_list)
-            return
-        # Query each tool object for its extruder field
-        # tool_names already contains full object names like "tool T0"
-        for name, number in zip(tool_names, tool_numbers):
-            tool_obj_name = name
-            if tool_obj_name not in obj_list:
-                continue
-            try:
-                tool_result = await self.klippy_apis.query_objects(
-                    {tool_obj_name: ["extruder"]}
-                )
-                tool_data = tool_result.get(tool_obj_name, {})
-                extruder = tool_data.get("extruder")
-                if extruder:
-                    tool_num = int(number)
-                    self._extruder_to_tool[extruder] = tool_num
-            except Exception:
-                logging.debug(
-                    f"Spoolman: failed to query tool '{name}'"
-                )
-        # Subscribe to toolchanger for runtime tool_number tracking
-        try:
-            await self.klippy_apis.subscribe_objects(
-                {"toolchanger": ["tool_number"]},
-                self._handle_toolchanger_update, {}
-            )
-        except Exception:
-            logging.debug("Spoolman: failed to subscribe to toolchanger")
-
-    def _handle_toolchanger_update(
-        self, status: Dict[str, Any], _: float
-    ) -> None:
-        """Handle toolchanger status updates for tool_number tracking."""
-        tc = status.get("toolchanger")
-        if tc is None:
-            return
-        tool_number = tc.get("tool_number")
-        if tool_number is not None:
-            self._current_tool = int(tool_number)
 
     def _discover_extruder_tools(self, obj_list: List[str]) -> None:
         """Fall back to parsing extruder names for tool mapping."""
@@ -454,9 +389,27 @@ class SpoolManager:
             self.pending_reports[spool_id] = used_length
 
     def set_active_spool(
-        self, spool_id: Union[int, None], tool: int = 0
+        self,
+        spool_id: Union[int, None],
+        tool: Union[int, None] = None
     ) -> None:
         assert spool_id is None or isinstance(spool_id, int)
+        if tool is not None:
+            self._set_tool_spool(spool_id, tool)
+        else:
+            # No tool specified: apply to all tracked tools for backward
+            # compatibility with existing workflows that call
+            # set_active_spool() without a tool parameter.
+            if self._tool_spool_map:
+                for t in list(self._tool_spool_map.keys()):
+                    self._set_tool_spool(spool_id, t)
+            else:
+                # No tools tracked yet, default to tool 0
+                self._set_tool_spool(spool_id, 0)
+
+    def _set_tool_spool(
+        self, spool_id: Union[int, None], tool: int
+    ) -> None:
         current = self._tool_spool_map.get(tool)
         if current == spool_id:
             logging.info(
@@ -530,9 +483,12 @@ class SpoolManager:
     async def _handle_spool_id_request(self, web_request: WebRequest):
         if web_request.get_request_type() == RequestType.POST:
             spool_id = web_request.get_int("spool_id", None)
-            tool = web_request.get_int("tool", 0)
+            tool_val = web_request.get("tool", None)
+            tool = int(tool_val) if tool_val is not None else None
             self.set_active_spool(spool_id, tool=tool)
-            return {"spool_id": self._tool_spool_map.get(tool)}
+            # Return tool 0 for legacy compat when tool not specified
+            return_tool = tool if tool is not None else 0
+            return {"spool_id": self._tool_spool_map.get(return_tool)}
         # GET request
         tool_val = web_request.get("tool", None)
         if tool_val is not None:

--- a/tests/test_spoolman.py
+++ b/tests/test_spoolman.py
@@ -176,10 +176,22 @@ class TestSetActiveSpool:
         sm.set_active_spool(15, tool=0)
         sm.database.insert_item.assert_called()
 
-    def test_default_tool_is_zero(self):
+    def test_no_tool_defaults_to_tool_0_when_empty(self):
         sm = _make_spoolman()
         sm.set_active_spool(3)
         assert sm._tool_spool_map == {0: 3}
+
+    def test_no_tool_sets_all_tracked_tools(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 5, 1: 10}
+        sm.set_active_spool(99)
+        assert sm._tool_spool_map == {0: 99, 1: 99}
+
+    def test_no_tool_clears_all_tracked_tools(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 5, 1: 10}
+        sm.set_active_spool(None)
+        assert sm._tool_spool_map == {}
 
     def test_resets_epos_watermark(self):
         sm = _make_spoolman()
@@ -465,11 +477,19 @@ class TestHandleSpoolIdRequest:
         assert result == {"spool_id": 42}
 
     @pytest.mark.asyncio
-    async def test_post_default_tool_zero(self):
+    async def test_post_no_tool_defaults_to_tool_0_when_empty(self):
         sm = _make_spoolman()
         wr = _make_web_request("POST", {"spool_id": 42})
         await sm._handle_spool_id_request(wr)
         assert sm._tool_spool_map[0] == 42
+
+    @pytest.mark.asyncio
+    async def test_post_no_tool_sets_all_tracked_tools(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 5, 1: 10}
+        wr = _make_web_request("POST", {"spool_id": 42})
+        await sm._handle_spool_id_request(wr)
+        assert sm._tool_spool_map == {0: 42, 1: 42}
 
     @pytest.mark.asyncio
     async def test_post_clear_spool(self):

--- a/tests/test_spoolman.py
+++ b/tests/test_spoolman.py
@@ -1,0 +1,589 @@
+# Unit tests for the spoolman per-tool spool tracking logic.
+#
+# These tests exercise the SpoolManager's tool-spool map management,
+# extrusion attribution, extruder discovery, and API handlers without
+# requiring a running Klipper or Spoolman instance.
+
+from __future__ import annotations
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+from typing import Any, Dict, List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build a SpoolManager with mocked dependencies
+# ---------------------------------------------------------------------------
+
+def _make_mock_config() -> MagicMock:
+    config = MagicMock()
+    config.get_server.return_value = _make_mock_server()
+    config.get.return_value = "http://localhost:7912"
+    config.getint.return_value = 5
+    config.error = Exception
+    return config
+
+
+def _make_mock_server() -> MagicMock:
+    server = MagicMock()
+    server.get_event_loop.return_value = _make_mock_eventloop()
+    server.lookup_component.side_effect = _mock_lookup
+    server.register_notification = MagicMock()
+    server.register_event_handler = MagicMock()
+    server.register_endpoint = MagicMock()
+    server.register_remote_method = MagicMock()
+    server.send_event = MagicMock()
+    server.error = Exception
+    server.is_verbose_enabled.return_value = False
+    return server
+
+
+def _make_mock_eventloop() -> MagicMock:
+    el = MagicMock()
+    el.register_timer.return_value = MagicMock()
+    el.create_task = MagicMock()
+    el.get_loop_time.return_value = 0.0
+    el.create_future.return_value = MagicMock()
+    return el
+
+
+def _mock_lookup(name: str, default: Any = MagicMock()) -> Any:
+    if name == "database":
+        db = MagicMock()
+        db.get_item = AsyncMock(return_value=None)
+        db.insert_item = MagicMock()
+        return db
+    if name == "history":
+        hist = MagicMock()
+        hist.register_auxiliary_field = MagicMock()
+        hist.tracking_enabled = MagicMock(return_value=True)
+        return hist
+    if name == "announcements":
+        ann = MagicMock()
+        ann.register_feed = MagicMock()
+        return ann
+    return MagicMock()
+
+
+def _patch_trackers(sm: Any) -> None:
+    """Patch the history trackers so tracker.update() doesn't crash."""
+    for field in [sm.spool_history, sm.tool_spool_history]:
+        field.tracker.history = MagicMock()
+        field.tracker.history.tracking_enabled = MagicMock(return_value=True)
+
+
+def _make_spoolman():
+    """Create a SpoolManager instance with all dependencies mocked."""
+    from moonraker.components.spoolman import SpoolManager
+    config = _make_mock_config()
+    sm = SpoolManager(config)
+    _patch_trackers(sm)
+    return sm
+
+
+def _make_web_request(
+    req_type: str = "GET",
+    params: Optional[Dict[str, Any]] = None
+) -> MagicMock:
+    from moonraker.common import RequestType
+    wr = MagicMock()
+    rt = RequestType.GET if req_type == "GET" else RequestType.POST
+    wr.get_request_type.return_value = rt
+
+    def get_int(key, default=None):
+        if params and key in params:
+            return int(params[key]) if params[key] is not None else default
+        return default
+
+    def get_str(key, default=None):
+        if params and key in params:
+            return str(params[key])
+        return default
+
+    wr.get_int = get_int
+    wr.get_str = get_str
+    wr.get = lambda key, default=None: params.get(key, default) if params else default
+    wr.get_boolean = lambda key, default=False: params.get(key, default) if params else default
+    return wr
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+class TestSpoolIdProperty:
+    """The spool_id property should return tool 0's spool for backward compat."""
+
+    def test_returns_none_when_empty(self):
+        sm = _make_spoolman()
+        assert sm.spool_id is None
+
+    def test_returns_tool_0_spool(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 42, 1: 99}
+        assert sm.spool_id == 42
+
+    def test_returns_none_when_only_tool_1(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {1: 99}
+        assert sm.spool_id is None
+
+
+class TestSetActiveSpool:
+    """set_active_spool manages the tool-spool map."""
+
+    def test_set_single_tool(self):
+        sm = _make_spoolman()
+        sm.set_active_spool(5, tool=0)
+        assert sm._tool_spool_map == {0: 5}
+
+    def test_set_multi_tool(self):
+        sm = _make_spoolman()
+        sm.set_active_spool(10, tool=0)
+        sm.set_active_spool(20, tool=1)
+        assert sm._tool_spool_map == {0: 10, 1: 20}
+
+    def test_clear_spool(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 5, 1: 10}
+        sm.set_active_spool(None, tool=1)
+        assert 1 not in sm._tool_spool_map
+        assert sm._tool_spool_map == {0: 5}
+
+    def test_clear_only_tool_0(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 5}
+        sm.set_active_spool(None, tool=0)
+        assert sm._tool_spool_map == {}
+
+    def test_noop_when_already_set(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 5}
+        sm.server.send_event.reset_mock()
+        sm.set_active_spool(5, tool=0)
+        # Should not fire event when value unchanged
+        sm.server.send_event.assert_not_called()
+
+    def test_fires_event(self):
+        sm = _make_spoolman()
+        sm.set_active_spool(7, tool=1)
+        sm.server.send_event.assert_called_with(
+            "spoolman:active_spool_set",
+            {"spool_id": 7, "tool": 1}
+        )
+
+    def test_saves_to_database(self):
+        sm = _make_spoolman()
+        sm.set_active_spool(15, tool=0)
+        sm.database.insert_item.assert_called()
+
+    def test_default_tool_is_zero(self):
+        sm = _make_spoolman()
+        sm.set_active_spool(3)
+        assert sm._tool_spool_map == {0: 3}
+
+    def test_resets_epos_watermark(self):
+        sm = _make_spoolman()
+        sm._last_epos = 100.0
+        sm.set_active_spool(5, tool=1)
+        assert sm._highest_epos[1] == 100.0
+
+
+class TestHasAnySpool:
+    def test_false_when_empty(self):
+        sm = _make_spoolman()
+        assert sm._has_any_spool() is False
+
+    def test_true_single_tool(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 5}
+        assert sm._has_any_spool() is True
+
+    def test_true_multi_tool(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 5, 1: 10}
+        assert sm._has_any_spool() is True
+
+    def test_false_when_all_none(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: None, 1: None}
+        assert sm._has_any_spool() is False
+
+
+class TestSaveToolSpoolMap:
+    """_save_tool_spool_map persists the map and legacy key."""
+
+    def test_saves_both_keys(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 5, 1: 10}
+        sm._save_tool_spool_map()
+        calls = sm.database.insert_item.call_args_list
+        # Should have at least 2 calls: tool_spool_map and legacy spool_id
+        keys_saved = [c[0][1] for c in calls]
+        assert "spoolman.tool_spool_map" in keys_saved
+        assert "spoolman.spool_id" in keys_saved
+
+    def test_legacy_key_is_tool_0(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 42, 1: 99}
+        sm._save_tool_spool_map()
+        # Find the legacy key call
+        for call in sm.database.insert_item.call_args_list:
+            if call[0][1] == "spoolman.spool_id":
+                assert call[0][2] == 42
+                return
+        pytest.fail("Legacy spool_id key not saved")
+
+    def test_legacy_key_none_when_no_tool_0(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {1: 99}
+        sm._save_tool_spool_map()
+        for call in sm.database.insert_item.call_args_list:
+            if call[0][1] == "spoolman.spool_id":
+                assert call[0][2] is None
+                return
+        pytest.fail("Legacy spool_id key not saved")
+
+    def test_map_keys_are_strings(self):
+        """DB keys must be strings for JSON serialization."""
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 5, 1: 10}
+        sm._save_tool_spool_map()
+        for call in sm.database.insert_item.call_args_list:
+            if call[0][1] == "spoolman.tool_spool_map":
+                db_map = call[0][2]
+                assert all(isinstance(k, str) for k in db_map.keys())
+                assert db_map == {"0": 5, "1": 10}
+                return
+        pytest.fail("tool_spool_map not saved")
+
+
+class TestDiscoverExtruderTools:
+    """_discover_extruder_tools parses extruder names from Klipper objects."""
+
+    def test_single_extruder(self):
+        sm = _make_spoolman()
+        sm._discover_extruder_tools(["extruder", "heater_bed"])
+        assert sm._extruder_to_tool == {"extruder": 0}
+
+    def test_dual_extruder(self):
+        sm = _make_spoolman()
+        sm._discover_extruder_tools(["extruder", "extruder1", "heater_bed"])
+        assert sm._extruder_to_tool == {"extruder": 0, "extruder1": 1}
+
+    def test_triple_extruder(self):
+        sm = _make_spoolman()
+        sm._discover_extruder_tools(
+            ["extruder", "extruder1", "extruder2"]
+        )
+        assert sm._extruder_to_tool == {
+            "extruder": 0, "extruder1": 1, "extruder2": 2
+        }
+
+    def test_no_extruders(self):
+        sm = _make_spoolman()
+        sm._discover_extruder_tools(["heater_bed", "fan"])
+        assert sm._extruder_to_tool == {}
+
+    def test_ignores_non_numeric_suffix(self):
+        sm = _make_spoolman()
+        sm._discover_extruder_tools(["extruder", "extruder_stepper"])
+        assert sm._extruder_to_tool == {"extruder": 0}
+
+
+class TestHandleStatusUpdate:
+    """_handle_status_update tracks extrusion per-tool."""
+
+    def test_extrusion_attributed_to_current_tool(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 5}
+        sm._extruder_to_tool = {"extruder": 0}
+        sm._current_tool = 0
+        sm._current_extruder = "extruder"
+        sm._highest_epos = {0: 0.0}
+        sm._handle_status_update(
+            {"toolhead": {"position": [0, 0, 0, 10.0], "extruder": "extruder"}},
+            0.0
+        )
+        assert sm.pending_reports.get(5, 0) == pytest.approx(10.0)
+        assert sm._highest_epos[0] == 10.0
+
+    def test_no_report_without_spool(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {}
+        sm._extruder_to_tool = {"extruder": 0}
+        sm._current_tool = 0
+        sm._current_extruder = "extruder"
+        sm._highest_epos = {0: 0.0}
+        sm._handle_status_update(
+            {"toolhead": {"position": [0, 0, 0, 10.0], "extruder": "extruder"}},
+            0.0
+        )
+        assert sm.pending_reports == {}
+
+    def test_tool_change_updates_current_tool(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 5, 1: 10}
+        sm._extruder_to_tool = {"extruder": 0, "extruder1": 1}
+        sm._current_tool = 0
+        sm._current_extruder = "extruder"
+        sm._highest_epos = {0: 50.0}
+        # Simulate tool change to extruder1
+        sm._handle_status_update(
+            {"toolhead": {"position": [0, 0, 0, 50.0], "extruder": "extruder1"}},
+            0.0
+        )
+        assert sm._current_tool == 1
+        assert sm._current_extruder == "extruder1"
+        assert sm._highest_epos[1] == 50.0
+
+    def test_extrusion_after_tool_change(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 5, 1: 10}
+        sm._extruder_to_tool = {"extruder": 0, "extruder1": 1}
+        sm._current_tool = 0
+        sm._current_extruder = "extruder"
+        sm._highest_epos = {0: 50.0}
+        # Tool change
+        sm._handle_status_update(
+            {"toolhead": {"position": [0, 0, 0, 50.0], "extruder": "extruder1"}},
+            0.0
+        )
+        # Extrude 5mm on tool 1
+        sm._handle_status_update(
+            {"toolhead": {"position": [0, 0, 0, 55.0], "extruder": "extruder1"}},
+            0.0
+        )
+        assert sm.pending_reports.get(10, 0) == pytest.approx(5.0)
+        assert sm.pending_reports.get(5, 0) == 0  # Tool 0 unchanged
+
+    def test_no_extrusion_on_retract(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 5}
+        sm._extruder_to_tool = {"extruder": 0}
+        sm._current_tool = 0
+        sm._current_extruder = "extruder"
+        sm._highest_epos = {0: 50.0}
+        # E position goes down (retraction)
+        sm._handle_status_update(
+            {"toolhead": {"position": [0, 0, 0, 48.0], "extruder": "extruder"}},
+            0.0
+        )
+        assert sm.pending_reports == {}
+        assert sm._highest_epos[0] == 50.0  # Watermark unchanged
+
+    def test_ignores_update_without_toolhead(self):
+        sm = _make_spoolman()
+        sm._handle_status_update({"other": "data"}, 0.0)
+        assert sm.pending_reports == {}
+
+
+class TestDecodeMessage:
+    """_decode_message handles spool deletion from Spoolman websocket."""
+
+    def test_clears_deleted_spool_single_tool(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 42}
+        sm._decode_message(
+            '{"resource": "spool", "type": "deleted", "payload": {"id": 42}}'
+        )
+        assert 0 not in sm._tool_spool_map
+
+    def test_clears_deleted_spool_multi_tool(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 42, 1: 42}
+        sm._decode_message(
+            '{"resource": "spool", "type": "deleted", "payload": {"id": 42}}'
+        )
+        assert sm._tool_spool_map == {}
+
+    def test_ignores_non_spool_resource(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 42}
+        sm._decode_message(
+            '{"resource": "filament", "type": "deleted", "payload": {"id": 42}}'
+        )
+        assert sm._tool_spool_map == {0: 42}
+
+    def test_ignores_non_delete_event(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 42}
+        sm._decode_message(
+            '{"resource": "spool", "type": "updated", "payload": {"id": 42}}'
+        )
+        assert sm._tool_spool_map == {0: 42}
+
+    def test_does_not_clear_other_spools(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 42, 1: 99}
+        sm._decode_message(
+            '{"resource": "spool", "type": "deleted", "payload": {"id": 42}}'
+        )
+        assert sm._tool_spool_map == {1: 99}
+
+
+class TestHandleSpoolIdRequest:
+    """API endpoint: GET/POST /server/spoolman/spool_id"""
+
+    @pytest.mark.asyncio
+    async def test_get_single_tool(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 5}
+        wr = _make_web_request("GET", {"tool": 0})
+        result = await sm._handle_spool_id_request(wr)
+        assert result == {"spool_id": 5}
+
+    @pytest.mark.asyncio
+    async def test_get_multi_tool(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 5, 1: 10}
+        wr = _make_web_request("GET", {"tool": 1})
+        result = await sm._handle_spool_id_request(wr)
+        assert result == {"spool_id": 10}
+
+    @pytest.mark.asyncio
+    async def test_get_legacy_no_tool_param(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 5}
+        wr = _make_web_request("GET", {})
+        result = await sm._handle_spool_id_request(wr)
+        assert result == {"spool_id": 5}
+
+    @pytest.mark.asyncio
+    async def test_get_unassigned_tool(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 5}
+        wr = _make_web_request("GET", {"tool": 1})
+        result = await sm._handle_spool_id_request(wr)
+        assert result == {"spool_id": None}
+
+    @pytest.mark.asyncio
+    async def test_post_sets_spool(self):
+        sm = _make_spoolman()
+        wr = _make_web_request("POST", {"spool_id": 42, "tool": 1})
+        result = await sm._handle_spool_id_request(wr)
+        assert sm._tool_spool_map[1] == 42
+        assert result == {"spool_id": 42}
+
+    @pytest.mark.asyncio
+    async def test_post_default_tool_zero(self):
+        sm = _make_spoolman()
+        wr = _make_web_request("POST", {"spool_id": 42})
+        await sm._handle_spool_id_request(wr)
+        assert sm._tool_spool_map[0] == 42
+
+    @pytest.mark.asyncio
+    async def test_post_clear_spool(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 5}
+        wr = _make_web_request("POST", {"spool_id": None, "tool": 0})
+        await sm._handle_spool_id_request(wr)
+        assert 0 not in sm._tool_spool_map
+
+
+class TestHandleStatusRequest:
+    """API endpoint: GET /server/spoolman/status"""
+
+    @pytest.mark.asyncio
+    async def test_empty_state(self):
+        sm = _make_spoolman()
+        wr = _make_web_request("GET")
+        result = await sm._handle_status_request(wr)
+        assert result["spoolman_connected"] is False
+        assert result["spool_id"] is None
+        assert result["tool_spool_map"] == {}
+        assert result["pending_reports"] == []
+
+    @pytest.mark.asyncio
+    async def test_single_tool_status(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 5}
+        wr = _make_web_request("GET")
+        result = await sm._handle_status_request(wr)
+        assert result["spool_id"] == 5
+        assert result["tool_spool_map"] == {0: 5}
+
+    @pytest.mark.asyncio
+    async def test_multi_tool_status(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 5, 1: 10}
+        wr = _make_web_request("GET")
+        result = await sm._handle_status_request(wr)
+        assert result["spool_id"] == 5
+        assert result["tool_spool_map"] == {0: 5, 1: 10}
+
+    @pytest.mark.asyncio
+    async def test_pending_reports_included(self):
+        sm = _make_spoolman()
+        sm.pending_reports = {5: 12.5, 10: 3.2}
+        wr = _make_web_request("GET")
+        result = await sm._handle_status_request(wr)
+        reports = result["pending_reports"]
+        assert len(reports) == 2
+        ids = {r["spool_id"] for r in reports}
+        assert ids == {5, 10}
+
+
+class TestHistoryCallbacks:
+    """History auxiliary field reset callbacks."""
+
+    def test_history_reset_returns_tool_0_spool(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 5}
+        result = sm._on_history_reset()
+        assert result == [5]
+
+    def test_history_reset_empty_when_no_spool(self):
+        sm = _make_spoolman()
+        result = sm._on_history_reset()
+        assert result == []
+
+    def test_tool_spool_history_reset_multi_tool(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: 5, 1: 10}
+        result = sm._on_tool_spool_history_reset()
+        assert len(result) == 2
+        tools = {e["tool"] for e in result}
+        assert tools == {0, 1}
+
+    def test_tool_spool_history_reset_skips_none(self):
+        sm = _make_spoolman()
+        sm._tool_spool_map = {0: None, 1: 10}
+        result = sm._on_tool_spool_history_reset()
+        assert len(result) == 1
+        assert result[0] == {"tool": 1, "spool_id": 10}
+
+
+class TestComponentInit:
+    """component_init loads from DB and handles migration."""
+
+    @pytest.mark.asyncio
+    async def test_loads_existing_tool_map(self):
+        sm = _make_spoolman()
+        sm.database.get_item = AsyncMock(
+            side_effect=lambda ns, key, default=None: (
+                {"0": 5, "1": 10} if key == "spoolman.tool_spool_map" else default
+            )
+        )
+        await sm.component_init()
+        assert sm._tool_spool_map == {0: 5, 1: 10}
+
+    @pytest.mark.asyncio
+    async def test_migrates_legacy_spool_id(self):
+        sm = _make_spoolman()
+        sm.database.get_item = AsyncMock(
+            side_effect=lambda ns, key, default=None: (
+                42 if key == "spoolman.spool_id"
+                else default
+            )
+        )
+        await sm.component_init()
+        assert sm._tool_spool_map == {0: 42}
+        # Should have saved the new format
+        sm.database.insert_item.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_when_no_data(self):
+        sm = _make_spoolman()
+        sm.database.get_item = AsyncMock(return_value=None)
+        await sm.component_init()
+        assert sm._tool_spool_map == {}


### PR DESCRIPTION
Replace the single `spool_id` with a tool-indexed map to support StealthChanger, IDEX, and MMU setups. Each tool gets independent spool assignment and filament usage tracking.

**Changes:**
- Replace `spool_id` attribute with `_tool_spool_map` dict + backward-compatible `spool_id` property (returns tool 0)
- Add toolchanger discovery on `klippy_ready` with extruder name fallback
- Per-tool `_highest_epos` watermarks for correct extrusion attribution across tool changes
- API endpoints (`GET/POST /server/spoolman/spool_id`) accept optional `tool` parameter (default 0)
- `GET /server/spoolman/status` response includes `tool_spool_map`
- `spoolman:active_spool_set` notification includes `tool` field
- History tracking via `tool_spool_map` auxiliary field
- Spool deletion iterates full tool map (clears all tools using deleted spool)
- DB migration from legacy single `spoolman.spool_id` key to `spoolman.tool_spool_map`; both keys maintained for rollback safety

**Backward compatibility:**
- All changes are opt-in via the `tool` parameter; existing single-tool setups work identically
- Legacy DB key continues to be written alongside the new format
- `spool_id` property returns tool 0's spool for code that reads it directly

**Tests:**
- 54 new unit tests covering: tool-spool map CRUD, backward-compat property, extrusion attribution across tool changes, extruder discovery parsing, spool deletion handling, GET/POST API endpoints, DB persistence with string key serialization, legacy migration, and historyreset callbacks — all for both single-tool and multi-tool scenarios

Fixes #1057

Signed-off-by: Jon Charnas <goeland86@gmail.com>