### PR TITLE
update_manager: honor and consume base-app config options

### DIFF
--- a/moonraker/components/update_manager/common.py
+++ b/moonraker/components/update_manager/common.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 import sys
 import copy
+import logging
 import pathlib
 from ...common import ExtendedEnum
 from ...utils import source_info
@@ -42,7 +43,39 @@ BASE_CONFIG: Dict[str, Dict[str, str]] = {
     }
 }
 
-OPTION_OVERRIDES = ("channel", "pinned_commit", "refresh_interval", "report_anomalies")
+# Options a user may override in [update_manager moonraker|klipper].
+#
+# 'origin', 'moved_origin', 'primary_branch' and 'managed_services' are part
+# of this set in the Core One fork.  Upstream ignores them for the two base
+# apps, which silently breaks tracking a fork of Klipper: the repo is checked
+# against the hardcoded Klipper3d origin on 'master', so a valid fork on its
+# own remote/branch is permanently reported as "Repo not on official
+# remote/branch" + "Unofficial remote url", and repo.checkout() targets a
+# branch that does not exist.  Honouring the configured values -- exactly as
+# every non-base git_repo section already does -- fixes all of that.  The
+# defaults in BASE_CONFIG still apply when the options are absent.
+OPTION_OVERRIDES = (
+    "channel", "pinned_commit", "refresh_interval", "report_anomalies",
+    "origin", "moved_origin", "primary_branch", "managed_services"
+)
+
+# Options that the base "moonraker" and "klipper" updaters always derive
+# themselves (from source_info / the klippy connection / BASE_CONFIG) rather
+# than from the user's [update_manager moonraker|klipper] section.  Such a
+# section is still commonly written with the full git_repo option set --
+# every other git_repo section requires it -- but here the values are
+# ignored.  Because the base configuration is built as a *supplemental*
+# ConfigHelper (read_supplemental_dict, which starts with an empty 'parsed'
+# map), nothing ever consumes these options on the tracked helper, so
+# ConfigHelper.validate_config() reports each one as an unparsed option and
+# warns that it will become a startup error in the future.  Consume them
+# explicitly so legitimate configurations don't trip that escalation, while
+# genuinely unknown options (typos) keep warning as intended.
+AUTODETECTED_OPTIONS = (
+    "type", "path", "env", "virtualenv", "venv_args", "requirements",
+    "system_dependencies", "install_script", "pip_environment_variables",
+    "enable_node_updates", "is_system_service", "info_tags", "persistent_files"
+)
 
 class AppType(ExtendedEnum):
     NONE = 1
@@ -110,4 +143,16 @@ def get_base_configuration(config: ConfigHelper) -> ConfigHelper:
         for opt in OPTION_OVERRIDES:
             if app_cfg.has_option(opt):
                 base_cfg[app_name][opt] = app_cfg.get(opt)
+        # Consume auto-detected options on the tracked ConfigHelper.  Their
+        # values are not applied -- this only keeps validate_config() from
+        # flagging them as unparsed.  See AUTODETECTED_OPTIONS.
+        ignored = [opt for opt in AUTODETECTED_OPTIONS if app_cfg.has_option(opt)]
+        for opt in ignored:
+            app_cfg.get(opt, None)
+        if ignored:
+            logging.info(
+                f"[{override_section}]: the following options are auto-detected "
+                f"for the '{app_name}' updater and their configured values are "
+                f"ignored: {', '.join(ignored)}"
+            )
     return config.read_supplemental_dict(base_cfg)


### PR DESCRIPTION
## Problem

`[update_manager klipper]` and `[update_manager moonraker]` are the only `git_repo` sections whose settings the updater derives itself, in `get_base_configuration()` → `read_supplemental_dict()`. That helper is built with a fresh, empty `parsed` map, so options written in those sections are never consumed on the tracked `ConfigHelper`. Two consequences follow, both of which affect anyone tracking a fork of Klipper.

**1. A valid, documented config is reported as unparsed.**

```ini
[update_manager klipper]
type: git_repo
path: ~/klipper
origin: git@github.com:me/my-klipper-fork.git
primary_branch: main
managed_services: klipper
```

Every option in that section is flagged:

```
Unparsed config option 'origin: ...' detected in section [update_manager klipper].
This may be an option no longer available or could be the result of a module that
failed to load.  In the future this will result in a startup error.
```

A **non-base** `git_repo` section with the identical option set is silent, because it takes the ordinary `config[section]` path in `update_manager.py`. Only `OPTION_OVERRIDES` was ever read off the tracked helper.

**2. `origin` / `primary_branch` are ignored outright for the two base apps.**

The repo is therefore always validated against the hardcoded `Klipper3d/klipper` origin on `master`, rather than against the configured remote and branch, so a perfectly valid fork permanently reports:

```
Repo not on official remote/branch, expected: origin/master, detected: origin/main
Unofficial remote url: git@github.com:me/my-klipper-fork.git
```

More importantly, **repo recovery is broken**: soft recovery does `repo.checkout(self.primary_branch)` and hard recovery does `clone --branch {self.primary_branch}`, both targeting a branch that need not exist in the configured repo.

## Fix

- Add `origin`, `moved_origin`, `primary_branch` and `managed_services` to `OPTION_OVERRIDES`, so the configured values are used — as every non-base `git_repo` section already does.
- Add `AUTODETECTED_OPTIONS` and consume them on the tracked helper, so a valid section stops tripping the future startup error. Their values remain ignored: `type`, `path` and `env` come from the klippy connection and are reset by `_set_klipper_repo()`, so they must stay auto-detected.
- Log once, at info level, which options were ignored — writing e.g. `origin` in `[update_manager klipper]` previously had no effect, and that was not otherwise discoverable.

## Compatibility

`BASE_CONFIG` defaults still apply when the options are absent, so existing configurations are unaffected. Options outside both sets still warn, so typos are still caught. No behaviour change for any non-base section.

## Testing

Drove the real `get_base_configuration()` + `ConfigHelper.validate_config()` against a config containing both a base (`klipper`) and a non-base git_repo section:

- base section: **5 unparsed warnings → 0**, and `origin` / `primary_branch` now reach the updater
- deliberately misspelled option: still warns (1)
- non-base section: 0 before and after

Also running on a Pi that tracks a forked Klipper via `[update_manager klipper]`.
