### PR TITLE
Feat: add mirror support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ share
 # Sometimes uv lock generates the version file and places it in
 # the repo.  We don't want to commit this, so ignore it
 moonraker/__version__.py
+
+.DS_Store

--- a/moonraker/components/http_client.py
+++ b/moonraker/components/http_client.py
@@ -214,6 +214,55 @@ class HttpClient:
                 resp_hdrs['X-Ratelimit-Reset'])
         return resp
 
+    async def request_json(
+        self,
+        resource: str,
+        attempts: int = 1,
+        retry_pause_time: float = .1,
+        headers: Optional[Dict[str, str]] = None
+    ) -> HttpResponse:
+
+        if resource.startswith(('http://', 'https://')):
+            url = resource
+            is_github = "github.com" in url
+        else:
+
+            url = f"{GITHUB_PREFIX}{resource.strip('/')}"
+            is_github = True
+
+        limit_remaining = getattr(self, 'gh_limit_remaining', 1)
+        limit_reset_time = getattr(self, 'gh_limit_reset_time', None)
+
+        if limit_reset_time and limit_remaining == 0:
+            if time.time() < limit_reset_time:
+                reset_str = time.ctime(limit_reset_time)
+                raise Exception(f"Rate Limit Reached for {url}\nReset at: {reset_str}")
+
+        request_headers = {"Accept": "application/json"}
+        if is_github:
+            request_headers["Accept"] = "application/vnd.github.v3+json"
+
+        if headers:
+            request_headers.update(headers)
+
+        resp = await self.get(
+            url,
+            headers=request_headers,
+            attempts=attempts,
+            retry_pause_time=retry_pause_time
+        )
+
+        hdrs = resp.headers
+        rem = hdrs.get('X-Ratelimit-Remaining') or hdrs.get('RateLimit-Remaining')
+        reset = hdrs.get('X-Ratelimit-Reset') or hdrs.get('RateLimit-Reset')
+
+        if rem is not None:
+            self.gh_limit_remaining = int(rem)
+        if reset is not None:
+            self.gh_limit_reset_time = float(reset)
+
+        return resp
+
     def github_api_stats(self) -> Dict[str, Any]:
         return {
             'github_rate_limit': self.gh_rate_limit,

--- a/moonraker/components/update_manager/common.py
+++ b/moonraker/components/update_manager/common.py
@@ -33,7 +33,6 @@ BASE_CONFIG: Dict[str, Dict[str, str]] = {
         "managed_services": "moonraker"
     },
     "klipper": {
-        "moved_origin": "https://github.com/kevinoconnor/klipper.git",
         "origin": "https://github.com/Klipper3d/klipper.git",
         "requirements": "scripts/klippy-requirements.txt",
         "venv_args": "-p python3",
@@ -42,7 +41,8 @@ BASE_CONFIG: Dict[str, Dict[str, str]] = {
     }
 }
 
-OPTION_OVERRIDES = ("channel", "pinned_commit", "refresh_interval", "report_anomalies")
+OPTION_OVERRIDES = ("channel", "pinned_commit", "refresh_interval", "report_anomalies",
+                    "origin", "dev_mode")
 
 class AppType(ExtendedEnum):
     NONE = 1

--- a/moonraker/components/update_manager/git_deploy.py
+++ b/moonraker/components/update_manager/git_deploy.py
@@ -37,6 +37,7 @@ class GitDeploy(AppDeploy):
         self._configure_dependencies(config)
         self._configure_managed_services(config)
         self.origin: str = config.get('origin')
+        self.dev_mode: bool = config.getboolean('dev_mode', False)
         self.moved_origin: Optional[str] = config.get('moved_origin', None)
         self.primary_branch = config.get("primary_branch", "master")
         pinned_commit = config.get("pinned_commit", None)
@@ -50,7 +51,7 @@ class GitDeploy(AppDeploy):
                 )
         self.repo = GitRepo(
             self.cmd_helper, self.path, self.name, self.origin, self.moved_origin,
-            self.primary_branch, self.channel, pinned_commit
+            self.primary_branch, self.channel, pinned_commit, self.dev_mode
         )
 
     async def initialize(self) -> Dict[str, Any]:
