### PR TITLE
fix repeated words in docs and messages

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -144,7 +144,7 @@ If `default` is not provided a `ServerError` will be raised.
 #### *Server.load_component(config, component_name, default=Sentinel)*
 
 Attempts to load an uninitialized component and returns the result.  It is
-only valid to call this within a a component's `__init__()` method, and
+only valid to call this within a component's `__init__()` method, and
 should only be necessary if one optional component relies on another.  Core components will always be loaded before optional components, thus an optional
 component may always call
 [lookup_component()](#serverlookup_componentcomponent_name-defaultsentinel)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -175,7 +175,7 @@ documentation for details.
 ### `[machine]`
 
 The `machine` section provides configuration for Moonraker's machine component, which
-is responsible for for collecting "machine" (ie: PC, SBC, etc) data and communicating
+is responsible for collecting "machine" (ie: PC, SBC, etc) data and communicating
 with system services such as systemd.
 
 ```ini {title="Moonraker Config Specification"}
@@ -994,7 +994,7 @@ off_code:
 TPLink has removed access to the local API for some of its Kasa devices
 in recent firmware releases.  As such, it is possible that Moonraker
 will be unable to communicate with your device.  While TPLink claims that
-they will provide a new local API, they have have not done so as of
+they will provide a new local API, they have not done so as of
 December 22nd, 2021.
 See [this TPLink forum post](https://community.tp-link.com/en/smart-home/forum/topic/239364)
 and [this Home Assistant Alert](https://alerts.home-assistant.io/#tplink.markdown)
@@ -1091,7 +1091,7 @@ address:
 user:
 #   A user name to use for request authentication.  This option accepts
 #   Jinja2 Templates, see the [secrets] section for details.  If no password
-#   is set the the default is no user, otherwise the default is "admin".
+#   is set the default is no user, otherwise the default is "admin".
 password:
 #   The password to use for request authentication.  This option accepts
 #   Jinja2 Templates, see the [secrets] section for details. The default is no
@@ -1910,7 +1910,7 @@ gcode:
 To power on a device after an upload, `queue_gcode_uploads: True` must
 be set in the `[file_manager]`, `load_on_startup: True` must be set in
 `[job_queue]` and `one_when_job_queued: True` must be set in `[power dev_name]`,
-where "dev_name" the the name of your power device.  For example:
+where "dev_name" is the name of your power device.  For example:
 
 ```ini {title="Moonraker Config Example"}
 # moonraker.conf
@@ -2207,7 +2207,7 @@ path:
 #     path: ~/service_name
 origin:
 #   The full git URL of the "origin" remote for the repository.  This can
-#   be be viewed by navigating to your repository and running:
+#   be viewed by navigating to your repository and running:
 #     git remote -v
 #   This parameter must be provided.
 primary_branch:
@@ -2585,7 +2585,7 @@ Enables an MQTT Client.  When configured most of Moonraker's APIs are available
 by publishing JSON-RPC requests to `{instance_name}/moonraker/api/request`.
 Responses will be published to `{instance_name}/moonraker/api/response`. See
 the [API Documentation](./external_api/introduction.md#json-rpc-api-overview)
-for details on on JSON-RPC.
+for details on JSON-RPC.
 
 It is also possible for other components within Moonraker to use MQTT to
 publish and subscribe to topics.
@@ -3108,7 +3108,7 @@ The Apprise library is actively developed and frequently adds new notification
 services. When at least one notifier has been configured `moonraker.log` will
 report the currently installed version of Apprise.  Alternatively Moonraker's
 [pyproject.toml](https://github.com/Arksine/moonraker/blob/master/pyproject.toml)
-can be be referenced to determine the latest version of Apprise that should be
+can be referenced to determine the latest version of Apprise that should be
 installed. For example:
 
 ```toml

--- a/docs/dev_changelog.md
+++ b/docs/dev_changelog.md
@@ -59,7 +59,7 @@
 - Python 3 support has been added.
 - API Key management has moved from Klippy to Moonraker
 - File Management has moved from Klippy to Moonraker. All static files are now
-  located in the the `/server/files` root path:
+  located in the `/server/files` root path:
   - klippy.log - `/server/files/klippy.log`
   - moonraker.log - `/server/files/moonraker.log`
   - gcode files - `/server/files/gcodes/(.*)`
@@ -136,7 +136,7 @@
   printer.cfg accordingly
 - Static files no longer served by the API server.  As a result, there is
   no `web_path` option in `[remote_api]`.
-- The server process now now forwards logging requests back to the Klippy
+- The server process now forwards logging requests back to the Klippy
   Host, thus all logging is done in klippy.log.  The temporary endpoint serving
   klippy_server.log has been removed.
 - `/printer/info` now includes two additional keys:
@@ -281,7 +281,7 @@
     `location` object in javascript.  Instead it returns CPU information.
   - `GET /printer/objects` is no longer used to accommodate multiple request
     types by modifying the "Accept" headers.  Each request has been broken
-    down in their their own endpoints:
+    down in their own endpoints:
     - `GET /printer/objects` returns all available printer objects that may
       be queried
     - `GET /printer/status?gcode=gcode_position,speed&toolhead` returns the

--- a/docs/external_api/announcements.md
+++ b/docs/external_api/announcements.md
@@ -479,7 +479,7 @@ for generating RSS feeds from GitHub issues using GitHub's REST API. These
 RSS feeds are hosted on GitHub Pages, for example Moonraker's feed may be found
 [here](https://arksine.github.io/moonlight/assets/moonraker.xml). By
 centralizing GitHub API queries in `moonlight` we are able to poll multiple
-repos without running into API rate limit issues. Moonlight has has a workflow
+repos without running into API rate limit issues. Moonlight has a workflow
 that checks all registered repos for new announcements every 30 minutes.  In
 theory it would be able to check for announcements in up to 500 repos before
 exceeding GitHub's API rate limit.

--- a/docs/external_api/database.md
+++ b/docs/external_api/database.md
@@ -283,7 +283,7 @@ DELETE /server/database/item?namespace={namespace}&key={key}
 
 ## Compact Database
 
-Compacts and defragments the the sqlite database using the `VACUUM` command.
+Compacts and defragments the sqlite database using the `VACUUM` command.
 This endpoint cannot be requested when Klipper is printing.
 
 ```{.http .apirequest title="HTTP Request"}

--- a/docs/external_api/machine.md
+++ b/docs/external_api/machine.md
@@ -996,7 +996,7 @@ GET /machine/peripherals/serial
 | `path_by_hardware` | string | A symbolic link to the device based on its physical         |
 |                    | \| null         | connection, ie: usb port.  Will be `null` if no             |^
 |                    |         | matching link exists.                                       |^
-| `path_by_id`       | string | A symbolic link the the device based on its reported IDs.   |
+| `path_by_id`       | string | A symbolic link to the device based on its reported IDs.     |
 |                    | \| null         | Will be `null` if no matching link exists.                  |^
 | `usb_location`     | string | An identifier derived from the reported usb bus and .       |
 |                    | \| null         | device numbers Can be used to match results from            |^
@@ -1354,7 +1354,7 @@ GET /machine/peripherals/video
 | `path_by_hardware` |  string  | A symbolic link to the device based on its physical      |
 |                    | \| null  | connection, ie: usb port.. Will be  `null` if no         |^
 |                    |          | matching link exists.                                    |^
-| `path_by_id`       |  string  | A symbolic link the the device based on its reported     |
+| `path_by_id`       |  string  | A symbolic link to the device based on its reported      |
 |                    | \| null  | ID. Will be  `null` if no matching link exists.          |^
 | `usb_location`     |  string  | An identifier derived from the reported usb bus and      |
 |                    | \| null  | device numbers. Will be `null` for non-usb devices.      |^

--- a/docs/external_api/update_manager.md
+++ b/docs/external_api/update_manager.md
@@ -392,7 +392,7 @@ The `refresh` parameter is deprecated.  Front end developers should use the
 |                       |                | package's metadata.                                       |^
 | `current_hash`        |     string     | The hash of the commit used to build the current version  |
 |                       |                | of the package.  A placeholder of `not-specified` is used |^
-|                       |                | when the the current hash is not provided in the package  |^
+|                       |                | when the current hash is not provided in the package      |^
 |                       |                | metadata.                                                 |^
 | `remote_hash`         |     string     | The hash of the latest update available. A placeholder of |
 |                       |                | `update-available` is used when the remote hash is not    |^

--- a/moonraker/components/data_store.py
+++ b/moonraker/components/data_store.py
@@ -1,4 +1,4 @@
-# Klipper data logging and storage storage
+# Klipper data logging and storage
 #
 # Copyright (C) 2020 Eric Callahan <arksine.code@gmail.com>
 #

--- a/moonraker/components/database.py
+++ b/moonraker/components/database.py
@@ -1290,7 +1290,7 @@ class SqliteProvider(Thread):
     def register_table(self, table_def: SqlTableDefinition) -> None:
         if self.is_alive():
             raise self.server.error(
-                "Table registration must occur during during init."
+                "Table registration must occur during init."
             )
         if table_def.name in self._tables:
             logging.info(f"Found registered table {table_def.name}")

--- a/moonraker/components/klippy_connection.py
+++ b/moonraker/components/klippy_connection.py
@@ -503,7 +503,7 @@ class KlippyConnection:
             err_str = ", ".join([f"[{o}]" for o in self._missing_reqs])
             logging.info(
                 f"\nWarning, unable to detect the following printer "
-                f"objects:\n{err_str}\nPlease add the the above sections "
+                f"objects:\n{err_str}\nPlease add the above sections "
                 f"to printer.cfg for full Moonraker functionality.")
         if "virtual_sdcard" not in self._missing_reqs:
             # Update the gcode path

--- a/moonraker/components/paneldue.py
+++ b/moonraker/components/paneldue.py
@@ -404,7 +404,7 @@ class PanelDue:
         return cmd
 
     def _prepare_M290(self, args: List[str]) -> str:
-        # args should in in the format Z0.02
+        # args should be in the format Z0.02
         offset = args[0][1:].strip()
         return f"SET_GCODE_OFFSET Z_ADJUST={offset} MOVE=1"
 

--- a/moonraker/components/update_manager/app_deploy.py
+++ b/moonraker/components/update_manager/app_deploy.py
@@ -285,7 +285,7 @@ class AppDeploy(BaseDeploy):
         # Fall back on install script if configured
         if self.install_script is None:
             return []
-        # Open install file file and read
+        # Open install file and read
         inst_path: pathlib.Path = self.install_script
         if not inst_path.is_file():
             self.log_info(f"Failed to open install script: {inst_path}")

--- a/moonraker/server.py
+++ b/moonraker/server.py
@@ -726,7 +726,7 @@ def main(from_package: bool = True) -> None:
         estatus = asyncio.run(launch_server(log_manager, app_args))
         if estatus is not None:
             break
-        # Since we are running outside of the the server
+        # Since we are running outside of the server
         # it is ok to use a blocking sleep here
         time.sleep(.5)
         logging.info("Attempting Server Restart...")


### PR DESCRIPTION
## Summary
- fix repeated words in documentation, comments, and user-visible messages
- leave intentional repeated tokens such as G-code examples and boolean conversions untouched

## Testing
- `git diff --check`
- `python -m py_compile moonraker\server.py moonraker\components\database.py moonraker\components\data_store.py moonraker\components\klippy_connection.py moonraker\components\paneldue.py moonraker\components\update_manager\app_deploy.py`