### PR TITLE
paneldue: ignore empty direct gcode arguments

### DIFF
--- a/moonraker/components/paneldue.py
+++ b/moonraker/components/paneldue.py
@@ -299,6 +299,8 @@ class PanelDue:
         if cmd in self.direct_gcodes:
             params: Dict[str, Any] = {}
             for p in parts[1:]:
+                if not p:
+                    continue
                 if p[0] not in "PSR":
                     params["arg_p"] = p.strip(" \"\t\n")
                     continue


### PR DESCRIPTION
## Summary
- Ignore empty argument fragments while parsing PanelDue direct gcodes.
- Allows commands such as `M36` with no trailing argument to use the existing default `arg_p=None` path instead of indexing into an empty string.

## Root Cause
`process_line()` rewrites selected PanelDue commands into `[cmd, arg]` so their remaining text can be handled as one argument. When a command such as `M36` has no remaining text, `arg` is an empty string. The direct-gcode parser then read `p[0]` before checking whether `p` was empty.

## Testing
- `git diff --check origin/master..HEAD`
- `python -m py_compile moonraker/components/paneldue.py`
- Manual parser check for `M36`, `M36 Pfoo.gcode`, and `M20 S2 P/gcodes`

Not run: `flake8` and `mypy`, because the local Python environment does not have those modules installed.