### PR TITLE
paneldue: ignore empty direct gcode arguments

### DIFF
--- a/moonraker/components/paneldue.py
+++ b/moonraker/components/paneldue.py
@@ -300,6 +300,8 @@ class PanelDue:
         if cmd in self.direct_gcodes:
             params: Dict[str, Any] = {}
             for p in parts[1:]:
+                if not p:
+                    continue
                 if p[0] not in "PSR":
                     params["arg_p"] = p.strip(" \"\t\n")
                     continue


### PR DESCRIPTION
## Summary
- skip empty direct G-code argument tokens in PanelDue command parsing
- prevents empty RRF command arguments from indexing `p[0]`

## Testing
- `git diff --check`
- `python -m py_compile moonraker\components\paneldue.py`