### PR TITLE
fix: use constant-time comparison for auth credentials (CWE-208)

### DIFF
--- a/moonraker/components/authorization.py
+++ b/moonraker/components/authorization.py
@@ -9,6 +9,7 @@ import asyncio
 import base64
 import uuid
 import hashlib
+import hmac
 import secrets
 import os
 import time
@@ -703,7 +704,7 @@ class Authorization:
     def validate_api_key(self, api_key: str) -> UserInfo:
         if not self.enable_api_key:
             raise self.server.error("API Key authentication is disabled", 401)
-        if api_key and api_key == self.api_key:
+        if api_key and self.api_key and hmac.compare_digest(api_key, self.api_key):
             return self.users[API_USER]
         raise self.server.error("Invalid API Key", 401)
 
@@ -875,7 +876,7 @@ class Authorization:
         # Check API Key Header
         if self.enable_api_key:
             key: Optional[str] = request.headers.get("X-Api-Key")
-            if key and key == self.api_key:
+            if key and self.api_key and hmac.compare_digest(key, self.api_key):
                 return self.users[API_USER]
 
         # If the force_logins option is enabled and at least one user is created


### PR DESCRIPTION
## Summary

Fixes #1067 — replaces timing-vulnerable comparison with constant-time alternative.

## Changes

- `moonraker/components/authorization.py`: Replace `==` API key comparison with `hmac.compare_digest()` in both `validate_api_key()` and `_check_authorized_request()`
- Add null-check guard for empty API key
- No behavioral change for valid authentication flows
- Uses stdlib only — no new dependencies

## CWE Reference

- **CWE-208**: Observable Timing Discrepancy

---
*Found by [SpiderShield](https://github.com/teehooai/spidershield) security scanner*