### PR TITLE
Correctly handling multiple filament types that may contain spaces

### DIFF
--- a/moonraker/components/file_manager/metadata.py
+++ b/moonraker/components/file_manager/metadata.py
@@ -118,7 +118,7 @@ def regex_find_string(pattern: str, data: str) -> Optional[str]:
     pattern = pattern.replace(r"(%S)", r"(.*)")
     match = re.search(pattern, data)
     if match:
-        return match.group(1).strip('"')
+        return match.group(1).replace('"', '')
     return None
 
 def regex_find_min_float(pattern: str, data: str) -> Optional[float]:


### PR DESCRIPTION
This small fix addresses ```filament_type``` parsing from PrusaSlicer based slicers in cases where multiple filament types are used and one or more of these types contain spaces.

When spaces are present in the filament type the slicer surrounds the name with double quotes, which are correctly stripped in case only one type is present. However, for multi-extruder printers this is not the case and it's possible to encounter situations like this:

```
; filament_type = "PLA Matte";PLA+;PLA+;PLA+
```

The previous implementation returns ```'PLA Matte";PLA+;PLA+;PLA+'``` which contains a spurious double quote.

Current fix correctly returns ```'PLA Matte;PLA+;PLA+;PLA+'```

I took a quick look at the other usages of ```regex_find_string``` and it seems like removing double quotes altogether shouldn't be an issue.

**But why this very minor change is relevant and should be merged?** Some printers (cough cough Snapmaker U1) rely on moonraker's metadata parsing for determining if you're allowed to print a given file with the loaded filaments, if there is a name mismatch between the parsed filament types and the loaded ones you will not be allowed to print and instead spend the rest of the evening trying to understand where those pesky double quotes came from.