@@ -212,7 +213,8 @@ class GitRepo:
         moved_origin_url: Optional[str],
         primary_branch: str,
         channel: Channel,
-        pinned_commit: Optional[str]
+        pinned_commit: Optional[str],
+        dev_mode: Optional[bool]
     ) -> None:
         self.server = cmd_helper.get_server()
         self.cmd_helper = cmd_helper
@@ -246,6 +248,7 @@ class GitRepo:
         self.fetch_input_recd: bool = False
         self.channel = channel
         self.pinned_commit = pinned_commit
+        self.dev_mode = dev_mode
         self.is_shallow = False
 
     async def restore_state(self, storage: Dict[str, Any]) -> None:
@@ -283,6 +286,8 @@ class GitRepo:
         self.pinned_commit_valid: bool = storage.get('pinned_commit_valid', True)
         if not await self._detect_git_dir():
             self.valid_git_repo = False
+        if self.dev_mode is None:
+            self.dev_mode = storage.get('dev_mode', False)
         self._check_warnings()
 
     def get_persistent_data(self) -> Dict[str, Any]:
@@ -310,7 +315,8 @@ class GitRepo:
             'corrupt': self.repo_corrupt,
             'modified_files': self.modified_files,
             'untracked_files': self.untracked_files,
-            'pinned_commit_valid': self.pinned_commit_valid
+            'pinned_commit_valid': self.pinned_commit_valid,
+            'dev_mode': self.dev_mode
         }
 
     async def refresh_repo_state(self, need_fetch: bool = True) -> None:
@@ -327,6 +333,32 @@ class GitRepo:
             await self._check_repo_status()
             self._verify_repo()
             await self._find_current_branch()
+
+            if self.dev_mode and self.git_remote != "?":
+                try:
+                    # get current remote url
+                    current_remote_url = await self.remote(
+                        f"get-url {self.git_remote}",
+                        True)
+                    current_remote_url = current_remote_url.strip()
+
+                    # check with origin_url
+                    if current_remote_url != self.origin_url:
+                        logging.info(
+                            f"git Repo URL mismatch{self.alias}\n"
+                            f"current: {current_remote_url}\n"
+                            f"target:  {self.origin_url}\n"
+                            f"updating remote url..."
+                        )
+                        # set url in dev
+                        await self.remote(
+                            f"set-url {self.git_remote} {self.origin_url}",
+                            True)
+                    else:
+                        logging.debug(f"git remote url is up to date {self.alias}")
+
+                except Exception as e:
+                    logging.error(f"failed to check/update remote URL: {e}")
 
             # Fetch the upstream url.  If the repo has been moved,
             # set the new url
@@ -698,7 +730,8 @@ class GitRepo:
             f"Is Shallow: {self.is_shallow}\n"
             f"Commits Behind Count: {self.commits_behind_count}\n"
             f"Diverged: {self.diverged}\n"
-            f"Pinned Commit: {self.pinned_commit}"
+            f"Pinned Commit: {self.pinned_commit}\n"
+            f"dev_mode: {self.dev_mode}"
             f"{warnings}"
         )
 

--- a/moonraker/components/update_manager/net_deploy.py
+++ b/moonraker/components/update_manager/net_deploy.py
@@ -46,6 +46,16 @@ class NetDeploy(AppDeploy):
             self._configure_managed_services(config)
         self.repo = config.get('repo').strip().strip("/")
         self.owner, self.project_name = self.repo.split("/", 1)
+
+        self.enable_mirror = config.getboolean('enable_mirror', False)
+        self.mirror_url = config.get('mirror_url', "")
+        self.mirror_latest_template = config.get(
+            'mirror_latest_template', "{base_url}/LatestRelease/release"
+        )
+        self.mirror_tag_template = config.get(
+            'mirror_tag_template', "{base_url}/{tag}/release"
+        )
+
         self.asset_name: Optional[str] = None
         self.persistent_files: List[str] = []
         self.warnings: List[str] = []
