### PR TITLE
git_deploy: handle "(no branch)" detached HEAD and tag-pinned repos

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2179,7 +2179,10 @@ type: git_repo
 #   This parameter must be provided.
 channel: dev
 #   The update channel.  May be set to stable, beta, or dev.
-#   The default is dev.
+#   The default is dev.  A detached HEAD, such as a checkout pinned
+#   directly to a tag, is reported as not updatable; return the repo to a
+#   branch (attached) to update it.  The exception is debug mode, where a
+#   detached HEAD can update when its ref is a remote branch.
 refresh_interval:
 #   This overrides the refresh_interval set in the primary [update_manager]
 #   section.


### PR DESCRIPTION
## Problem

Pinning a managed `git_repo` (for example Klipper) to a release tag leaves the working copy in a detached HEAD. git renders that state as either `(HEAD detached at <ref>)` or `(no branch)`. The update manager only recognised the first form; `(no branch)` was treated as a literal branch name, so `_find_current_branch` ran `git config branch.(no branch).remote` and got `error: invalid key: branch.(no`. The tracking remote was lost and the whole refresh failed, leaving the repo reported as fully invalid with every field `?`, even though `git remote get-url origin` and `git describe --tags` both worked.

## What this changes

Two independent commits plus a docs note.

1. `git_deploy: handle "(no branch)" detached HEAD` — treat any current branch starting with `(` as detached so the invalid `branch.<name>.remote` lookup is never built. When the detached ref encodes no remote (a bare tag or commit), fall back to `origin`, or the sole remote if there is exactly one, so the repo url, fetch and tag-based version detection still resolve. This alone turns the broken state into the normal detached-HEAD state the update manager already supports.

2. `git_deploy: treat tag-pinned detached HEAD as valid for stable/beta` — the `stable` and `beta` channels track release tags, so a checkout sitting detached exactly on a qualifying tag is their natural state. `has_recoverable_errors()` previously flagged every detached HEAD as an error, which forced `is_valid()` to false and disabled updates. It now accepts a detached HEAD that is exactly on a tag matching the channel (a final release for `stable`, a non-alpha tag for `beta`), reusing the same tag-eligibility predicates as the upstream-version filter. The detached update path is also corrected: `checkout()` assumed a tracking branch and built `<remote>/<branch>`, which is wrong when the branch is unknown or stale after pinning; it now checks out the resolved target commit directly and raises a clear error instead of running `git checkout ?` when no target resolves.

## Design note

The `stable`/`beta` model is "stay on the primary branch, but reset the branch pointer to the latest qualifying tag commit". A genuinely detached checkout is a less common shape, so the two commits are kept independent: the first is a self-contained crash fix that does not depend on the second, and the second makes the detached-on-tag shape a first-class valid state for the tag-tracking channels.

## Testing

Verified:

- Added `tests/test_git_deploy.py` covering branch parsing (normal branch, `(HEAD detached at origin/master)`, detached on a tag, `(no branch)`, sole-remote and ambiguous-remote fallback, stale tracking after pinning), `has_recoverable_errors` (qualifying `stable`/`beta` tags are valid; `dev_count > 0`, dirty, diverged, alpha-for-beta and the `dev` channel stay recoverable), and `checkout()` target resolution. The tests are red against the pre-fix code and green after.
- flake8 6.1.0 and mypy 1.5.1 pass on the changed source with the project's CI options.

Reproduction for end-to-end confirmation:

- Build a tag-only clone that renders `* (no branch)` (`git clone --no-checkout`, set `remote.origin.fetch` to a single `+refs/tags/<tag>:refs/tags/<tag>`, `git checkout <tag-commit>`), configure an `[update_manager]` entry with `channel: stable`, and call `GET /machine/update/status?refresh=true`. Before the fix the entry is invalid with `git_messages` containing `error: invalid key: branch.(no`; after the fix the entry is valid with a populated `version` and `remote_url`.