@@ -91,6 +101,13 @@ class NetDeploy(AppDeploy):
         self._is_fallback = False
         eventloop = self.server.get_event_loop()
         self.warnings.clear()
+
+        # mirror override
+        if self.enable_mirror:
+            self._is_valid = True
+            self._is_fallback = True
+            return
+
         repo_parent = source_info.find_git_repo(self.path)
         homedir = pathlib.Path("~").expanduser()
         if not self._path_writable:
@@ -242,16 +259,42 @@ class NetDeploy(AppDeploy):
                 self.log_info("Invalid Installation, aborting remote refresh")
                 return {}
             repo = self.repo
-        if tag is not None:
-            resource = f"repos/{repo}/releases/tags/{tag}"
-        elif self.channel == Channel.STABLE:
-            resource = f"repos/{repo}/releases/latest"
+
+        # mirror enable
+        if self.enable_mirror:
+            try:
+                if tag is not None:
+                    # Rendering rollback / Specific version URL
+                    resource = self.mirror_tag_template.format(
+                        base_url=self.mirror_url,
+                        tag=tag
+                    )
+                else:
+                    # Render Latest Version URL
+                    resource = self.mirror_latest_template.format(
+                        base_url=self.mirror_url
+                    )
+            except KeyError as e:
+                self.log_info(f"Mirror template error: missing key {e}")
+                return {}
         else:
-            resource = f"repos/{repo}/releases?per_page=1"
+            if tag is not None:
+                resource = f"repos/{repo}/releases/tags/{tag}"
+            elif self.channel == Channel.STABLE:
+                resource = f"repos/{repo}/releases/latest"
+            else:
+                resource = f"repos/{repo}/releases?per_page=1"
+
+        # init http client
         client = self.cmd_helper.get_http_client()
-        resp = await client.github_api_request(
+
+        resp = await client.request_json(
             resource, attempts=3, retry_pause_time=.5
         )
+        # resp = await client.github_api_request(
+        #     resource, attempts=3, retry_pause_time=.5
+        # )
+
         release: Union[List[Any], Dict[str, Any]] = {}
         if resp.status_code == 304:
             if resp.content:
@@ -318,7 +361,11 @@ class NetDeploy(AppDeploy):
             f"Download Size: {size}\n"
             f"Content Type: {content_type}\n"
             f"Rollback Version: {self.rollback_version}\n"
-            f"Rollback Repo: {self.rollback_repo}"
+            f"Rollback Repo: {self.rollback_repo}\n"
+            f"enable_mirror: {self.enable_mirror}\n"
+            f"mirror_url: {self.mirror_url}\n"
+            f"mirror_latest_template: {self.mirror_latest_template}\n"
+            f"mirror_tag_template: {self.mirror_tag_template}\n"
             f"{warn_str}"
         )
 


### PR DESCRIPTION
### what problem solve

This PR is able let moonraker support change klipper / moonraker / webui mirror

> [!tip]
> Mirror Tool [Neko-vecter/moonraker-mirror-toolkit](https://github.com/Neko-vecter/moonraker-mirror-toolkit)

- set different location for git repo it will require set `dev_mode: True`
    - it will allow user to change git repo from `moonraker.conf`
- set a mirror for webui will require set `enable_mirror: True`
    - it allow user to change net deploy release file to a custom mirror.

### example config

below is config example in `moonraker.conf`

```
[update_manager moonraker]
dev_mode: True
origin: https://<mirror>/moonraker.git

[update_manager klipper]
dev_mode: True
origin: https://<mirror>/klipper.git

[update_manager mainsail]
type: web
channel: stable
repo: mainsail-crew/mainsail
path: ~/mainsail

# config how mirror work
enable_mirror: True
mirror_url: https://<mirror>/mainsail-release/
mirror_latest_template: {base_url}/LatestRelease/release
mirror_tag_template: {base_url}/{tag}/release
```

### relate issue

is relate to issue #470 
- It will also benefit in large deploy. due to the rate limit.

maybe relate to #615 since it can easy change klipper repo. Also intro the dev mode to the git repo type.

-Neko.vecter